### PR TITLE
fix: expose verify option through client options

### DIFF
--- a/supabase/_async/client.py
+++ b/supabase/_async/client.py
@@ -81,6 +81,11 @@ class AsyncClient:
         self.auth = self._init_supabase_auth_client(
             auth_url=self.auth_url,
             client_options=options,
+            verify=(
+                options.httpx_options.get("verify")
+                if options.httpx_options is not None
+                else True
+            ),
         )
         self.realtime = self._init_realtime_client(
             realtime_url=self.realtime_url,
@@ -168,6 +173,11 @@ class AsyncClient:
                 headers=self.options.headers,
                 schema=self.options.schema,
                 timeout=self.options.postgrest_client_timeout,
+                verify=(
+                    self.options.httpx_options.get("verify")
+                    if self.options.httpx_options is not None
+                    else True
+                ),
             )
 
         return self._postgrest
@@ -179,6 +189,11 @@ class AsyncClient:
                 storage_url=self.storage_url,
                 headers=self.options.headers,
                 storage_client_timeout=self.options.storage_client_timeout,
+                verify=(
+                    self.options.httpx_options.get("verify")
+                    if self.options.httpx_options is not None
+                    else True
+                ),
             )
         return self._storage
 
@@ -189,6 +204,11 @@ class AsyncClient:
                 self.functions_url,
                 self.options.headers,
                 self.options.function_client_timeout,
+                verify=(
+                    self.options.httpx_options.get("verify")
+                    if self.options.httpx_options is not None
+                    else True
+                ),
             )
         return self._functions
 

--- a/supabase/_sync/client.py
+++ b/supabase/_sync/client.py
@@ -80,6 +80,11 @@ class SyncClient:
         self.auth = self._init_supabase_auth_client(
             auth_url=self.auth_url,
             client_options=options,
+            verify=(
+                options.httpx_options.get("verify")
+                if options.httpx_options is not None
+                else True
+            ),
         )
         self.realtime = self._init_realtime_client(
             realtime_url=self.realtime_url,
@@ -167,6 +172,11 @@ class SyncClient:
                 headers=self.options.headers,
                 schema=self.options.schema,
                 timeout=self.options.postgrest_client_timeout,
+                verify=(
+                    self.options.httpx_options.get("verify")
+                    if self.options.httpx_options is not None
+                    else True
+                ),
             )
 
         return self._postgrest
@@ -178,6 +188,11 @@ class SyncClient:
                 storage_url=self.storage_url,
                 headers=self.options.headers,
                 storage_client_timeout=self.options.storage_client_timeout,
+                verify=(
+                    self.options.httpx_options.get("verify")
+                    if self.options.httpx_options is not None
+                    else True
+                ),
             )
         return self._storage
 
@@ -188,6 +203,11 @@ class SyncClient:
                 self.functions_url,
                 self.options.headers,
                 self.options.function_client_timeout,
+                verify=(
+                    self.options.httpx_options.get("verify")
+                    if self.options.httpx_options is not None
+                    else True
+                ),
             )
         return self._functions
 

--- a/supabase/lib/client_options.py
+++ b/supabase/lib/client_options.py
@@ -13,7 +13,7 @@ from postgrest.constants import DEFAULT_POSTGREST_CLIENT_TIMEOUT
 from storage3.constants import DEFAULT_TIMEOUT as DEFAULT_STORAGE_CLIENT_TIMEOUT
 from supafunc.utils import DEFAULT_FUNCTION_CLIENT_TIMEOUT
 
-from supabase.types import RealtimeClientOptions
+from supabase.types import HttpxOptions, RealtimeClientOptions
 
 from ..version import __version__
 
@@ -39,6 +39,9 @@ class ClientOptions:
 
     storage: SyncSupportedStorage = field(default_factory=SyncMemoryStorage)
     """A storage provider. Used to store the logged in session."""
+
+    httpx_options: Optional[HttpxOptions] = None
+    """Options passed to httpx when making requests"""
 
     realtime: Optional[RealtimeClientOptions] = None
     """Options passed to the realtime-py instance"""
@@ -74,6 +77,7 @@ class ClientOptions:
             int, float, Timeout
         ] = DEFAULT_STORAGE_CLIENT_TIMEOUT,
         flow_type: Optional[AuthFlowType] = None,
+        httpx_options: Optional[HttpxOptions] = None,
     ) -> "ClientOptions":
         """Create a new SupabaseClientOptions with changes"""
         client_options = ClientOptions()
@@ -85,6 +89,7 @@ class ClientOptions:
         client_options.persist_session = persist_session or self.persist_session
         client_options.storage = storage or self.storage
         client_options.realtime = realtime or self.realtime
+        client_options.httpx_options = httpx_options or self.httpx_options
         client_options.postgrest_client_timeout = (
             postgrest_client_timeout or self.postgrest_client_timeout
         )
@@ -115,6 +120,7 @@ class AsyncClientOptions(ClientOptions):
             int, float, Timeout
         ] = DEFAULT_STORAGE_CLIENT_TIMEOUT,
         flow_type: Optional[AuthFlowType] = None,
+        httpx_options: Optional[HttpxOptions] = None,
     ) -> "AsyncClientOptions":
         """Create a new SupabaseClientOptions with changes"""
         client_options = AsyncClientOptions()
@@ -126,6 +132,7 @@ class AsyncClientOptions(ClientOptions):
         client_options.persist_session = persist_session or self.persist_session
         client_options.storage = storage or self.storage
         client_options.realtime = realtime or self.realtime
+        client_options.httpx_options = httpx_options or self.httpx_options
         client_options.postgrest_client_timeout = (
             postgrest_client_timeout or self.postgrest_client_timeout
         )
@@ -153,6 +160,7 @@ class SyncClientOptions(ClientOptions):
             int, float, Timeout
         ] = DEFAULT_STORAGE_CLIENT_TIMEOUT,
         flow_type: Optional[AuthFlowType] = None,
+        httpx_options: Optional[HttpxOptions] = None,
     ) -> "SyncClientOptions":
         """Create a new SupabaseClientOptions with changes"""
         client_options = SyncClientOptions()
@@ -164,6 +172,7 @@ class SyncClientOptions(ClientOptions):
         client_options.persist_session = persist_session or self.persist_session
         client_options.storage = storage or self.storage
         client_options.realtime = realtime or self.realtime
+        client_options.httpx_options = httpx_options or self.httpx_options
         client_options.postgrest_client_timeout = (
             postgrest_client_timeout or self.postgrest_client_timeout
         )

--- a/supabase/types.py
+++ b/supabase/types.py
@@ -6,3 +6,8 @@ class RealtimeClientOptions(TypedDict, total=False):
     hb_interval: int
     max_retries: int
     initial_backoff: float
+
+
+class HttpxOptions(TypedDict, total=False):
+    verify: bool = True
+    """Either `True` to use an SSL context with the default CA bundle, `False` to disable verification."""


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix to expose `verify` via the `ClientOptions` through the `httpx_options` config.

```py
from supabase import create_client, ClientOptions

supabase = create_client(
  url, 
  anon_key, 
  options=ClientOptions(httpx_options={"verify": False})
)
```

## What is the current behavior?

There is no way to set the `verify` flag from the `supabase` python library.

## What is the new behavior?

You can now set the `verify` flag from the `supabase` python library

## Additional context

#1086 
