### PR TITLE
Await for realtime set auth on auth event

### DIFF
--- a/supabase/_async/client.py
+++ b/supabase/_async/client.py
@@ -284,7 +284,7 @@ class AsyncClient:
             "Authorization": authorization,
         }
 
-    def _listen_to_auth_events(
+    async def _listen_to_auth_events(
         self, event: AuthChangeEvent, session: Union[Session, None]
     ):
         access_token = self.supabase_key
@@ -297,8 +297,8 @@ class AsyncClient:
 
         self.options.headers["Authorization"] = self._create_auth_header(access_token)
 
-        # set_auth is a coroutine, how to handle this?
-        self.realtime.set_auth(access_token)
+        # Await for the realtime client to set the auth token
+        await self.realtime.set_auth(access_token)
 
 
 async def create_client(

--- a/supabase/_sync/client.py
+++ b/supabase/_sync/client.py
@@ -284,7 +284,7 @@ class SyncClient:
             "Authorization": authorization,
         }
 
-    def _listen_to_auth_events(
+    async def _listen_to_auth_events(
         self, event: AuthChangeEvent, session: Union[Session, None]
     ):
         access_token = self.supabase_key
@@ -297,8 +297,8 @@ class SyncClient:
 
         self.options.headers["Authorization"] = self._create_auth_header(access_token)
 
-        # set_auth is a coroutine, how to handle this?
-        self.realtime.set_auth(access_token)
+        # Await for the realtime client to set the auth token
+        await self.realtime.set_auth(access_token)
 
 
 def create_client(


### PR DESCRIPTION
## What kind of change does this PR introduce?

Solves https://github.com/supabase/supabase-py/issues/919.

Needs: https://github.com/supabase/auth-py/pull/591

## What is the current behavior?

AsyncClient crashes due to missing await at [self.realtime.set_auth()](https://github.com/supabase/supabase-py/blob/main/supabase/_async/client.py#L301)

## What is the new behavior?

AsyncClient now awaits for self.realtime.set_auth