### PR TITLE
fix: update SupabaseAuthClient to use super instead of calling base class

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,5 @@ tests_only:
 build_sync:
 	poetry run unasync supabase tests
 	sed -i 's/asyncio.create_task(self.realtime.set_auth(access_token))//g' supabase/_sync/client.py
+	sed -i 's/asynch/synch/g' supabase/_sync/auth_client.py
+	sed -i 's/Async/Sync/g' supabase/_sync/auth_client.py

--- a/supabase/_async/auth_client.py
+++ b/supabase/_async/auth_client.py
@@ -10,7 +10,7 @@ from gotrue.http_clients import AsyncClient
 
 
 class AsyncSupabaseAuthClient(AsyncGoTrueClient):
-    """SupabaseAuthClient"""
+    """Supabase Auth Client for asynchronous operations."""
 
     def __init__(
         self,
@@ -26,12 +26,25 @@ class AsyncSupabaseAuthClient(AsyncGoTrueClient):
         verify: bool = True,
         proxy: Optional[str] = None,
     ):
-        """Instantiate SupabaseAuthClient instance."""
+        """
+        Instantiate a SupabaseAuthClient instance.
+
+        Args:
+            url (str): The URL of the Supabase instance.
+            headers (Optional[Dict[str, str]]): Optional headers to include in requests.
+            storage_key (Optional[str]): Key to store session information.
+            auto_refresh_token (bool): Whether to automatically refresh the token. Defaults to True.
+            persist_session (bool): Whether to persist the session. Defaults to True.
+            storage (AsyncSupportedStorage): Storage mechanism. Defaults to AsyncMemoryStorage().
+            http_client (Optional[AsyncClient]): HTTP client for making requests. Defaults to None.
+            flow_type (AuthFlowType): Type of authentication flow. Defaults to "implicit".
+            verify (bool): Whether to verify SSL certificates. Defaults to True.
+            proxy (Optional[str]): Proxy URL. Defaults to None.
+        """
         if headers is None:
             headers = {}
 
-        AsyncGoTrueClient.__init__(
-            self,
+        super().__init__(
             url=url,
             headers=headers,
             storage_key=storage_key,

--- a/supabase/_sync/auth_client.py
+++ b/supabase/_sync/auth_client.py
@@ -10,7 +10,7 @@ from gotrue.http_clients import SyncClient
 
 
 class SyncSupabaseAuthClient(SyncGoTrueClient):
-    """SupabaseAuthClient"""
+    """Supabase Auth Client for synchronous operations."""
 
     def __init__(
         self,
@@ -26,12 +26,25 @@ class SyncSupabaseAuthClient(SyncGoTrueClient):
         verify: bool = True,
         proxy: Optional[str] = None,
     ):
-        """Instantiate SupabaseAuthClient instance."""
+        """
+        Instantiate a SupabaseAuthClient instance.
+
+        Args:
+            url (str): The URL of the Supabase instance.
+            headers (Optional[Dict[str, str]]): Optional headers to include in requests.
+            storage_key (Optional[str]): Key to store session information.
+            auto_refresh_token (bool): Whether to automatically refresh the token. Defaults to True.
+            persist_session (bool): Whether to persist the session. Defaults to True.
+            storage (SyncSupportedStorage): Storage mechanism. Defaults to SyncMemoryStorage().
+            http_client (Optional[SyncClient]): HTTP client for making requests. Defaults to None.
+            flow_type (AuthFlowType): Type of authentication flow. Defaults to "implicit".
+            verify (bool): Whether to verify SSL certificates. Defaults to True.
+            proxy (Optional[str]): Proxy URL. Defaults to None.
+        """
         if headers is None:
             headers = {}
 
-        SyncGoTrueClient.__init__(
-            self,
+        super().__init__(
             url=url,
             headers=headers,
             storage_key=storage_key,


### PR DESCRIPTION
Hi, my name is Pedro Manuel. I have modified the file to use super() instead of calling the base class constructor directly. This makes the code clearer and easier to maintain.

## What kind of change does this PR introduce?

File update.

