### PR TITLE
chore: update httpx

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2115,4 +2115,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "f795339e7d66b2ab74e4e38b8bf0821ad457c215221947c63513e51b696beb6e"
+content-hash = "2d2db00be7b0af7937f0e50e41266b68239b7864d69141c5c3d9616af60282c2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ python = "^3.9"
 postgrest = "^0.19"
 realtime = "^2.0.0"
 gotrue = "^2.11.0"
-httpx = ">=0.26,<0.28"
+httpx = ">=0.26,<0.29"
 storage3 = "^0.10"
 supafunc = "^0.9"
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

The last bump of httpx has been done in this commit: https://github.com/supabase/supabase-py/commit/fadbc4b41fc7ef2dc92929c28150901ea700f83f

httpx now release 0.28 (and 0.28.1) and this is causing some conflicts with other packages.

## What is the current behavior?

Unable to install supabase alongside some packages because of httpx

## What is the new behavior?

It should not change the existing install but not block project requiring httpx >= 0.28

