### PR TITLE
feat(realtime): add presence enabled flag on join payload

### DIFF
--- a/src/realtime/src/realtime/_async/channel.py
+++ b/src/realtime/src/realtime/_async/channel.py
@@ -191,12 +191,16 @@ class AsyncRealtimeChannel:
         else:
             config: RealtimeChannelConfig = self.params["config"]
             broadcast = config.get("broadcast")
-            presence = config.get("presence") or RealtimeChannelPresenceConfig(key="",enabled=False)
+            presence = config.get("presence") or RealtimeChannelPresenceConfig(
+                key="", enabled=False
+            )
             private = config.get("private", False)
 
-            presence_enabled = self.presence._has_callback_attached or presence.get("enabled", False)
+            presence_enabled = self.presence._has_callback_attached or presence.get(
+                "enabled", False
+            )
             presence["enabled"] = presence_enabled
-            
+
             config_payload: Dict[str, Any] = {
                 "config": {
                     "broadcast": broadcast,
@@ -434,7 +438,9 @@ class AsyncRealtimeChannel:
         self.presence.on_sync(callback)
 
         if self.is_joined:
-            logger.info(f"channel {self.topic} resubscribe due to change in presence callbacks on joined channel")
+            logger.info(
+                f"channel {self.topic} resubscribe due to change in presence callbacks on joined channel"
+            )
             asyncio.create_task(self._resubscribe())
 
         return self
@@ -450,7 +456,9 @@ class AsyncRealtimeChannel:
         """
         self.presence.on_join(callback)
         if self.is_joined:
-            logger.info(f"channel {self.topic} resubscribe due to change in presence callbacks on joined channel")
+            logger.info(
+                f"channel {self.topic} resubscribe due to change in presence callbacks on joined channel"
+            )
             asyncio.create_task(self._resubscribe())
 
         return self
@@ -466,7 +474,9 @@ class AsyncRealtimeChannel:
         """
         self.presence.on_leave(callback)
         if self.is_joined:
-            logger.info(f"channel {self.topic} resubscribe due to change in presence callbacks on joined channel")
+            logger.info(
+                f"channel {self.topic} resubscribe due to change in presence callbacks on joined channel"
+            )
             asyncio.create_task(self._resubscribe())
         return self
 

--- a/src/realtime/src/realtime/_async/channel.py
+++ b/src/realtime/src/realtime/_async/channel.py
@@ -85,7 +85,7 @@ class AsyncRealtimeChannel:
             else {
                 "config": {
                     "broadcast": {"ack": False, "self": False},
-                    "presence": {"key": ""},
+                    "presence": {"key": "", "enabled": False},
                     "private": False,
                 }
             }
@@ -191,9 +191,12 @@ class AsyncRealtimeChannel:
         else:
             config: RealtimeChannelConfig = self.params["config"]
             broadcast = config.get("broadcast")
-            presence = config.get("presence")
+            presence = config.get("presence") or RealtimeChannelPresenceConfig(key="",enabled=False)
             private = config.get("private", False)
 
+            presence_enabled = self.presence._has_callback_attached or presence.get("enabled", False)
+            presence["enabled"] = presence_enabled
+            
             config_payload: Dict[str, Any] = {
                 "config": {
                     "broadcast": broadcast,
@@ -429,6 +432,11 @@ class AsyncRealtimeChannel:
         :return: The Channel instance for method chaining.
         """
         self.presence.on_sync(callback)
+
+        if self.is_joined:
+            logger.info(f"channel {self.topic} resubscribe due to change in presence callbacks on joined channel")
+            asyncio.create_task(self._resubscribe())
+
         return self
 
     def on_presence_join(
@@ -441,6 +449,10 @@ class AsyncRealtimeChannel:
         :return: The Channel instance for method chaining.
         """
         self.presence.on_join(callback)
+        if self.is_joined:
+            logger.info(f"channel {self.topic} resubscribe due to change in presence callbacks on joined channel")
+            asyncio.create_task(self._resubscribe())
+
         return self
 
     def on_presence_leave(
@@ -453,6 +465,9 @@ class AsyncRealtimeChannel:
         :return: The Channel instance for method chaining.
         """
         self.presence.on_leave(callback)
+        if self.is_joined:
+            logger.info(f"channel {self.topic} resubscribe due to change in presence callbacks on joined channel")
+            asyncio.create_task(self._resubscribe())
         return self
 
     # Broadcast methods
@@ -469,6 +484,11 @@ class AsyncRealtimeChannel:
         )
 
     # Internal methods
+
+    async def _resubscribe(self) -> None:
+        await self.unsubscribe()
+        await self.subscribe()
+
     def _broadcast_endpoint_url(self):
         return f"{http_endpoint_url(self.socket.http_endpoint)}/api/broadcast"
 

--- a/src/realtime/src/realtime/_async/presence.py
+++ b/src/realtime/src/realtime/_async/presence.py
@@ -21,6 +21,16 @@ logger = logging.getLogger(__name__)
 
 
 class AsyncRealtimePresence:
+
+
+    @property
+    def _has_callback_attached(self) -> bool:
+        return (
+            self.on_join_callback is not None
+            or self.on_leave_callback is not None
+            or self.on_sync_callback is not None
+        )
+
     def __init__(self):
         self.state: RealtimePresenceState = {}
         self.on_join_callback: Optional[PresenceOnJoinCallback] = None

--- a/src/realtime/src/realtime/_async/presence.py
+++ b/src/realtime/src/realtime/_async/presence.py
@@ -21,8 +21,6 @@ logger = logging.getLogger(__name__)
 
 
 class AsyncRealtimePresence:
-
-
     @property
     def _has_callback_attached(self) -> bool:
         return (

--- a/src/realtime/src/realtime/types.py
+++ b/src/realtime/src/realtime/types.py
@@ -179,6 +179,7 @@ class RealtimeChannelBroadcastConfig(TypedDict):
 
 class RealtimeChannelPresenceConfig(TypedDict):
     key: str
+    enabled: bool
 
 
 class RealtimeChannelConfig(TypedDict):

--- a/src/realtime/tests/test_presence.py
+++ b/src/realtime/tests/test_presence.py
@@ -202,18 +202,12 @@ def test_presence_config_includes_enabled_field():
     from realtime.types import RealtimeChannelPresenceConfig
 
     # Test creating presence config with enabled field
-    config: RealtimeChannelPresenceConfig = {
-        "key": "user123",
-        "enabled": True
-    }
+    config: RealtimeChannelPresenceConfig = {"key": "user123", "enabled": True}
     assert config["key"] == "user123"
     assert config["enabled"] == True
 
     # Test with enabled False
-    config_disabled: RealtimeChannelPresenceConfig = {
-        "key": "",
-        "enabled": False
-    }
+    config_disabled: RealtimeChannelPresenceConfig = {"key": "", "enabled": False}
     assert config_disabled["key"] == ""
     assert config_disabled["enabled"] == False
 
@@ -221,7 +215,7 @@ def test_presence_config_includes_enabled_field():
 @pytest.mark.asyncio
 async def test_presence_enabled_when_callbacks_attached():
     """Test that presence.enabled is set correctly based on callback attachment."""
-    from unittest.mock import Mock, AsyncMock
+    from unittest.mock import AsyncMock, Mock
 
     socket = AsyncRealtimeClient(f"{URL}/realtime/v1", ANON_KEY)
     channel = socket.channel("test")
@@ -257,8 +251,8 @@ async def test_presence_enabled_when_callbacks_attached():
 @pytest.mark.asyncio
 async def test_resubscribe_on_presence_callback_addition():
     """Test that channel resubscribes when presence callbacks are added after joining."""
-    from unittest.mock import AsyncMock
     import asyncio
+    from unittest.mock import AsyncMock
 
     socket = AsyncRealtimeClient(f"{URL}/realtime/v1", ANON_KEY)
     channel = socket.channel("test")

--- a/src/realtime/tests/test_presence.py
+++ b/src/realtime/tests/test_presence.py
@@ -233,8 +233,9 @@ async def test_presence_enabled_when_callbacks_attached():
     mock_join_push.resend = AsyncMock()
     channel.join_push = mock_join_push
 
-    # Mock socket connection
-    socket.is_connected = True
+    # Mock socket connection by setting _ws_connection
+    mock_ws = Mock()
+    socket._ws_connection = mock_ws
     socket._leave_open_topic = AsyncMock()
 
     # Add presence callback before subscription


### PR DESCRIPTION
## Summary
- Add `enabled` field to `RealtimeChannelPresenceConfig` type definition
- Add `_has_callback_attached` property to `AsyncRealtimePresence` class to detect if any presence callbacks are registered
- Modify channel subscription logic to automatically set `presence.enabled=true` when presence callbacks are attached or manually configured
- Add automatic resubscription functionality when presence callbacks are added to an already joined channel

## Test plan
- [x] Add unit tests for `_has_callback_attached` property
- [x] Add tests for presence config type validation with `enabled` field
- [x] Add integration tests for automatic `presence.enabled` flag setting
- [x] Add tests for automatic resubscription behavior when callbacks are added post-join
- [x] Verify all existing presence functionality continues to work as expected

🤖 Generated with [Claude Code](https://claude.ai/code)