### PR TITLE
fix: add `verify` argument to `_init_supabase_auth_client()`

### DIFF
--- a/supabase/_async/auth_client.py
+++ b/supabase/_async/auth_client.py
@@ -22,7 +22,8 @@ class AsyncSupabaseAuthClient(AsyncGoTrueClient):
         persist_session: bool = True,
         storage: AsyncSupportedStorage = AsyncMemoryStorage(),
         http_client: Optional[AsyncClient] = None,
-        flow_type: AuthFlowType = "implicit"
+        flow_type: AuthFlowType = "implicit",
+        verify: bool = True,
     ):
         """Instantiate SupabaseAuthClient instance."""
         if headers is None:
@@ -38,4 +39,5 @@ class AsyncSupabaseAuthClient(AsyncGoTrueClient):
             storage=storage,
             http_client=http_client,
             flow_type=flow_type,
+            verify=verify,
         )

--- a/supabase/_async/client.py
+++ b/supabase/_async/client.py
@@ -237,6 +237,7 @@ class AsyncClient:
     def _init_supabase_auth_client(
         auth_url: str,
         client_options: ClientOptions,
+        verify: bool = True,
     ) -> AsyncSupabaseAuthClient:
         """Creates a wrapped instance of the GoTrue Client."""
         return AsyncSupabaseAuthClient(
@@ -246,6 +247,7 @@ class AsyncClient:
             storage=client_options.storage,
             headers=client_options.headers,
             flow_type=client_options.flow_type,
+            verify=verify,
         )
 
     @staticmethod

--- a/supabase/_sync/auth_client.py
+++ b/supabase/_sync/auth_client.py
@@ -22,7 +22,8 @@ class SyncSupabaseAuthClient(SyncGoTrueClient):
         persist_session: bool = True,
         storage: SyncSupportedStorage = SyncMemoryStorage(),
         http_client: Optional[SyncClient] = None,
-        flow_type: AuthFlowType = "implicit"
+        flow_type: AuthFlowType = "implicit",
+        verify: bool = True,
     ):
         """Instantiate SupabaseAuthClient instance."""
         if headers is None:
@@ -38,4 +39,5 @@ class SyncSupabaseAuthClient(SyncGoTrueClient):
             storage=storage,
             http_client=http_client,
             flow_type=flow_type,
+            verify=verify,
         )

--- a/supabase/_sync/client.py
+++ b/supabase/_sync/client.py
@@ -237,6 +237,7 @@ class SyncClient:
     def _init_supabase_auth_client(
         auth_url: str,
         client_options: ClientOptions,
+        verify: bool = True,
     ) -> SyncSupabaseAuthClient:
         """Creates a wrapped instance of the GoTrue Client."""
         return SyncSupabaseAuthClient(
@@ -246,6 +247,7 @@ class SyncClient:
             storage=client_options.storage,
             headers=client_options.headers,
             flow_type=client_options.flow_type,
+            verify=verify,
         )
 
     @staticmethod


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add `verify` argument to `_init_supabase_auth_client()` for SSL certificate verification. This follows the convention set by `_init_postgrest_client()` and `_init_storage_client()`.

## What is the current behavior?

`verify` flag cannot be passed to the underlying `[Async]GoTrueClient`.

## What is the new behavior?

`_init_supabase_auth_client()` can be passed the `verify` flag that is propagated to the underlying `[Async]GoTrueClient`.

## Additional context

Follows convention of https://github.com/supabase/supabase-py/pull/813
