### PR TITLE
fix: raise the minimum version of gotrue to 2.9.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1971,4 +1971,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "4defa77d3b7a8a9570d54d93af5777f48d335f914f23d6cebc0ca5f893ff04eb"
+content-hash = "ce9b2093cdd1a886d6fc9447bca4fd98b18409293e7cb74862fd75eee3a9e803"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 python = "^3.9"
 postgrest = "^0.17.0"
 realtime = "^2.0.0"
-gotrue = "^2.7.0"
+gotrue = "^2.9.0"
 httpx = ">=0.26,<0.28"
 storage3 = "^0.8.0"
 supafunc = "^0.6.0"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

The `proxy` argument for `SyncGoTrueClient` was added in version 2.9.0 

As a result, having a lower version than 2.9.0 will cause an error

https://github.com/supabase/auth-py/releases/tag/v2.9.0

## What is the current behavior?

Currently having a lower version than `gotrue==2.9.0`, causes the following error: 

```
File "/opt/venv/lib/python3.11/site-packages/supabase/_sync/auth_client.py", line 33, in __init__
   SyncGoTrueClient.__init__(
TypeError: SyncGoTrueClient.__init__() got an unexpected keyword argument 'proxy'
```

Please link any relevant issues here.

Related https://github.com/supabase/supabase-py/issues/949 but this issue is not fully resolved by raising the `httpx` version

## What is the new behavior?
Minimum version of `gotrue` updated to v2.9.0

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
