### PR TITLE
fix: Cleanout old code

### DIFF
--- a/supabase/_async/__init__.py
+++ b/supabase/_async/__init__.py
@@ -1,1 +1,0 @@
-from __future__ import annotations

--- a/supabase/_sync/__init__.py
+++ b/supabase/_sync/__init__.py
@@ -1,1 +1,0 @@
-from __future__ import annotations

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import os
 
 import pytest

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import os
 from typing import Any
 from unittest.mock import MagicMock


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Cleanout future imports `from __future__ import annotations` no longer needed for Python >= `3.9.0`.
