### PR TITLE
Fix client.py

### DIFF
--- a/supabase/_async/client.py
+++ b/supabase/_async/client.py
@@ -290,16 +290,14 @@ class AsyncClient:
         http_client: Union[AsyncHttpxClient, None] = None,
     ) -> AsyncPostgrestClient:
         """Private helper for creating an instance of the Postgrest client."""
+        kwargs = {
+            "timeout": timeout,
+            "verify": verify,
+            "proxy": proxy,
+        }
         if http_client is not None:
             # If an http client is provided, use it
-            kwargs = {"http_client": http_client}
-        else:
-            kwargs = {
-                "timeout": timeout,
-                "verify": verify,
-                "proxy": proxy,
-                "http_client": None,
-            }
+            kwargs["httpx_client"] = http_client
 
         return AsyncPostgrestClient(
             rest_url,


### PR DESCRIPTION
What kind of change does this PR introduce?
Bug fix

What is the current behavior?
When initializing the Supabase async client with a custom HTTP client, the following error occurs:
AsyncPostgrestClient.__init__() got an unexpected keyword argument 'http_client'

This is because the AsyncPostgrestClient expects the keyword argument to be httpx_client, not http_client.

What is the new behavior?
The _init_postgrest_client method now passes the custom HTTP client using the correct keyword argument httpx_client. This allows users to provide a custom HTTPX client for Postgrest operations without error.

Additional context
This change keeps the logic for custom HTTP client support, but uses the correct argument name for compatibility with the AsyncPostgrestClient constructor.