### PR TITLE
chore(nix): improve nix setup to be locally editable

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -29,11 +29,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753063383,
-        "narHash": "sha256-H+gLv6424OjJSD+l1OU1ejxkN/v0U+yaoQdh2huCXYI=",
+        "lastModified": 1757296493,
+        "narHash": "sha256-6nzSZl28IwH2Vx8YSmd3t6TREHpDbKlDPK+dq1LKIZQ=",
         "owner": "pyproject-nix",
         "repo": "build-system-pkgs",
-        "rev": "45888b7fd4bf36c57acc55f07917bdf49ec89ec9",
+        "rev": "5b8e37fe0077db5c1df3a5ee90a651345f085d38",
         "type": "github"
       },
       "original": {
@@ -49,11 +49,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754287816,
-        "narHash": "sha256-kDt0HB89oWTlTQMnTwDxx3BlRHK1AdAJ1kMcVYGuccs=",
+        "lastModified": 1758087687,
+        "narHash": "sha256-mH17yoWmkT5Kf9cpbDp0s2pgU9iTnfadsypy4n5IXWY=",
         "owner": "pyproject-nix",
         "repo": "pyproject.nix",
-        "rev": "efe944d0902f406c28b4e8662312292a37e4de87",
+        "rev": "e82d2bf1b96908f457ef199fa69e97825d9f228f",
         "type": "github"
       },
       "original": {
@@ -80,11 +80,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754285395,
-        "narHash": "sha256-ot8qz71k3Pqg/Fr6goQs3DCOz11IQEeSObuJ5LJOBPg=",
+        "lastModified": 1758104552,
+        "narHash": "sha256-v8h7NL8aNx1edzmCMQvJZ48rehZp3rzaIXuReF2x0vU=",
         "owner": "pyproject-nix",
         "repo": "uv2nix",
-        "rev": "0772521d8700b5cffb5420d14a085e92527f6fa2",
+        "rev": "8653cbebd61058e6629fc3ff79098775f9797df7",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -38,7 +38,11 @@
     workspace = uv2nix.lib.workspace.loadWorkspace { workspaceRoot = ./.; };
 
     workspace-overlay = workspace.mkPyprojectOverlay {
-      sourcePreference = "wheel"; # or sourcePreference = "sdist";
+      sourcePreference = "wheel";
+    };
+
+    editable-overlay = workspace.mkEditablePyprojectOverlay {
+      root = "$REPO_ROOT";
     };
 
     pyproject-overlay = final: prev: {
@@ -56,6 +60,7 @@
       extensions = pkgs.lib.composeManyExtensions [
         pyproject-build-systems.overlays.default
         workspace-overlay
+        editable-overlay
         pyproject-overlay
       ];
       base-python = pkgs.callPackage pyproject-nix.build.packages {
@@ -82,6 +87,7 @@
         shellHook = ''
           # Undo dependency propagation by nixpkgs.
           unset PYTHONPATH
+          export REPO_ROOT=$(git rev-parse --show-toplevel)
         '';
         packages = [ python-env ] ++ (dev-tools pkgs);
       };


### PR DESCRIPTION
## What kind of change does this PR introduce?

Make the python packages in the nix dev environment locally editable. 

## What is the current behavior?

Currently, the nix setup copies all the python packages to the nix store, which makes them immutable. When locally making changes, it is necessary to reload the environment whenever a change is made, which is not ergonomic.

## What is the new behavior?

We can make it editable by leveraging the `mkEditablePythonOverlay` function from `uv2nix`, which lets you decide on a workspace root to read the packages from. This is done through the `$REPO_ROOT` env var, set by the default environment's `shellHook`, which should always point to the repository root.
