### PR TITLE
fix: async client options default values

### DIFF
--- a/supabase/__init__.py
+++ b/supabase/__init__.py
@@ -16,7 +16,8 @@ from supafunc.errors import FunctionsError, FunctionsHttpError, FunctionsRelayEr
 
 # Async Client
 from ._async.auth_client import AsyncSupabaseAuthClient as ASupabaseAuthClient
-from ._async.client import AsyncClient as AClient, AsyncClient
+from ._async.client import AsyncClient
+from ._async.client import AsyncClient as AClient
 from ._async.client import AsyncStorageClient as ASupabaseStorageClient
 from ._async.client import create_client as acreate_client
 from ._async.client import create_client as create_async_client
@@ -28,11 +29,9 @@ from ._sync.client import SyncStorageClient as SupabaseStorageClient
 from ._sync.client import create_client
 
 # Lib
-from .lib.client_options import (
-    SyncClientOptions as ClientOptions,
-    AsyncClientOptions as AClientOptions,
-    AsyncClientOptions,
-)
+from .lib.client_options import AsyncClientOptions
+from .lib.client_options import AsyncClientOptions as AClientOptions
+from .lib.client_options import SyncClientOptions as ClientOptions
 
 # Version
 from .version import __version__

--- a/supabase/__init__.py
+++ b/supabase/__init__.py
@@ -16,9 +16,8 @@ from supafunc.errors import FunctionsError, FunctionsHttpError, FunctionsRelayEr
 
 # Async Client
 from ._async.auth_client import AsyncSupabaseAuthClient as ASupabaseAuthClient
-from ._async.client import AsyncClient as AClient
+from ._async.client import AsyncClient as AClient, AsyncClient
 from ._async.client import AsyncStorageClient as ASupabaseStorageClient
-from ._async.client import ClientOptions as AClientOptions
 from ._async.client import create_client as acreate_client
 from ._async.client import create_client as create_async_client
 
@@ -29,7 +28,11 @@ from ._sync.client import SyncStorageClient as SupabaseStorageClient
 from ._sync.client import create_client
 
 # Lib
-from .lib.client_options import ClientOptions
+from .lib.client_options import (
+    SyncClientOptions as ClientOptions,
+    AsyncClientOptions as AClientOptions,
+    AsyncClientOptions,
+)
 
 # Version
 from .version import __version__
@@ -41,6 +44,8 @@ __all__ = [
     "ASupabaseAuthClient",
     "ASupabaseStorageClient",
     "AClientOptions",
+    "AsyncClient",
+    "AsyncClientOptions",
     "create_client",
     "Client",
     "SupabaseAuthClient",

--- a/supabase/_async/client.py
+++ b/supabase/_async/client.py
@@ -16,7 +16,7 @@ from storage3 import AsyncStorageClient
 from storage3.constants import DEFAULT_TIMEOUT as DEFAULT_STORAGE_CLIENT_TIMEOUT
 from supafunc import AsyncFunctionsClient
 
-from ..lib.client_options import ClientOptions
+from ..lib.client_options import AsyncClientOptions as ClientOptions
 from .auth_client import AsyncSupabaseAuthClient
 
 

--- a/supabase/_sync/client.py
+++ b/supabase/_sync/client.py
@@ -15,7 +15,7 @@ from storage3 import SyncStorageClient
 from storage3.constants import DEFAULT_TIMEOUT as DEFAULT_STORAGE_CLIENT_TIMEOUT
 from supafunc import SyncFunctionsClient
 
-from ..lib.client_options import ClientOptions
+from ..lib.client_options import SyncClientOptions as ClientOptions
 from .auth_client import SyncSupabaseAuthClient
 
 

--- a/supabase/client.py
+++ b/supabase/client.py
@@ -28,11 +28,9 @@ from ._sync.client import SyncStorageClient as SupabaseStorageClient
 from ._sync.client import create_client
 
 # Lib
-from .lib.client_options import (
-    SyncClientOptions as ClientOptions,
-    AsyncClientOptions as AClientOptions,
-    AsyncClientOptions,
-)
+from .lib.client_options import AsyncClientOptions
+from .lib.client_options import AsyncClientOptions as AClientOptions
+from .lib.client_options import SyncClientOptions as ClientOptions
 
 # Version
 from .version import __version__

--- a/supabase/client.py
+++ b/supabase/client.py
@@ -1,11 +1,24 @@
+from gotrue.errors import (
+    AuthApiError,
+    AuthError,
+    AuthImplicitGrantRedirectError,
+    AuthInvalidCredentialsError,
+    AuthRetryableError,
+    AuthSessionMissingError,
+    AuthUnknownError,
+    AuthWeakPasswordError,
+)
 from postgrest import APIError as PostgrestAPIError
 from postgrest import APIResponse as PostgrestAPIResponse
+from realtime import AuthorizationError, NotConnectedError
 from storage3.utils import StorageException
+from supafunc.errors import FunctionsError, FunctionsHttpError, FunctionsRelayError
 
 # Async Client
 from ._async.auth_client import AsyncSupabaseAuthClient
 from ._async.client import AsyncClient
 from ._async.client import AsyncStorageClient as AsyncSupabaseStorageClient
+from ._async.client import create_client as acreate_client
 from ._async.client import create_client as create_async_client
 
 # Sync Client
@@ -15,15 +28,22 @@ from ._sync.client import SyncStorageClient as SupabaseStorageClient
 from ._sync.client import create_client
 
 # Lib
-from .lib.client_options import ClientOptions
+from .lib.client_options import (
+    SyncClientOptions as ClientOptions,
+    AsyncClientOptions as AClientOptions,
+    AsyncClientOptions,
+)
 
 # Version
 from .version import __version__
 
 __all__ = [
     "AsyncSupabaseAuthClient",
+    "acreate_client",
     "create_async_client",
+    "AClientOptions",
     "AsyncClient",
+    "AsyncClientOptions",
     "AsyncSupabaseStorageClient",
     "SupabaseAuthClient",
     "create_client",
@@ -34,4 +54,17 @@ __all__ = [
     "PostgrestAPIResponse",
     "StorageException",
     "__version__",
+    "AuthApiError",
+    "AuthError",
+    "AuthImplicitGrantRedirectError",
+    "AuthInvalidCredentialsError",
+    "AuthRetryableError",
+    "AuthSessionMissingError",
+    "AuthWeakPasswordError",
+    "AuthUnknownError",
+    "FunctionsHttpError",
+    "FunctionsRelayError",
+    "FunctionsError",
+    "AuthorizationError",
+    "NotConnectedError",
 ]

--- a/supabase/lib/client_options.py
+++ b/supabase/lib/client_options.py
@@ -97,6 +97,75 @@ class AsyncClientOptions(ClientOptions):
     storage: SyncSupportedStorage = field(default_factory=AsyncMemoryStorage)
     """A storage provider. Used to store the logged in session."""
 
+    def replace(
+        self,
+        schema: Optional[str] = None,
+        headers: Optional[Dict[str, str]] = None,
+        auto_refresh_token: Optional[bool] = None,
+        persist_session: Optional[bool] = None,
+        storage: Optional[SyncSupportedStorage] = None,
+        realtime: Optional[Dict[str, Any]] = None,
+        postgrest_client_timeout: Union[
+            int, float, Timeout
+        ] = DEFAULT_POSTGREST_CLIENT_TIMEOUT,
+        storage_client_timeout: Union[
+            int, float, Timeout
+        ] = DEFAULT_STORAGE_CLIENT_TIMEOUT,
+        flow_type: Optional[AuthFlowType] = None,
+    ) -> "AsyncClientOptions":
+        """Create a new SupabaseClientOptions with changes"""
+        client_options = AsyncClientOptions()
+        client_options.schema = schema or self.schema
+        client_options.headers = headers or self.headers
+        client_options.auto_refresh_token = (
+            auto_refresh_token or self.auto_refresh_token
+        )
+        client_options.persist_session = persist_session or self.persist_session
+        client_options.storage = storage or self.storage
+        client_options.realtime = realtime or self.realtime
+        client_options.postgrest_client_timeout = (
+            postgrest_client_timeout or self.postgrest_client_timeout
+        )
+        client_options.storage_client_timeout = (
+            storage_client_timeout or self.storage_client_timeout
+        )
+        client_options.flow_type = flow_type or self.flow_type
+        return client_options
+
 
 @dataclass
-class SyncClientOptions(ClientOptions): ...
+class SyncClientOptions(ClientOptions):
+    def replace(
+        self,
+        schema: Optional[str] = None,
+        headers: Optional[Dict[str, str]] = None,
+        auto_refresh_token: Optional[bool] = None,
+        persist_session: Optional[bool] = None,
+        storage: Optional[SyncSupportedStorage] = None,
+        realtime: Optional[Dict[str, Any]] = None,
+        postgrest_client_timeout: Union[
+            int, float, Timeout
+        ] = DEFAULT_POSTGREST_CLIENT_TIMEOUT,
+        storage_client_timeout: Union[
+            int, float, Timeout
+        ] = DEFAULT_STORAGE_CLIENT_TIMEOUT,
+        flow_type: Optional[AuthFlowType] = None,
+    ) -> "SyncClientOptions":
+        """Create a new SupabaseClientOptions with changes"""
+        client_options = SyncClientOptions()
+        client_options.schema = schema or self.schema
+        client_options.headers = headers or self.headers
+        client_options.auto_refresh_token = (
+            auto_refresh_token or self.auto_refresh_token
+        )
+        client_options.persist_session = persist_session or self.persist_session
+        client_options.storage = storage or self.storage
+        client_options.realtime = realtime or self.realtime
+        client_options.postgrest_client_timeout = (
+            postgrest_client_timeout or self.postgrest_client_timeout
+        )
+        client_options.storage_client_timeout = (
+            storage_client_timeout or self.storage_client_timeout
+        )
+        client_options.flow_type = flow_type or self.flow_type
+        return client_options

--- a/supabase/lib/client_options.py
+++ b/supabase/lib/client_options.py
@@ -1,7 +1,12 @@
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional, Union
 
-from gotrue import AuthFlowType, SyncMemoryStorage, SyncSupportedStorage
+from gotrue import (
+    AsyncMemoryStorage,
+    AuthFlowType,
+    SyncMemoryStorage,
+    SyncSupportedStorage,
+)
 from httpx import Timeout
 from postgrest.constants import DEFAULT_POSTGREST_CLIENT_TIMEOUT
 from storage3.constants import DEFAULT_TIMEOUT as DEFAULT_STORAGE_CLIENT_TIMEOUT
@@ -85,3 +90,13 @@ class ClientOptions:
         )
         client_options.flow_type = flow_type or self.flow_type
         return client_options
+
+
+@dataclass
+class AsyncClientOptions(ClientOptions):
+    storage: SyncSupportedStorage = field(default_factory=AsyncMemoryStorage)
+    """A storage provider. Used to store the logged in session."""
+
+
+@dataclass
+class SyncClientOptions(ClientOptions): ...

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -6,8 +6,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from supabase import Client, create_client
-from supabase.lib.client_options import ClientOptions
+from supabase import Client, ClientOptions, create_client
 
 
 @pytest.mark.xfail(

--- a/tests/test_client_options.py
+++ b/tests/test_client_options.py
@@ -1,6 +1,6 @@
 from gotrue import SyncMemoryStorage
 
-from supabase.lib.client_options import ClientOptions
+from supabase import ClientOptions
 
 
 class TestClientOptions:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix for default values of async client options

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

closing #929 
