### PR TITLE
chore: switch to `supabase_auth` and `supabase_functions`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,9 @@ requires-python = ">=3.9"
 dependencies = [
   "postgrest == 1.1.1",
   "realtime == 2.7.0",
-  "gotrue == 2.12.3",
+  "supabase_auth == 2.12.3",
   "storage3 == 0.12.1",
-  "supafunc == 0.10.1",
+  "supabase_functions == 0.10.1",
   "httpx >=0.26,<0.29",
 ]
 

--- a/supabase/__init__.py
+++ b/supabase/__init__.py
@@ -1,4 +1,4 @@
-from gotrue.errors import (
+from supabase_auth.errors import (
     AuthApiError,
     AuthError,
     AuthImplicitGrantRedirectError,
@@ -12,7 +12,7 @@ from postgrest import APIError as PostgrestAPIError
 from postgrest import APIResponse as PostgrestAPIResponse
 from realtime import AuthorizationError, NotConnectedError
 from storage3.utils import StorageException
-from supafunc.errors import FunctionsError, FunctionsHttpError, FunctionsRelayError
+from supabase_functions.errors import FunctionsError, FunctionsHttpError, FunctionsRelayError
 
 # Async Client
 from ._async.auth_client import AsyncSupabaseAuthClient as ASupabaseAuthClient

--- a/supabase/_async/auth_client.py
+++ b/supabase/_async/auth_client.py
@@ -1,12 +1,12 @@
 from typing import Dict, Optional
 
-from gotrue import (
+from supabase_auth import (
     AsyncGoTrueClient,
     AsyncMemoryStorage,
     AsyncSupportedStorage,
     AuthFlowType,
 )
-from gotrue.http_clients import AsyncClient
+from supabase_auth.http_clients import AsyncClient
 
 
 class AsyncSupabaseAuthClient(AsyncGoTrueClient):

--- a/supabase/_async/client.py
+++ b/supabase/_async/client.py
@@ -3,8 +3,8 @@ import copy
 import re
 from typing import Any, Dict, Optional, Union
 
-from gotrue import AsyncMemoryStorage
-from gotrue.types import AuthChangeEvent, Session
+from supabase_auth import AsyncMemoryStorage
+from supabase_auth.types import AuthChangeEvent, Session
 from httpx import Timeout
 from postgrest import (
     AsyncPostgrestClient,
@@ -14,7 +14,7 @@ from postgrest.types import CountMethod
 from realtime import AsyncRealtimeChannel, AsyncRealtimeClient, RealtimeChannelOptions
 from storage3 import AsyncStorageClient
 from storage3.constants import DEFAULT_TIMEOUT as DEFAULT_STORAGE_CLIENT_TIMEOUT
-from supafunc import AsyncFunctionsClient
+from supabase_functions import AsyncFunctionsClient
 
 from ..lib.client_options import AsyncClientOptions as ClientOptions
 from ..lib.client_options import AsyncHttpxClient

--- a/supabase/_sync/auth_client.py
+++ b/supabase/_sync/auth_client.py
@@ -1,12 +1,12 @@
 from typing import Dict, Optional
 
-from gotrue import (
+from supabase_auth import (
     AuthFlowType,
     SyncGoTrueClient,
     SyncMemoryStorage,
     SyncSupportedStorage,
 )
-from gotrue.http_clients import SyncClient
+from supabase_auth.http_clients import SyncClient
 
 
 class SyncSupabaseAuthClient(SyncGoTrueClient):

--- a/supabase/_sync/client.py
+++ b/supabase/_sync/client.py
@@ -2,8 +2,8 @@ import copy
 import re
 from typing import Any, Dict, Optional, Union
 
-from gotrue import SyncMemoryStorage
-from gotrue.types import AuthChangeEvent, Session
+from supabase_auth import SyncMemoryStorage
+from supabase_auth.types import AuthChangeEvent, Session
 from httpx import Timeout
 from postgrest import (
     SyncPostgrestClient,
@@ -13,7 +13,7 @@ from postgrest.types import CountMethod
 from realtime import RealtimeChannelOptions, SyncRealtimeChannel, SyncRealtimeClient
 from storage3 import SyncStorageClient
 from storage3.constants import DEFAULT_TIMEOUT as DEFAULT_STORAGE_CLIENT_TIMEOUT
-from supafunc import SyncFunctionsClient
+from supabase_functions import SyncFunctionsClient
 
 from ..lib.client_options import SyncClientOptions as ClientOptions
 from ..lib.client_options import SyncHttpxClient

--- a/supabase/client.py
+++ b/supabase/client.py
@@ -1,4 +1,4 @@
-from gotrue.errors import (
+from supabase_auth.errors import (
     AuthApiError,
     AuthError,
     AuthImplicitGrantRedirectError,
@@ -12,7 +12,7 @@ from postgrest import APIError as PostgrestAPIError
 from postgrest import APIResponse as PostgrestAPIResponse
 from realtime import AuthorizationError, NotConnectedError
 from storage3.utils import StorageException
-from supafunc.errors import FunctionsError, FunctionsHttpError, FunctionsRelayError
+from supabase_functions.errors import FunctionsError, FunctionsHttpError, FunctionsRelayError
 
 # Async Client
 from ._async.auth_client import AsyncSupabaseAuthClient

--- a/supabase/lib/client_options.py
+++ b/supabase/lib/client_options.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 from typing import Dict, Optional, Union
 
-from gotrue import (
+from supabase_auth import (
     AsyncMemoryStorage,
     AsyncSupportedStorage,
     AuthFlowType,
@@ -13,7 +13,7 @@ from httpx import Client as SyncHttpxClient
 from httpx import Timeout
 from postgrest.constants import DEFAULT_POSTGREST_CLIENT_TIMEOUT
 from storage3.constants import DEFAULT_TIMEOUT as DEFAULT_STORAGE_CLIENT_TIMEOUT
-from supafunc.utils import DEFAULT_FUNCTION_CLIENT_TIMEOUT
+from supabase_functions.utils import DEFAULT_FUNCTION_CLIENT_TIMEOUT
 
 from supabase.types import RealtimeClientOptions
 

--- a/tests/_async/test_client.py
+++ b/tests/_async/test_client.py
@@ -3,7 +3,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from gotrue import AsyncMemoryStorage
+from supabase_auth import AsyncMemoryStorage
 from httpx import AsyncClient as AsyncHttpxClient
 from httpx import AsyncHTTPTransport, Limits, Timeout
 

--- a/tests/_sync/test_client.py
+++ b/tests/_sync/test_client.py
@@ -3,7 +3,7 @@ from typing import Any
 from unittest.mock import MagicMock, Mock
 
 import pytest
-from gotrue import SyncMemoryStorage
+from supabase_auth import SyncMemoryStorage
 from httpx import Client as SyncHttpxClient
 from httpx import HTTPTransport, Limits, Timeout
 

--- a/tests/test_client_options.py
+++ b/tests/test_client_options.py
@@ -1,4 +1,4 @@
-from gotrue import SyncMemoryStorage
+from supabase_auth import SyncMemoryStorage
 
 from supabase import AClientOptions, ClientOptions
 

--- a/uv.lock
+++ b/uv.lock
@@ -327,20 +327,6 @@ wheels = [
 ]
 
 [[package]]
-name = "gotrue"
-version = "2.12.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "httpx", extra = ["http2"] },
-    { name = "pydantic" },
-    { name = "pyjwt" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fe/67/ae47f68daae1bbb56a9fbf960dfb7d08b3dec52a6ad1e96f69c2ba5b3116/gotrue-2.12.3.tar.gz", hash = "sha256:f874cf9d0b2f0335bfbd0d6e29e3f7aff79998cd1c14d2ad814db8c06cee3852", size = 38323, upload-time = "2025-07-04T06:50:03.941Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/fa/4165d298ef89254c9f742faa3f99a61fe6fd3552b4ba44df6924f8d307d7/gotrue-2.12.3-py3-none-any.whl", hash = "sha256:b1a3c6a5fe3f92e854a026c4c19de58706a96fd5fbdcc3d620b2802f6a46a26b", size = 44022, upload-time = "2025-07-04T06:50:02.591Z" },
-]
-
-[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -975,15 +961,15 @@ wheels = [
 
 [[package]]
 name = "supabase"
-version = "2.17.0"
+version = "2.18.0"
 source = { editable = "." }
 dependencies = [
-    { name = "gotrue" },
     { name = "httpx" },
     { name = "postgrest" },
     { name = "realtime" },
     { name = "storage3" },
-    { name = "supafunc" },
+    { name = "supabase-auth" },
+    { name = "supabase-functions" },
 ]
 
 [package.dev-dependencies]
@@ -1014,12 +1000,12 @@ tests = [
 
 [package.metadata]
 requires-dist = [
-    { name = "gotrue", specifier = "==2.12.3" },
     { name = "httpx", specifier = ">=0.26,<0.29" },
     { name = "postgrest", specifier = "==1.1.1" },
     { name = "realtime", specifier = "==2.7.0" },
     { name = "storage3", specifier = "==0.12.1" },
-    { name = "supafunc", specifier = "==0.10.1" },
+    { name = "supabase-auth", specifier = "==2.12.3" },
+    { name = "supabase-functions", specifier = "==0.10.1" },
 ]
 
 [package.metadata.requires-dev]
@@ -1049,16 +1035,30 @@ tests = [
 ]
 
 [[package]]
-name = "supafunc"
+name = "supabase-auth"
+version = "2.12.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx", extra = ["http2"] },
+    { name = "pydantic" },
+    { name = "pyjwt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e9/3d6f696a604752803b9e389b04d454f4b26a29b5d155b257fea4af8dc543/supabase_auth-2.12.3.tar.gz", hash = "sha256:8d3b67543f3b27f5adbfe46b66990424c8504c6b08c1141ec572a9802761edc2", size = 38430, upload-time = "2025-07-04T06:49:22.906Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/a6/4102d5fa08a8521d9432b4d10bb58fedbd1f92b211d1b45d5394f5cb9021/supabase_auth-2.12.3-py3-none-any.whl", hash = "sha256:15c7580e1313d30ffddeb3221cb3cdb87c2a80fd220bf85d67db19cd1668435b", size = 44417, upload-time = "2025-07-04T06:49:21.351Z" },
+]
+
+[[package]]
+name = "supabase-functions"
 version = "0.10.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx", extra = ["http2"] },
     { name = "strenum" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e8/4b/16f94bcae8a49f5e09544a4fb0e6ad1c2288038036cefdeedb72fcffd92c/supafunc-0.10.1.tar.gz", hash = "sha256:a5b33c8baecb6b5297d25da29a2503e2ec67ee6986f3d44c137e651b8a59a17d", size = 5036, upload-time = "2025-06-23T18:26:50.327Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/e4/6df7cd4366396553449e9907c745862ebf010305835b2bac99933dd7db9d/supabase_functions-0.10.1.tar.gz", hash = "sha256:4779d33a1cc3d4aea567f586b16d8efdb7cddcd6b40ce367c5fb24288af3a4f1", size = 5025, upload-time = "2025-06-23T18:26:12.239Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/4a/9cbea12d86a741d4e73a6e278c2b1d6479fb03d1002efb00e8e71aea76db/supafunc-0.10.1-py3-none-any.whl", hash = "sha256:26df9bd25ff2ef56cb5bfb8962de98f43331f7f8ff69572bac3ed9c3a9672040", size = 8028, upload-time = "2025-06-23T18:26:49.176Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/06/060118a1e602c9bda8e4bf950bd1c8b5e1542349f2940ec57541266fabe1/supabase_functions-0.10.1-py3-none-any.whl", hash = "sha256:1db85e20210b465075aacee4e171332424f7305f9903c5918096be1423d6fcc5", size = 8275, upload-time = "2025-06-23T18:26:10.387Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What kind of change does this PR introduce?

Switch to `supabase-auth` instead of `gotrue`, and `supabase-functions` instead of `supafunc`. Fixes https://github.com/supabase/supabase-py/issues/1166. 

Should be merge after both of the packages are properly deprecated.

## What is the current behavior?

Using `gotrue` and `supafunc` packages.

## What is the new behavior?

Using `supabase_auth` and `supabase_functions` packages.