### PR TITLE
chore(ci): pipeline using same version of python for all tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Poetry
-        uses: pipx install poetry==1.8.5 --python python3.11
+        run: pipx install poetry==1.8.5 --python python3.11
 
       - name: Install dependencies
         run: poetry install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Set up Poetry
-        uses: abatilo/actions-poetry@v4
-        with:
-          poetry-version: 1.8.4
+        run: pipx install poetry==1.8.5 --python python${{ matrix.python-version }}
 
       - name: Run Tests
         run: poetry run tests
@@ -41,6 +39,21 @@ jobs:
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          flag-name: run-${{ join(matrix.*, '-') }}
+          parallel: true
+
+  finish_tests:
+    needs: test
+    name: Upload tests coveralls results
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel-finished: true
+          carryforward: "run-ubuntu-latest-3.9,run-ubuntu-latest-3.10,run-ubuntu-latest-3.11,run-ubuntu-latest-3.12,run-ubuntu-latest-3.13"
 
   release-please:
     needs: test
@@ -80,9 +93,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Poetry
-        uses: abatilo/actions-poetry@v4
-        with:
-          poetry-version: 1.8.4
+        uses: pipx install poetry==1.8.5 --python python3.11
 
       - name: Install dependencies
         run: poetry install

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: '^.*\.(md|MD)$'
 repos:
     - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v4.6.0
+      rev: v5.0.0
       hooks:
           - id: trailing-whitespace
           - id: check-added-large-files
@@ -10,7 +10,7 @@ repos:
             args: ["--fix=lf"]
 
     - repo: https://github.com/pycqa/isort
-      rev: 5.13.2
+      rev: 6.0.0
       hooks:
           - id: isort
             args:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix for the CI pipeline

## What is the current behavior?

All tests are using Python 3.12

## What is the new behavior?

Tests now use the Python version from the matrix per test

## Additional context

Add any other context or screenshots.
