### PR TITLE
fix: custom headers not  setting

### DIFF
--- a/supabase/_async/client.py
+++ b/supabase/_async/client.py
@@ -70,7 +70,10 @@ class AsyncClient:
         self.supabase_url = supabase_url
         self.supabase_key = supabase_key
         self.options = copy.copy(options)
-        self.options.headers = copy.copy(self._get_auth_headers())
+        self.options.headers = {
+            **options.headers,
+            **self._get_auth_headers(),
+        }
 
         self.rest_url = f"{supabase_url}/rest/v1"
         self.realtime_url = f"{supabase_url}/realtime/v1".replace("http", "ws")

--- a/supabase/_sync/client.py
+++ b/supabase/_sync/client.py
@@ -69,7 +69,10 @@ class SyncClient:
         self.supabase_url = supabase_url
         self.supabase_key = supabase_key
         self.options = copy.copy(options)
-        self.options.headers = copy.copy(self._get_auth_headers())
+        self.options.headers = {
+            **options.headers,
+            **self._get_auth_headers(),
+        }
 
         self.rest_url = f"{supabase_url}/rest/v1"
         self.realtime_url = f"{supabase_url}/realtime/v1".replace("http", "ws")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -147,3 +147,41 @@ def test_global_authorization_header_issue():
     client = create_client(url, key, options)
 
     assert client.options.headers.get("apiKey") == key
+
+
+def test_custom_headers():
+    url = os.environ.get("SUPABASE_TEST_URL")
+    key = os.environ.get("SUPABASE_TEST_KEY")
+
+    options = ClientOptions(
+        headers={
+            "x-app-name": "apple",
+            "x-version": "1.0",
+        }
+    )
+
+    client = create_client(url, key, options)
+
+    assert client.options.headers.get("x-app-name") == "apple"
+    assert client.options.headers.get("x-version") == "1.0"
+
+
+def test_custom_headers_immutable():
+    url = os.environ.get("SUPABASE_TEST_URL")
+    key = os.environ.get("SUPABASE_TEST_KEY")
+
+    options = ClientOptions(
+        headers={
+            "x-app-name": "apple",
+            "x-version": "1.0",
+        }
+    )
+
+    client1 = create_client(url, key, options)
+    client2 = create_client(url, key, options)
+
+    client1.options.headers["x-app-name"] = "grapes"
+
+    assert client1.options.headers.get("x-app-name") == "grapes"
+    assert client1.options.headers.get("x-version") == "1.0"
+    assert client2.options.headers.get("x-app-name") == "apple"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Setting custom headers is failing due to the headers being overwritten internally

## What is the new behavior?

Custom headers can be set as they are now copied internally and they remain immutable

## Additional context

Relates to #1153 
