### PR TITLE
fix: removed typing-extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ conda activate supabase-py
 
 ### PyPi installation
 
-Install the package (for Python > 3.7):
+Install the package (for Python >= 3.9):
 
 ```bash
 # with pip

--- a/poetry.lock
+++ b/poetry.lock
@@ -1971,4 +1971,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "4defa77d3b7a8a9570d54d93af5777f48d335f914f23d6cebc0ca5f893ff04eb"
+content-hash = "acbc7af9a66c718777619069de44f550f22f03219cc41067a7cb86324596f563"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ gotrue = "^2.7.0"
 httpx = ">=0.26,<0.28"
 storage3 = "^0.8.0"
 supafunc = "^0.6.0"
-typing-extensions = "^4.12.2"
 
 [tool.poetry.dev-dependencies]
 pre-commit = "^3.8.0"

--- a/supabase/types.py
+++ b/supabase/types.py
@@ -1,8 +1,8 @@
-from typing_extensions import NotRequired, TypedDict
+from typing import TypedDict
 
 
 class RealtimeClientOptions(TypedDict, total=False):
-    auto_reconnect: NotRequired[bool]
-    hb_interval: NotRequired[int]
-    max_retries: NotRequired[int]
-    initial_backoff: NotRequired[float]
+    auto_reconnect: bool
+    hb_interval: int
+    max_retries: int
+    initial_backoff: float


### PR DESCRIPTION
## Proposal

Related to #964 

This PR includes:
- **Refactoring**: Refactored `TypedDict` from `typing import TypedDict`
- **Docs Update**:  Updated description of python's version