### PR TITLE
fix: missing json bodies in patch and put requests

### DIFF
--- a/supabase_py/lib/query_builder.py
+++ b/supabase_py/lib/query_builder.py
@@ -18,8 +18,10 @@ def _execute_monkey_patch(self) -> Dict[str, Any]:
         additional_kwargs = {"json": self.json}
     elif method == "put":
         func = requests.put
+        additional_kwargs = {"json": self.json}
     elif method == "patch":
         func = requests.patch
+        additional_kwargs = {"json": self.json}
     elif method == "delete":
         func = requests.delete
     else:


### PR DESCRIPTION
Fixes https://github.com/supabase/postgrest-py/issues/7 and #30 

Why are we monkey patching postgrest-py here? If we really need to hide the async reality and offer a synchronous interface, can we move it down to the postgrest-py layer so at least it's tested and kept in sync?