### PR TITLE
feat(storage): mypy storage

### DIFF
--- a/src/storage/Makefile
+++ b/src/storage/Makefile
@@ -1,13 +1,30 @@
+help::
+	@echo "Available commands"
+	@echo "  help           -- (default) print this message"
+
 start-infra:
 	supabase --workdir infra start -x studio,gotrue,postgrest,mailpit,realtime,edge-runtime,logflare,vector,supavisor
+help::
+	@echo "  start-infra    -- start containers for tests"
 
 stop-infra:
 	supabase --workdir infra stop
+help::
+	@echo "  stop-infra     -- stop containers for tests"
 
-tests: pytest
+tests: mypy pytest
+help::
+	@echo "  tests          -- run all tests for storage3"
+
+mypy:
+	uv run --package storage3 mypy src/storage3 tests
+help::
+	@echo "  mypy           -- run mypy on storage3"
 
 pytest: start-infra
 	uv run --package storage3 pytest --cov=./ --cov-report=xml --cov-report=html -vv
+help::
+	@echo "  pytest         -- run pytest on storage3"
 
 build-sync:
 	uv run --package storage3 run-unasync.py
@@ -15,10 +32,16 @@ build-sync:
 	sed -i 's/SyncMock/Mock/g' tests/_sync/test_bucket.py tests/_sync/test_client.py
 	sed -i 's/SyncClient/Client/g' src/storage3/_sync/client.py src/storage3/_sync/bucket.py src/storage3/_sync/file_api.py tests/_sync/test_bucket.py tests/_sync/test_client.py
 	sed -i 's/self\.session\.aclose/self\.session\.close/g' src/storage3/_sync/client.py
+help::
+	@echo "  build-sync     -- generate _sync from _async implementation"
 
 clean:
 	rm -rf htmlcov .pytest_cache .mypy_cache .ruff_cache
 	rm -f .coverage coverage.xml
+help::
+	@echo "  clean          -- clean intermediary files"
 
 build:
 	uv build --package storage3
+help::
+	@echo "  build          -- invoke uv build on storage3 package"

--- a/src/storage/Makefile
+++ b/src/storage/Makefile
@@ -13,8 +13,8 @@ build-sync:
 	uv run --package storage3 run-unasync.py
 	sed -i '0,/SyncMock, /{s/SyncMock, //}' tests/_sync/test_bucket.py tests/_sync/test_client.py
 	sed -i 's/SyncMock/Mock/g' tests/_sync/test_bucket.py tests/_sync/test_client.py
-	sed -i 's/SyncClient/Client/g' storage3/_sync/client.py storage3/_sync/bucket.py storage3/_sync/file_api.py tests/_sync/test_bucket.py tests/_sync/test_client.py
-	sed -i 's/self\.session\.aclose/self\.session\.close/g' storage3/_sync/client.py
+	sed -i 's/SyncClient/Client/g' src/storage3/_sync/client.py src/storage3/_sync/bucket.py src/storage3/_sync/file_api.py tests/_sync/test_bucket.py tests/_sync/test_client.py
+	sed -i 's/self\.session\.aclose/self\.session\.close/g' src/storage3/_sync/client.py
 
 clean:
 	rm -rf htmlcov .pytest_cache .mypy_cache .ruff_cache

--- a/src/storage/pyproject.toml
+++ b/src/storage/pyproject.toml
@@ -36,7 +36,10 @@ repository = "https://github.com/supabase/supabase-py"
 lints = [
   "pre-commit >=4.2.0",
   "ruff >=0.12.1",
-  "unasync >= 0.6.0"
+  "unasync >= 0.6.0",
+  "python-lsp-server (>=1.12.2,<2.0.0)",
+  "pylsp-mypy (>=0.7.0,<0.8.0)",
+  "python-lsp-ruff (>=2.2.2,<3.0.0)",
 ]
 docs = [
   "Sphinx >=7.1.2",
@@ -52,7 +55,6 @@ tests = [
 dev = [
   { include-group = "lints" },
   { include-group = "tests" },
-  { include-group = "lints" },
   { include-group = "docs" },
 ]
 
@@ -84,6 +86,10 @@ addopts = "tests"
 filterwarnings = [
     "ignore::DeprecationWarning", # ignore deprecation warnings globally
 ]
+
+[tool.mypy]
+follow_untyped_imports = true # for deprecation module that does not have stubs
+allow_redefinition = true
 
 [tool.uv]
 default-groups = [ "dev" ]

--- a/src/storage/run-unasync.py
+++ b/src/storage/run-unasync.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import unasync
 
-paths = Path("src/functions").glob("**/*.py")
+paths = Path("src/storage3").glob("**/*.py")
 tests = Path("tests").glob("**/*.py")
 
 rules = (unasync._DEFAULT_RULE,)

--- a/src/storage/src/storage3/_async/file_api.py
+++ b/src/storage/src/storage3/_async/file_api.py
@@ -210,7 +210,10 @@ class AsyncBucketActionsMixin:
         options
             options to be passed for downloading the file.
         """
-        json: dict[str, str | bool | None | list[str]] = {"paths": paths, "expiresIn": str(expires_in)}
+        json: dict[str, str | bool | None | list[str]] = {
+            "paths": paths,
+            "expiresIn": str(expires_in),
+        }
         download_query = ""
         if options.get("download"):
             json.update({"download": options.get("download")})
@@ -266,9 +269,7 @@ class AsyncBucketActionsMixin:
 
         render_path = "render/image" if options.get("transform") else "object"
         transformation_query = (
-            urllib.parse.urlencode(t)
-            if (t := options.get("transform"))
-            else None
+            urllib.parse.urlencode(t) if (t := options.get("transform")) else None
         )
 
         if transformation_query:

--- a/src/storage/src/storage3/_async/file_api.py
+++ b/src/storage/src/storage3/_async/file_api.py
@@ -323,7 +323,7 @@ class AsyncBucketActionsMixin:
         )
         return res.json()
 
-    async def remove(self, paths: list[Any]) -> list[dict[str, Any]]:
+    async def remove(self, paths: list[str]) -> list[dict[str, Any]]:
         """
         Deletes files within the same bucket
 
@@ -342,7 +342,7 @@ class AsyncBucketActionsMixin:
     async def info(
         self,
         path: str,
-    ) -> list[dict[str, str]]:
+    ) -> dict[str, Any]:
         """
         Lists info for a particular file.
 
@@ -382,7 +382,7 @@ class AsyncBucketActionsMixin:
         self,
         path: Optional[str] = None,
         options: Optional[ListBucketFilesOptions] = None,
-    ) -> list[dict[str, str]]:
+    ) -> list[dict[str, Any]]:
         """
         Lists all the files within a bucket.
 

--- a/src/storage/src/storage3/_async/file_api.py
+++ b/src/storage/src/storage3/_async/file_api.py
@@ -22,6 +22,7 @@ from ..types import (
     RequestMethod,
     SignedUploadURL,
     SignedUrlResponse,
+    TransformOptions,
     UploadData,
     UploadResponse,
     URLOptions,
@@ -165,7 +166,7 @@ class AsyncBucketActionsMixin:
         options
             options to be passed for downloading or transforming the file.
         """
-        json = {"expiresIn": str(expires_in)}
+        json: dict[str, str | bool | TransformOptions] = {"expiresIn": str(expires_in)}
         download_query = ""
         if options.get("download"):
             json.update({"download": options["download"]})
@@ -209,7 +210,7 @@ class AsyncBucketActionsMixin:
         options
             options to be passed for downloading the file.
         """
-        json = {"paths": paths, "expiresIn": str(expires_in)}
+        json: dict[str, str | bool | None | list[str]] = {"paths": paths, "expiresIn": str(expires_in)}
         download_query = ""
         if options.get("download"):
             json.update({"download": options.get("download")})
@@ -265,8 +266,8 @@ class AsyncBucketActionsMixin:
 
         render_path = "render/image" if options.get("transform") else "object"
         transformation_query = (
-            urllib.parse.urlencode(options.get("transform"))
-            if options.get("transform")
+            urllib.parse.urlencode(t)
+            if (t := options.get("transform"))
             else None
         )
 
@@ -322,7 +323,7 @@ class AsyncBucketActionsMixin:
         )
         return res.json()
 
-    async def remove(self, paths: list) -> list[dict[str, Any]]:
+    async def remove(self, paths: list[Any]) -> list[dict[str, Any]]:
         """
         Deletes files within the same bucket
 

--- a/src/storage/src/storage3/_sync/file_api.py
+++ b/src/storage/src/storage3/_sync/file_api.py
@@ -323,7 +323,7 @@ class SyncBucketActionsMixin:
         )
         return res.json()
 
-    def remove(self, paths: list[Any]) -> list[dict[str, Any]]:
+    def remove(self, paths: list[str]) -> list[dict[str, Any]]:
         """
         Deletes files within the same bucket
 
@@ -342,7 +342,7 @@ class SyncBucketActionsMixin:
     def info(
         self,
         path: str,
-    ) -> list[dict[str, str]]:
+    ) -> dict[str, Any]:
         """
         Lists info for a particular file.
 
@@ -382,7 +382,7 @@ class SyncBucketActionsMixin:
         self,
         path: Optional[str] = None,
         options: Optional[ListBucketFilesOptions] = None,
-    ) -> list[dict[str, str]]:
+    ) -> list[dict[str, Any]]:
         """
         Lists all the files within a bucket.
 

--- a/src/storage/src/storage3/_sync/file_api.py
+++ b/src/storage/src/storage3/_sync/file_api.py
@@ -22,6 +22,7 @@ from ..types import (
     RequestMethod,
     SignedUploadURL,
     SignedUrlResponse,
+    TransformOptions,
     UploadData,
     UploadResponse,
     URLOptions,
@@ -165,7 +166,7 @@ class SyncBucketActionsMixin:
         options
             options to be passed for downloading or transforming the file.
         """
-        json = {"expiresIn": str(expires_in)}
+        json: dict[str, str | bool | TransformOptions] = {"expiresIn": str(expires_in)}
         download_query = ""
         if options.get("download"):
             json.update({"download": options["download"]})
@@ -209,7 +210,7 @@ class SyncBucketActionsMixin:
         options
             options to be passed for downloading the file.
         """
-        json = {"paths": paths, "expiresIn": str(expires_in)}
+        json: dict[str, str | bool | None | list[str]] = {"paths": paths, "expiresIn": str(expires_in)}
         download_query = ""
         if options.get("download"):
             json.update({"download": options.get("download")})
@@ -265,8 +266,8 @@ class SyncBucketActionsMixin:
 
         render_path = "render/image" if options.get("transform") else "object"
         transformation_query = (
-            urllib.parse.urlencode(options.get("transform"))
-            if options.get("transform")
+            urllib.parse.urlencode(t)
+            if (t := options.get("transform"))
             else None
         )
 
@@ -322,7 +323,7 @@ class SyncBucketActionsMixin:
         )
         return res.json()
 
-    def remove(self, paths: list) -> list[dict[str, Any]]:
+    def remove(self, paths: list[Any]) -> list[dict[str, Any]]:
         """
         Deletes files within the same bucket
 

--- a/src/storage/src/storage3/_sync/file_api.py
+++ b/src/storage/src/storage3/_sync/file_api.py
@@ -210,7 +210,10 @@ class SyncBucketActionsMixin:
         options
             options to be passed for downloading the file.
         """
-        json: dict[str, str | bool | None | list[str]] = {"paths": paths, "expiresIn": str(expires_in)}
+        json: dict[str, str | bool | None | list[str]] = {
+            "paths": paths,
+            "expiresIn": str(expires_in),
+        }
         download_query = ""
         if options.get("download"):
             json.update({"download": options.get("download")})
@@ -266,9 +269,7 @@ class SyncBucketActionsMixin:
 
         render_path = "render/image" if options.get("transform") else "object"
         transformation_query = (
-            urllib.parse.urlencode(t)
-            if (t := options.get("transform"))
-            else None
+            urllib.parse.urlencode(t) if (t := options.get("transform")) else None
         )
 
         if transformation_query:

--- a/src/storage/src/storage3/exceptions.py
+++ b/src/storage/src/storage3/exceptions.py
@@ -6,6 +6,7 @@ from .utils import StorageException
 class StorageApiErrorDict(TypedDict):
     name: str
     message: str
+    code: str
     status: int
 
 

--- a/src/storage/tests/_async/test_client.py
+++ b/src/storage/tests/_async/test_client.py
@@ -56,8 +56,11 @@ async def delete_left_buckets(
 
     request.addfinalizer(AsyncFinalizerFactory(afinalizer).finalizer)
 
+
 @pytest.fixture
-async def bucket(storage: AsyncStorageClient, uuid_factory: Callable[[], str]) -> AsyncGenerator[str]:
+async def bucket(
+    storage: AsyncStorageClient, uuid_factory: Callable[[], str]
+) -> AsyncGenerator[str]:
     """Creates a test bucket which will be used in the whole storage tests run and deleted at the end"""
     bucket_id = uuid_factory()
 
@@ -97,7 +100,9 @@ async def public_bucket(
 
 
 @pytest.fixture
-def storage_file_client(storage: AsyncStorageClient, bucket: str) -> Generator[AsyncBucketProxy]:
+def storage_file_client(
+    storage: AsyncStorageClient, bucket: str
+) -> Generator[AsyncBucketProxy]:
     """Creates the storage file client for the whole storage tests run"""
     yield storage.from_(bucket)
 

--- a/src/storage/tests/_sync/conftest.py
+++ b/src/storage/tests/_sync/conftest.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import os
-from collections.abc import Generator, Generator
+from collections.abc import Generator
 
 import pytest
 from dotenv import load_dotenv

--- a/src/storage/tests/_sync/conftest.py
+++ b/src/storage/tests/_sync/conftest.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import os
-from collections.abc import Generator
+from collections.abc import Generator, Generator
 
 import pytest
 from dotenv import load_dotenv
@@ -14,18 +14,7 @@ def pytest_configure(config) -> None:
     load_dotenv(dotenv_path="tests/tests.env")
 
 
-@pytest.fixture(scope="package")
-def event_loop() -> Generator[asyncio.AbstractEventLoop]:
-    """Returns an event loop for the current thread"""
-    try:
-        loop = asyncio.get_running_loop()
-    except RuntimeError:
-        loop = asyncio.new_event_loop()
-    yield loop
-    loop.close()
-
-
-@pytest.fixture(scope="package")
+@pytest.fixture
 def storage() -> Generator[SyncStorageClient]:
     url = os.environ.get("SUPABASE_TEST_URL")
     assert url is not None, "Must provide SUPABASE_TEST_URL environment variable"

--- a/src/storage/tests/_sync/test_client.py
+++ b/src/storage/tests/_sync/test_client.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Generator, Generator
+from collections.abc import Generator
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from unittest.mock import Mock, patch
@@ -56,8 +56,11 @@ def delete_left_buckets(
 
     request.addfinalizer(SyncFinalizerFactory(afinalizer).finalizer)
 
+
 @pytest.fixture
-def bucket(storage: SyncStorageClient, uuid_factory: Callable[[], str]) -> Generator[str]:
+def bucket(
+    storage: SyncStorageClient, uuid_factory: Callable[[], str]
+) -> Generator[str]:
     """Creates a test bucket which will be used in the whole storage tests run and deleted at the end"""
     bucket_id = uuid_factory()
 
@@ -97,7 +100,9 @@ def public_bucket(
 
 
 @pytest.fixture
-def storage_file_client(storage: SyncStorageClient, bucket: str) -> Generator[SyncBucketProxy]:
+def storage_file_client(
+    storage: SyncStorageClient, bucket: str
+) -> Generator[SyncBucketProxy]:
     """Creates the storage file client for the whole storage tests run"""
     yield storage.from_(bucket)
 
@@ -349,9 +354,7 @@ def test_client_upload_to_signed_url(
     assert image == file.file_content
 
     # Test with cache-control
-    data = storage_file_client.create_signed_upload_url(
-        f"cached_{file.bucket_path}"
-    )
+    data = storage_file_client.create_signed_upload_url(f"cached_{file.bucket_path}")
     storage_file_client.upload_to_signed_url(
         data["path"], data["token"], file.file_content, {"cache-control": "3600"}
     )

--- a/src/storage/tests/_sync/test_client.py
+++ b/src/storage/tests/_sync/test_client.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 temp_test_buckets_ids = []
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def uuid_factory() -> Callable[[], str]:
     def method() -> str:
         """Generate a 8 digits long UUID"""
@@ -34,7 +34,7 @@ def uuid_factory() -> Callable[[], str]:
     return method
 
 
-@pytest.fixture(scope="module", autouse=True)
+@pytest.fixture
 def delete_left_buckets(
     request: pytest.FixtureRequest,
     storage: SyncStorageClient,
@@ -62,7 +62,7 @@ def bucket_factory(
     """Creates a test bucket which will be used in the whole storage tests run and deleted at the end"""
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def bucket(storage: SyncStorageClient, uuid_factory: Callable[[], str]) -> str:
     """Creates a test bucket which will be used in the whole storage tests run and deleted at the end"""
     bucket_id = uuid_factory()
@@ -81,8 +81,10 @@ def bucket(storage: SyncStorageClient, uuid_factory: Callable[[], str]) -> str:
     temp_test_buckets_ids.remove(bucket_id)
 
 
-@pytest.fixture(scope="module")
-def public_bucket(storage: SyncStorageClient, uuid_factory: Callable[[], str]) -> str:
+@pytest.fixture
+def public_bucket(
+    storage: SyncStorageClient, uuid_factory: Callable[[], str]
+) -> str:
     """Creates a test public bucket which will be used in the whole storage tests run and deleted at the end"""
     bucket_id = uuid_factory()
 
@@ -100,13 +102,13 @@ def public_bucket(storage: SyncStorageClient, uuid_factory: Callable[[], str]) -
     temp_test_buckets_ids.remove(bucket_id)
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def storage_file_client(storage: SyncStorageClient, bucket: str) -> SyncBucketProxy:
     """Creates the storage file client for the whole storage tests run"""
     yield storage.from_(bucket)
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def storage_file_client_public(
     storage: SyncStorageClient, public_bucket: str
 ) -> SyncBucketProxy:
@@ -350,7 +352,9 @@ def test_client_upload_to_signed_url(
     assert image == file.file_content
 
     # Test with cache-control
-    data = storage_file_client.create_signed_upload_url(f"cached_{file.bucket_path}")
+    data = storage_file_client.create_signed_upload_url(
+        f"cached_{file.bucket_path}"
+    )
     storage_file_client.upload_to_signed_url(
         data["path"], data["token"], file.file_content, {"cache-control": "3600"}
     )

--- a/src/storage/tests/_sync/test_client.py
+++ b/src/storage/tests/_sync/test_client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Generator, Generator
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from unittest.mock import Mock, patch
@@ -22,7 +23,7 @@ if TYPE_CHECKING:
 
 
 # Global variable to track the ids from the buckets created in the tests run
-temp_test_buckets_ids = []
+temp_test_buckets_ids: list[str] = []
 
 
 @pytest.fixture
@@ -55,15 +56,8 @@ def delete_left_buckets(
 
     request.addfinalizer(SyncFinalizerFactory(afinalizer).finalizer)
 
-
-def bucket_factory(
-    storage: SyncStorageClient, uuid_factory: Callable[[], str], public: bool
-) -> str:
-    """Creates a test bucket which will be used in the whole storage tests run and deleted at the end"""
-
-
 @pytest.fixture
-def bucket(storage: SyncStorageClient, uuid_factory: Callable[[], str]) -> str:
+def bucket(storage: SyncStorageClient, uuid_factory: Callable[[], str]) -> Generator[str]:
     """Creates a test bucket which will be used in the whole storage tests run and deleted at the end"""
     bucket_id = uuid_factory()
 
@@ -84,7 +78,7 @@ def bucket(storage: SyncStorageClient, uuid_factory: Callable[[], str]) -> str:
 @pytest.fixture
 def public_bucket(
     storage: SyncStorageClient, uuid_factory: Callable[[], str]
-) -> str:
+) -> Generator[str]:
     """Creates a test public bucket which will be used in the whole storage tests run and deleted at the end"""
     bucket_id = uuid_factory()
 
@@ -103,7 +97,7 @@ def public_bucket(
 
 
 @pytest.fixture
-def storage_file_client(storage: SyncStorageClient, bucket: str) -> SyncBucketProxy:
+def storage_file_client(storage: SyncStorageClient, bucket: str) -> Generator[SyncBucketProxy]:
     """Creates the storage file client for the whole storage tests run"""
     yield storage.from_(bucket)
 
@@ -111,7 +105,7 @@ def storage_file_client(storage: SyncStorageClient, bucket: str) -> SyncBucketPr
 @pytest.fixture
 def storage_file_client_public(
     storage: SyncStorageClient, public_bucket: str
-) -> SyncBucketProxy:
+) -> Generator[SyncBucketProxy]:
     """Creates the storage file client for the whole storage tests run"""
     yield storage.from_(public_bucket)
 
@@ -281,6 +275,7 @@ def test_client_upload(
     image_info = next((f for f in files if f.get("name") == file.name), None)
 
     assert image == file.file_content
+    assert image_info is not None
     assert image_info.get("metadata", {}).get("mimetype") == file.mime_type
 
 
@@ -308,6 +303,7 @@ def test_client_update(
     )
 
     assert image == two_files[1].file_content
+    assert image_info is not None
     assert image_info.get("metadata", {}).get("mimetype") == two_files[1].mime_type
 
 
@@ -339,6 +335,7 @@ def test_client_upload_to_signed_url(
     image_info = next((f for f in files if f.get("name") == file.name), None)
 
     assert image == file.file_content
+    assert image_info is not None
     assert image_info.get("metadata", {}).get("mimetype") == file.mime_type
 
     # Test with file_options=None
@@ -586,6 +583,7 @@ def test_client_copy(
     copied_info = next(
         (f for f in files if f.get("name") == f"copied_{file.name}"), None
     )
+    assert copied_info is not None
     assert copied_info.get("metadata", {}).get("mimetype") == file.mime_type
 
 
@@ -612,6 +610,7 @@ def test_client_move(
     # Verify metadata was preserved
     files = storage_file_client.list(file.bucket_folder)
     moved_info = next((f for f in files if f.get("name") == f"moved_{file.name}"), None)
+    assert moved_info is not None
     assert moved_info.get("metadata", {}).get("mimetype") == file.mime_type
 
 
@@ -628,7 +627,7 @@ def test_client_remove(
     assert storage_file_client.exists(file.bucket_path)
 
     # Remove file
-    storage_file_client.remove(file.bucket_path)
+    storage_file_client.remove([file.bucket_path])
 
     # Verify file no longer exists
     assert not storage_file_client.exists(file.bucket_path)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -1611,7 +1611,7 @@ wheels = [
 
 [[package]]
 name = "postgrest"
-version = "1.1.1"
+version = "2.19.0"
 source = { editable = "src/postgrest" }
 dependencies = [
     { name = "deprecation" },
@@ -2181,7 +2181,7 @@ wheels = [
 
 [[package]]
 name = "realtime"
-version = "2.7.0"
+version = "2.19.0"
 source = { editable = "src/realtime" }
 dependencies = [
     { name = "pydantic" },
@@ -2761,7 +2761,7 @@ wheels = [
 
 [[package]]
 name = "storage3"
-version = "0.12.1"
+version = "2.19.0"
 source = { editable = "src/storage" }
 dependencies = [
     { name = "deprecation" },
@@ -2772,16 +2772,20 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "pre-commit" },
+    { name = "pylsp-mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "python-dotenv" },
+    { name = "python-lsp-ruff" },
+    { name = "python-lsp-server" },
     { name = "ruff" },
     { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
     { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "sphinx-press-theme" },
     { name = "sphinx-toolbox" },
+    { name = "types-deprecated" },
     { name = "unasync" },
 ]
 docs = [
@@ -2793,7 +2797,11 @@ docs = [
 ]
 lints = [
     { name = "pre-commit" },
+    { name = "pylsp-mypy" },
+    { name = "python-lsp-ruff" },
+    { name = "python-lsp-server" },
     { name = "ruff" },
+    { name = "types-deprecated" },
     { name = "unasync" },
 ]
 tests = [
@@ -2813,14 +2821,18 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "pre-commit", specifier = ">=4.2.0" },
+    { name = "pylsp-mypy", specifier = ">=0.7.0,<0.8.0" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-asyncio", specifier = ">=0.21.0" },
     { name = "pytest-cov", specifier = ">=6.1.0" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
+    { name = "python-lsp-ruff", specifier = ">=2.2.2,<3.0.0" },
+    { name = "python-lsp-server", specifier = ">=1.12.2,<2.0.0" },
     { name = "ruff", specifier = ">=0.12.1" },
     { name = "sphinx", specifier = ">=7.1.2" },
     { name = "sphinx-press-theme", specifier = ">=0.9.1" },
     { name = "sphinx-toolbox", specifier = ">=3.4.0" },
+    { name = "types-deprecated", specifier = ">=1.2.15" },
     { name = "unasync", specifier = ">=0.6.0" },
 ]
 docs = [
@@ -2830,7 +2842,11 @@ docs = [
 ]
 lints = [
     { name = "pre-commit", specifier = ">=4.2.0" },
+    { name = "pylsp-mypy", specifier = ">=0.7.0,<0.8.0" },
+    { name = "python-lsp-ruff", specifier = ">=2.2.2,<3.0.0" },
+    { name = "python-lsp-server", specifier = ">=1.12.2,<2.0.0" },
     { name = "ruff", specifier = ">=0.12.1" },
+    { name = "types-deprecated", specifier = ">=1.2.15" },
     { name = "unasync", specifier = ">=0.6.0" },
 ]
 tests = [
@@ -2851,7 +2867,7 @@ wheels = [
 
 [[package]]
 name = "supabase"
-version = "2.18.1"
+version = "2.19.0"
 source = { editable = "src/supabase" }
 dependencies = [
     { name = "httpx" },
@@ -2924,7 +2940,7 @@ tests = [
 
 [[package]]
 name = "supabase-auth"
-version = "2.12.3"
+version = "2.19.0"
 source = { editable = "src/auth" }
 dependencies = [
     { name = "httpx", extra = ["http2"] },
@@ -2993,7 +3009,7 @@ tests = [
 
 [[package]]
 name = "supabase-functions"
-version = "0.10.1"
+version = "2.19.0"
 source = { editable = "src/functions" }
 dependencies = [
     { name = "httpx", extra = ["http2"] },
@@ -3004,14 +3020,20 @@ dependencies = [
 dev = [
     { name = "pre-commit" },
     { name = "pyjwt" },
+    { name = "pylsp-mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "python-lsp-ruff" },
+    { name = "python-lsp-server" },
     { name = "ruff" },
     { name = "unasync" },
 ]
 lints = [
     { name = "pre-commit" },
+    { name = "pylsp-mypy" },
+    { name = "python-lsp-ruff" },
+    { name = "python-lsp-server" },
     { name = "ruff" },
     { name = "unasync" },
 ]
@@ -3032,14 +3054,20 @@ requires-dist = [
 dev = [
     { name = "pre-commit", specifier = ">=3.4,<5.0" },
     { name = "pyjwt", specifier = ">=2.8.0" },
+    { name = "pylsp-mypy", specifier = ">=0.7.0,<0.8.0" },
     { name = "pytest", specifier = ">=7.4.2,<9.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.21.1,<1.2.0" },
     { name = "pytest-cov", specifier = ">=4,<7" },
+    { name = "python-lsp-ruff", specifier = ">=2.2.2,<3.0.0" },
+    { name = "python-lsp-server", specifier = ">=1.12.2,<2.0.0" },
     { name = "ruff", specifier = ">=0.12.1" },
     { name = "unasync", specifier = ">=0.6.0" },
 ]
 lints = [
     { name = "pre-commit", specifier = ">=3.4,<5.0" },
+    { name = "pylsp-mypy", specifier = ">=0.7.0,<0.8.0" },
+    { name = "python-lsp-ruff", specifier = ">=2.2.2,<3.0.0" },
+    { name = "python-lsp-server", specifier = ">=1.12.2,<2.0.0" },
     { name = "ruff", specifier = ">=0.12.1" },
     { name = "unasync", specifier = ">=0.6.0" },
 ]
@@ -3123,6 +3151,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cc/18/0bbf3884e9eaa38819ebe46a7bd25dcd56b67434402b66a58c4b8e552575/tomlkit-0.13.3.tar.gz", hash = "sha256:430cf247ee57df2b94ee3fbe588e71d362a941ebb545dec29b53961d61add2a1", size = 185207, upload-time = "2025-06-05T07:13:44.947Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/75/8539d011f6be8e29f339c42e633aae3cb73bffa95dd0f9adec09b9c58e85/tomlkit-0.13.3-py3-none-any.whl", hash = "sha256:c89c649d79ee40629a9fda55f8ace8c6a1b42deb912b2a8fd8d942ddadb606b0", size = 38901, upload-time = "2025-06-05T07:13:43.546Z" },
+]
+
+[[package]]
+name = "types-deprecated"
+version = "1.2.15.20250304"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0e/67/eeefaaabb03b288aad85483d410452c8bbcbf8b2bd876b0e467ebd97415b/types_deprecated-1.2.15.20250304.tar.gz", hash = "sha256:c329030553029de5cc6cb30f269c11f4e00e598c4241290179f63cda7d33f719", size = 8015, upload-time = "2025-03-04T02:48:17.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/e3/c18aa72ab84e0bc127a3a94e93be1a6ac2cb281371d3a45376ab7cfdd31c/types_deprecated-1.2.15.20250304-py3-none-any.whl", hash = "sha256:86a65aa550ea8acf49f27e226b8953288cd851de887970fbbdf2239c116c3107", size = 8553, upload-time = "2025-03-04T02:48:16.666Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix type definitions in storage.

## What is the current behavior?

`mypy` throws errors in both `src/storage` and `tests`.

## What is the new behavior?

`mypy` passes for both. Also took the opportunity to improve `make` default message for `storage`.
