### PR TITLE
fix: schema method should use postgres method directly

### DIFF
--- a/supabase/_async/client.py
+++ b/supabase/_async/client.py
@@ -129,11 +129,7 @@ class AsyncClient:
 
         The schema needs to be on the list of exposed schemas inside Supabase.
         """
-        if self.options.schema != schema:
-            self.options.schema = schema
-            if self._postgrest:
-                self._postgrest.schema(schema)
-        return self.postgrest
+        return self.postgrest.schema(schema)
 
     def from_(self, table_name: str) -> AsyncRequestBuilder:
         """Perform a table operation.

--- a/supabase/_sync/client.py
+++ b/supabase/_sync/client.py
@@ -128,11 +128,7 @@ class SyncClient:
 
         The schema needs to be on the list of exposed schemas inside Supabase.
         """
-        if self.options.schema != schema:
-            self.options.schema = schema
-            if self._postgrest:
-                self._postgrest.schema(schema)
-        return self.postgrest
+        return self.postgrest.schema(schema)
 
     def from_(self, table_name: str) -> SyncRequestBuilder:
         """Perform a table operation.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Schema method was being cached and calling the wrong schema each call

## What is the new behavior?

Schema method is no longer being cached and calls the correct schema each call

## Additional context

Add any other context or screenshots.
