### PR TITLE
docs: add note about explicit client.auth.sign_out() for proper shutdown (#926)

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,14 @@ data = supabase.storage.from_(bucket_name).move(old_file_path, new_file_path)
 
 Contributing to the Python libraries are a great way to get involved with the Supabase community. Reach out to us on [Discord](https://discord.supabase.com) or on our [Github Discussions](https://github.com/orgs/supabase/discussions) page if you want to get involved.
 
+## Important: Proper Client Shutdown
+
+To ensure the Supabase client terminates correctly and to prevent resource leaks, you **must** explicitly call:
+
+```python
+client.auth.sign_out()
+```
+
 ### Running Tests
 
 Currently, the test suites are in a state of flux. We are expanding our clients' tests to ensure things are working, and for now can connect to this test instance, which is populated with the following table:


### PR DESCRIPTION
This PR adds a documentation note to clarify that an explicit call to `client.auth.sign_out()` is required to ensure proper shutdown of the Supabase client.

Without this call, background WebSocket connections and threads may continue running, potentially leading to resource leaks and hanging processes.

Relates to: #926

