### PR TITLE
docs: add quick usage example to README and fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,22 @@
 
 Python monorepo for all [Supabase](https://supabase.com) libraries.
 
-- [supabase](src/supabase/README.md)
-- [realtime-py](src/realtime/README.md)
-- [supabase_functions](src/functions/README.md)
-- [storage3](src/storage/README.md)
-- [postgrest](src/postgrest/README.md)
-- [supabase_auth](src/auth/README.md)
+---
+
+## 🚀 Quick Usage Example
+
+Here’s a simple example of how to connect to Supabase and fetch data with `supabase-py`:
+
+````python
+from supabase import create_client, Client
+
+url: str = "https://your-project.supabase.co"
+key: str = "your-anon-key"
+supabase: Client = create_client(url, key)
+
+# Example: fetch all rows from "countries" table
+response = supabase.table("countries").select("*").execute()
+print(response.data)
 
 Relevant links:
 
@@ -27,12 +37,13 @@ Relevant links:
 ```bash
 git clone https://github.com/supabase/supabase-py.git
 cd supabase-py
-```
+````
 
 ### Dependencies
 
-This repository relies on the following dependencies for development: 
-- `uv` for python project management.
+This repository relies on the following dependencies for development:
+
+- `uv` for Python project management (a fast modern replacement for pip/venv).
 - `make` for command running.
 - `docker` for both `postgrest` and `auth` test containers.
 - `supabase-cli` for both `storage` and `realtime` test containers.
@@ -56,24 +67,31 @@ If you're using nix, the generated `python` executable should have the correct d
 We use `make` to store and run the relevant commands. The structure is setup such that each sub package can individually set its command in its own `Makefile`, and the job of the main `Makefile` is just coordinate calling each of them.
 
 For instance, in order to run all tests of all packages, you should use the following root command
+
 ```bash
 make ci
 ```
+
 Which internally dispatches `make -C src/{package} tests` calls to each package in the monorepo.
 
 You should also consider using
+
 ```bash
 make ci -jN # where N is the number of max concurrent jobs, or just -j for infinite jobs
 ```
+
 To run each of the packages' tests in parallel. This should be generally faster than running in 1 job, but has the downside of messing up the CLI output, so parsing error messages might not be easy.
 
 Other relevant commands include
+
 ```bash
-make pre-commit # run lints and formmating before commiting
+make pre-commit # run lints and formatting before committing
 make stop-infra # stops all running containers from all packages
 make clean      # delete all intermediary files created by testing
 ```
+
 All the sub packages command are available from the main root by prefixing the command with `{package_name}.`. Examples:
+
 ```bash
 make realtime.tests # run only realtime tests
 make storage.clean # delete temporary files only in the storage package


### PR DESCRIPTION
This PR adds a quick usage example in the README so that new users can immediately see how to use supabase-py. and was also able to fix some typo in the README file 