### PR TITLE
Fix typo: PyPi ➝ PyPI in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ conda create --name supabase-py
 conda activate supabase-py
 ```
 
-### PyPi installation
+### PyPI installation
 
 Install the package (for Python >= 3.9):
 


### PR DESCRIPTION
Updated README for a type , PyPi to PyPI

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
