### PR TITLE
chore(ci): add python 3.13 to the ci test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Clone Repository


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Update CI https://blog.python.org/2024/10/python-3130-final-released.html
