### PR TITLE
feat: set default flow_type to pkce

### DIFF
--- a/supabase/lib/client_options.py
+++ b/supabase/lib/client_options.py
@@ -48,7 +48,7 @@ class ClientOptions:
     )
     """Timeout passed to the SyncFunctionsClient instance."""
 
-    flow_type: AuthFlowType = "implicit"
+    flow_type: AuthFlowType = "pkce"
     """flow type to use for authentication"""
 
     def replace(


### PR DESCRIPTION
## What kind of change does this PR introduce?

Implicit flow type doesn't make sense when working with server side frameworks. This PR is to change the default `flow_type` to `pkce`

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
