### PR TITLE
feat(auth): add sign_out method to reset session and trigger auth event

### DIFF
--- a/supabase/_sync/client.py
+++ b/supabase/_sync/client.py
@@ -300,6 +300,11 @@ class SyncClient:
 
         self.options.headers["Authorization"] = self._create_auth_header(access_token)
 
+    def sign_out(self) -> None:
+        """Signs out the current user by revoking the session token."""
+        self.auth.sign_out()
+        self._listen_to_auth_events("SIGNED_OUT", None)
+
 
 def create_client(
     supabase_url: str,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -91,3 +91,47 @@ def test_updates_the_authorization_header_on_auth_events() -> None:
 
     assert client.storage.session.headers.get("apiKey") == key
     assert client.storage.session.headers.get("Authorization") == updated_authorization
+
+
+def test_sign_out_resets_auth_headers() -> None:
+    url = os.environ.get("SUPABASE_TEST_URL")
+    key = os.environ.get("SUPABASE_TEST_KEY")
+
+    client = create_client(url, key)
+
+    mock_session = MagicMock(access_token="secretuserjwt")
+    client._listen_to_auth_events("SIGNED_IN", mock_session)
+
+    updated_authorization = f"Bearer {mock_session.access_token}"
+    assert client.options.headers.get("Authorization") == updated_authorization
+
+    client.sign_out()
+
+    assert client.options.headers.get("Authorization") == f"Bearer {key}"
+    assert client._postgrest is None
+    assert client._storage is None
+    assert client._functions is None
+
+
+def test_sign_out_calls_auth_sign_out() -> None:
+    url = os.environ.get("SUPABASE_TEST_URL")
+    key = os.environ.get("SUPABASE_TEST_KEY")
+
+    client = create_client(url, key)
+    client.auth.sign_out = MagicMock()
+
+    client.sign_out()
+
+    client.auth.sign_out.assert_called_once()
+
+
+def test_sign_out_triggers_auth_event() -> None:
+    url = os.environ.get("SUPABASE_TEST_URL")
+    key = os.environ.get("SUPABASE_TEST_KEY")
+
+    client = create_client(url, key)
+    client._listen_to_auth_events = MagicMock()
+
+    client.sign_out()
+
+    client._listen_to_auth_events.assert_called_once_with("SIGNED_OUT", None)


### PR DESCRIPTION
Related to #926 

This PR introduces a new `sign_out` method to handle user sign-out functionality in the Supabase client and includes corresponding tests to ensure the method works correctly.


## Proposal
In consideration of the Issue, If you can approve this PR, I will made the change of docs.

