### PR TITLE
fix: remove deprecated supafunc and gotrue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,10 +25,6 @@ dependencies = [
   "storage3 == 0.12.1",
   "supabase_functions == 0.10.1",
   "httpx >=0.26,<0.29",
-  # keep both of them in for a little while
-  # until the name deprecation is finished.
-  "gotrue == 2.12.4",
-  "supafunc == 0.10.2",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -327,20 +327,6 @@ wheels = [
 ]
 
 [[package]]
-name = "gotrue"
-version = "2.12.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "httpx", extra = ["http2"] },
-    { name = "pydantic" },
-    { name = "pyjwt" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/aa/6c/fe920e91959bd211325860332be5898b6b53d6ccd873c053fc5cc829020c/gotrue-2.12.4.tar.gz", hash = "sha256:35d2e58e066486321f4dff0033b30a53d057c7f436c15287122fa0cb833029b1", size = 34817, upload-time = "2025-08-08T15:55:49.393Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/2f/0e68d566d9339b8d320399d755704e17a94a123cf22f124b4ab2f686bcc3/gotrue-2.12.4-py3-none-any.whl", hash = "sha256:cf36dfcebc1da63b8d1e7b93eb1a35dfee3dcb1e1376833c256464010eb5fcd6", size = 42783, upload-time = "2025-08-08T15:55:48.289Z" },
-]
-
-[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -978,14 +964,12 @@ name = "supabase"
 version = "2.18.0"
 source = { editable = "." }
 dependencies = [
-    { name = "gotrue" },
     { name = "httpx" },
     { name = "postgrest" },
     { name = "realtime" },
     { name = "storage3" },
     { name = "supabase-auth" },
     { name = "supabase-functions" },
-    { name = "supafunc" },
 ]
 
 [package.dev-dependencies]
@@ -1016,14 +1000,12 @@ tests = [
 
 [package.metadata]
 requires-dist = [
-    { name = "gotrue", specifier = "==2.12.4" },
     { name = "httpx", specifier = ">=0.26,<0.29" },
     { name = "postgrest", specifier = "==1.1.1" },
     { name = "realtime", specifier = "==2.7.0" },
     { name = "storage3", specifier = "==0.12.1" },
     { name = "supabase-auth", specifier = "==2.12.3" },
     { name = "supabase-functions", specifier = "==0.10.1" },
-    { name = "supafunc", specifier = "==0.10.2" },
 ]
 
 [package.metadata.requires-dev]
@@ -1031,7 +1013,7 @@ dev = [
     { name = "commitizen", specifier = ">=4.8.3" },
     { name = "pre-commit", specifier = ">=4.1.0" },
     { name = "pytest", specifier = ">=8.4.1" },
-    { name = "pytest-asyncio", specifier = ">=0.24,<1.1" },
+    { name = "pytest-asyncio", specifier = ">=0.24,<1.2" },
     { name = "pytest-cov", specifier = ">=6.2.1" },
     { name = "python-dotenv", specifier = ">=1.1.1" },
     { name = "ruff", specifier = ">=0.12.1" },
@@ -1047,7 +1029,7 @@ pre-commit = [
 ]
 tests = [
     { name = "pytest", specifier = ">=8.4.1" },
-    { name = "pytest-asyncio", specifier = ">=0.24,<1.1" },
+    { name = "pytest-asyncio", specifier = ">=0.24,<1.2" },
     { name = "pytest-cov", specifier = ">=6.2.1" },
     { name = "python-dotenv", specifier = ">=1.1.1" },
 ]
@@ -1077,19 +1059,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6c/e4/6df7cd4366396553449e9907c745862ebf010305835b2bac99933dd7db9d/supabase_functions-0.10.1.tar.gz", hash = "sha256:4779d33a1cc3d4aea567f586b16d8efdb7cddcd6b40ce367c5fb24288af3a4f1", size = 5025, upload-time = "2025-06-23T18:26:12.239Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/06/060118a1e602c9bda8e4bf950bd1c8b5e1542349f2940ec57541266fabe1/supabase_functions-0.10.1-py3-none-any.whl", hash = "sha256:1db85e20210b465075aacee4e171332424f7305f9903c5918096be1423d6fcc5", size = 8275, upload-time = "2025-06-23T18:26:10.387Z" },
-]
-
-[[package]]
-name = "supafunc"
-version = "0.10.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "httpx", extra = ["http2"] },
-    { name = "strenum" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a0/a9/cd7c89972d8638f3b658126b2f580fe13bcd7235f8abfbdd9da70ebb2933/supafunc-0.10.2.tar.gz", hash = "sha256:45e4d500854167c261515c43f7a363320e0a928118182fe8932adefddeddb545", size = 5033, upload-time = "2025-08-08T15:58:28.626Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/d3/784314aa18185f97c4b998a0384c7b3c021637a93cef20247f15772f0c84/supafunc-0.10.2-py3-none-any.whl", hash = "sha256:547a2c115b15319c78fc84460f19cb5ea6e72597f7573a3498f4db087787e0fd", size = 8444, upload-time = "2025-08-08T15:58:27.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What kind of change does this PR introduce?

Removes `gotrue` and `supafunc` from dependencies as they're not longer needed.

## What is the current behavior?

Both packages are dependencies and unused.

## What is the new behavior?

No more unused packages.