### PR TITLE
fix: schema access optimization

### DIFF
--- a/supabase/_async/client.py
+++ b/supabase/_async/client.py
@@ -129,13 +129,11 @@ class AsyncClient:
 
         The schema needs to be on the list of exposed schemas inside Supabase.
         """
-        self._postgrest = self._init_postgrest_client(
-            rest_url=self.rest_url,
-            headers=self.options.headers,
-            schema=schema,
-            timeout=self.options.postgrest_client_timeout,
-        )
-        return self._postgrest
+        if self.options.schema != schema:
+            self.options.schema = schema
+            if self._postgrest:
+                self._postgrest.schema(schema)
+        return self.postgrest
 
     def from_(self, table_name: str) -> AsyncRequestBuilder:
         """Perform a table operation.

--- a/supabase/_sync/client.py
+++ b/supabase/_sync/client.py
@@ -128,13 +128,11 @@ class SyncClient:
 
         The schema needs to be on the list of exposed schemas inside Supabase.
         """
-        self._postgrest = self._init_postgrest_client(
-            rest_url=self.rest_url,
-            headers=self.options.headers,
-            schema=schema,
-            timeout=self.options.postgrest_client_timeout,
-        )
-        return self._postgrest
+        if self.options.schema != schema:
+            self.options.schema = schema
+            if self._postgrest:
+                self._postgrest.schema(schema)
+        return self.postgrest
 
     def from_(self, table_name: str) -> SyncRequestBuilder:
         """Perform a table operation.


### PR DESCRIPTION
Currently, accessing data across multiple schemas using the `schema()` method incurs significant performance overhead due to the creation of a new PostgreSQL client for each call. This contrasts with directly querying tables, which leverages existing connections and avoids this repeated client instantiation. The overhead becomes particularly noticeable when working with numerous schemas, adding unnecessary milliseconds to query build time.

Thoughts?