### PR TITLE
chore(ci): fix release please, run publish when new release is created

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
     needs: test
     if: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' && github.repository_owner == 'supabase' }}
     runs-on: ubuntu-latest
-    name: "Bump version and create changelog"
+    name: "Run release-please"
     permissions:
       id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
       contents: write # needed for github actions bot to write to repo


### PR DESCRIPTION
## What kind of change does this PR introduce?

Ensure that `make publish` when a new release PR is merged. Obsoletes #1220.

## What is the current behavior?

Uses regex to match the PR title to release a new version.

## What is the new behavior?

Use `release-please.outputs.release_created` to publish new version.

## Additional context
