### PR TITLE
fix: update exports from init file

### DIFF
--- a/supabase/__init__.py
+++ b/supabase/__init__.py
@@ -1,6 +1,18 @@
+from gotrue.errors import (
+    AuthApiError,
+    AuthError,
+    AuthImplicitGrantRedirectError,
+    AuthInvalidCredentialsError,
+    AuthRetryableError,
+    AuthSessionMissingError,
+    AuthUnknownError,
+    AuthWeakPasswordError,
+)
 from postgrest import APIError as PostgrestAPIError
 from postgrest import APIResponse as PostgrestAPIResponse
+from realtime import AuthorizationError, NotConnectedError
 from storage3.utils import StorageException
+from supafunc.errors import FunctionsError, FunctionsHttpError, FunctionsRelayError
 
 # Async Client
 from ._async.auth_client import AsyncSupabaseAuthClient as ASupabaseAuthClient
@@ -8,28 +20,47 @@ from ._async.client import AsyncClient as AClient
 from ._async.client import AsyncStorageClient as ASupabaseStorageClient
 from ._async.client import ClientOptions as AClientOptions
 from ._async.client import create_client as acreate_client
+from ._async.client import create_client as create_async_client
 
 # Sync Client
 from ._sync.auth_client import SyncSupabaseAuthClient as SupabaseAuthClient
-from ._sync.client import ClientOptions
 from ._sync.client import SyncClient as Client
 from ._sync.client import SyncStorageClient as SupabaseStorageClient
 from ._sync.client import create_client
+
+# Lib
+from .lib.client_options import ClientOptions
 
 # Version
 from .version import __version__
 
 __all__ = [
     "acreate_client",
+    "create_async_client",
     "AClient",
     "ASupabaseAuthClient",
     "ASupabaseStorageClient",
+    "AClientOptions",
     "create_client",
     "Client",
     "SupabaseAuthClient",
     "SupabaseStorageClient",
+    "ClientOptions",
     "PostgrestAPIError",
     "PostgrestAPIResponse",
     "StorageException",
-    "version",
+    "__version__",
+    "AuthApiError",
+    "AuthError",
+    "AuthImplicitGrantRedirectError",
+    "AuthInvalidCredentialsError",
+    "AuthRetryableError",
+    "AuthSessionMissingError",
+    "AuthWeakPasswordError",
+    "AuthUnknownError",
+    "FunctionsHttpError",
+    "FunctionsRelayError",
+    "FunctionsError",
+    "AuthorizationError",
+    "NotConnectedError",
 ]


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix to improve the use of the library.

## What is the current behavior?

Async client and errors aren't being exported from the `__init__.py` file.

## What is the new behavior?

Async client and errors are being exported from the `__init__.py` file.

## Additional context

Add any other context or screenshots.
