### PR TITLE
fix: remove return type from postgrest methods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,3 +20,4 @@ build_sync:
 	sed -i 's/asyncio.create_task(self.realtime.set_auth(access_token))//g' supabase/_sync/client.py
 	sed -i 's/asynch/synch/g' supabase/_sync/auth_client.py
 	sed -i 's/Async/Sync/g' supabase/_sync/auth_client.py
+	sed -i 's/Async/Sync/g' supabase/_sync/client.py

--- a/supabase/_async/client.py
+++ b/supabase/_async/client.py
@@ -1,14 +1,12 @@
 import asyncio
 import re
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, Optional, Union
 
 from gotrue import AsyncMemoryStorage
 from gotrue.types import AuthChangeEvent, Session
 from httpx import Timeout
 from postgrest import (
     AsyncPostgrestClient,
-    AsyncRequestBuilder,
-    AsyncRPCFilterRequestBuilder,
 )
 from postgrest.constants import DEFAULT_POSTGREST_CLIENT_TIMEOUT
 from postgrest.types import CountMethod
@@ -116,7 +114,7 @@ class AsyncClient:
 
         return client
 
-    def table(self, table_name: str) -> AsyncRequestBuilder:
+    def table(self, table_name: str):
         """Perform a table operation.
 
         Note that the supabase client uses the `from` method, but in Python,
@@ -125,14 +123,14 @@ class AsyncClient:
         """
         return self.from_(table_name)
 
-    def schema(self, schema: str) -> AsyncPostgrestClient:
+    def schema(self, schema: str):
         """Select a schema to query or perform an function (rpc) call.
 
         The schema needs to be on the list of exposed schemas inside Supabase.
         """
         return self.postgrest.schema(schema)
 
-    def from_(self, table_name: str) -> AsyncRequestBuilder:
+    def from_(self, table_name: str):
         """Perform a table operation.
 
         See the `table` method.
@@ -146,7 +144,7 @@ class AsyncClient:
         count: Optional[CountMethod] = None,
         head: bool = False,
         get: bool = False,
-    ) -> AsyncRPCFilterRequestBuilder:
+    ):
         """Performs a stored procedure call.
 
         Parameters
@@ -161,7 +159,7 @@ class AsyncClient:
 
         Returns
         -------
-        SyncFilterRequestBuilder
+        AsyncFilterRequestBuilder
             Returns a filter builder. This lets you apply filters on the response
             of an RPC.
         """
@@ -207,15 +205,15 @@ class AsyncClient:
         """Creates a Realtime channel with Broadcast, Presence, and Postgres Changes."""
         return self.realtime.channel(topic, params)
 
-    def get_channels(self) -> List[AsyncRealtimeChannel]:
+    def get_channels(self):
         """Returns all realtime channels."""
         return self.realtime.get_channels()
 
-    async def remove_channel(self, channel: AsyncRealtimeChannel) -> None:
+    async def remove_channel(self, channel: AsyncRealtimeChannel):
         """Unsubscribes and removes Realtime channel from Realtime client."""
         await self.realtime.remove_channel(channel)
 
-    async def remove_all_channels(self) -> None:
+    async def remove_all_channels(self):
         """Unsubscribes and removes all Realtime channels from Realtime client."""
         await self.realtime.remove_all_channels()
 

--- a/supabase/_sync/client.py
+++ b/supabase/_sync/client.py
@@ -1,13 +1,11 @@
 import re
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, Optional, Union
 
 from gotrue import SyncMemoryStorage
 from gotrue.types import AuthChangeEvent, Session
 from httpx import Timeout
 from postgrest import (
     SyncPostgrestClient,
-    SyncRequestBuilder,
-    SyncRPCFilterRequestBuilder,
 )
 from postgrest.constants import DEFAULT_POSTGREST_CLIENT_TIMEOUT
 from postgrest.types import CountMethod
@@ -115,7 +113,7 @@ class SyncClient:
 
         return client
 
-    def table(self, table_name: str) -> SyncRequestBuilder:
+    def table(self, table_name: str):
         """Perform a table operation.
 
         Note that the supabase client uses the `from` method, but in Python,
@@ -124,14 +122,14 @@ class SyncClient:
         """
         return self.from_(table_name)
 
-    def schema(self, schema: str) -> SyncPostgrestClient:
+    def schema(self, schema: str):
         """Select a schema to query or perform an function (rpc) call.
 
         The schema needs to be on the list of exposed schemas inside Supabase.
         """
         return self.postgrest.schema(schema)
 
-    def from_(self, table_name: str) -> SyncRequestBuilder:
+    def from_(self, table_name: str):
         """Perform a table operation.
 
         See the `table` method.
@@ -145,7 +143,7 @@ class SyncClient:
         count: Optional[CountMethod] = None,
         head: bool = False,
         get: bool = False,
-    ) -> SyncRPCFilterRequestBuilder:
+    ):
         """Performs a stored procedure call.
 
         Parameters
@@ -206,15 +204,15 @@ class SyncClient:
         """Creates a Realtime channel with Broadcast, Presence, and Postgres Changes."""
         return self.realtime.channel(topic, params)
 
-    def get_channels(self) -> List[SyncRealtimeChannel]:
+    def get_channels(self):
         """Returns all realtime channels."""
         return self.realtime.get_channels()
 
-    def remove_channel(self, channel: SyncRealtimeChannel) -> None:
+    def remove_channel(self, channel: SyncRealtimeChannel):
         """Unsubscribes and removes Realtime channel from Realtime client."""
         self.realtime.remove_channel(channel)
 
-    def remove_all_channels(self) -> None:
+    def remove_all_channels(self):
         """Unsubscribes and removes all Realtime channels from Realtime client."""
         self.realtime.remove_all_channels()
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The return types are incorrect from the postgrest methods inside of supabase-py

## What is the new behavior?

The return types are correct from the postgrest methods inside of supabase-py

## Additional context

Fixes #1105
