### PR TITLE
Reduce test code duplication via supabase Client in pytest fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import pytest
 from supabase_py import Client, create_client
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="session")
 def supabase() -> Client:
     url: str = os.environ.get("SUPABASE_TEST_URL")
     key: str = os.environ.get("SUPABASE_TEST_KEY")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from supabase_py import Client, create_client
+
+
+@pytest.fixture(scope="function")
+def supabase() -> Client:
+    url: str = os.environ.get("SUPABASE_TEST_URL")
+    key: str = os.environ.get("SUPABASE_TEST_KEY")
+    supabase: Client = create_client(url, key)
+    return supabase

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 import random
 import string
 from typing import TYPE_CHECKING, Any, Dict

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,9 +1,14 @@
+from __future__ import annotations
+
 import os
 import random
 import string
-from typing import Any, Dict
+from typing import TYPE_CHECKING, Any, Dict
 
 import pytest
+
+if TYPE_CHECKING:
+    from supabase_py import Client, create_client
 
 
 def _random_string(length: int = 10) -> str:
@@ -11,7 +16,7 @@ def _random_string(length: int = 10) -> str:
     return "".join(random.choices(string.ascii_uppercase + string.digits, k=length))
 
 
-def _assert_authenticated_user(data: Dict[str, Any]):
+def _assert_authenticated_user(data: Dict[str, Any]) -> None:
     """Raise assertion error if user is not logged in correctly."""
     assert "access_token" in data
     assert "refresh_token" in data
@@ -27,20 +32,15 @@ def _assert_authenticated_user(data: Dict[str, Any]):
 )
 @pytest.mark.parametrize("url", ["", None, "valeefgpoqwjgpj", 139, -1, {}, []])
 @pytest.mark.parametrize("key", ["", None, "valeefgpoqwjgpj", 139, -1, {}, []])
-def test_incorrect_values_dont_instanciate_client(url: Any, key: Any):
+def test_incorrect_values_dont_instanciate_client(url: Any, key: Any) -> None:
     """Ensure we can't instanciate client with nonesense values."""
-    from supabase_py import create_client, Client
+    from supabase_py import Client, create_client
 
     _: Client = create_client(url, key)
 
 
-def test_client_auth():
+def test_client_auth(supabase: Client) -> None:
     """Ensure we can create an auth user, and login with it."""
-    from supabase_py import create_client, Client
-
-    url: str = os.environ.get("SUPABASE_TEST_URL")
-    key: str = os.environ.get("SUPABASE_TEST_KEY")
-    supabase: Client = create_client(url, key)
     # Create a random user login email and password.
     random_email: str = f"{_random_string(10)}@supamail.com"
     random_password: str = _random_string(20)
@@ -56,13 +56,8 @@ def test_client_auth():
     _assert_authenticated_user(user)
 
 
-def test_client_select():
+def test_client_select(supabase: Client) -> None:
     """Ensure we can select data from a table."""
-    from supabase_py import create_client, Client
-
-    url: str = os.environ.get("SUPABASE_TEST_URL")
-    key: str = os.environ.get("SUPABASE_TEST_KEY")
-    supabase: Client = create_client(url, key)
     # TODO(fedden): Add this set back in (and expand on it) when postgrest and
     #               realtime libs are working.
     data = supabase.table("countries").select("*").execute()
@@ -70,13 +65,8 @@ def test_client_select():
     assert len(data.get("data", [])) > 0
 
 
-def test_client_insert():
+def test_client_insert(supabase: Client) -> None:
     """Ensure we can select data from a table."""
-    from supabase_py import create_client, Client
-
-    url: str = os.environ.get("SUPABASE_TEST_URL")
-    key: str = os.environ.get("SUPABASE_TEST_KEY")
-    supabase: Client = create_client(url, key)
     data = supabase.table("countries").select("*").execute()
     # Assert we pulled real data.
     previous_length: int = len(data.get("data", []))

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -9,10 +9,10 @@ client.auth.sign_up({"email": "anemail@gmail.com", "password": "apassword"})
 """
 
 
-def test_dummy():
+def test_dummy() -> None:
     # Test auth component
     assert True == True
 
 
-def test_client_initialziation():
+def test_client_initialziation() -> None:
     client = supabase_py.Client("http://testwebsite.com", "atestapi")

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -1,8 +1,5 @@
 import pytest
 
-import sys
-print(sys.path)
-
 import supabase_py
 
 """
@@ -11,10 +8,11 @@ client = supabase_py.Client("<insert link>", "<password>")
 client.auth.sign_up({"email": "anemail@gmail.com", "password": "apassword"})
 """
 
+
 def test_dummy():
     # Test auth component
     assert True == True
 
+
 def test_client_initialziation():
     client = supabase_py.Client("http://testwebsite.com", "atestapi")
-


### PR DESCRIPTION
## What kind of change does this PR introduce?

The test suite has some minor setup duplication at the top of each function. Namely,

```python
url: str = os.environ.get("SUPABASE_TEST_URL")
key: str = os.environ.get("SUPABASE_TEST_KEY")
supabase: Client = create_client(url, key)
```

This change factors that test setup into a pytest fixture that is created once and shared across the tests that require a `supabase.Client`.