### PR TITLE
fix(ci): fix ci action to reference output of release-please job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,8 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' && github.repository_owner == 'supabase' }}
     runs-on: ubuntu-latest
     name: "Run release-please"
+    outputs:
+      should_publish: steps.release.outputs.release_created
     permissions:
       id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
       contents: write # needed for github actions bot to write to repo
@@ -80,7 +82,7 @@ jobs:
           manifest-file: .release-please-manifest.json
   publish:
     needs: release-please
-    if: ${{ needs.release-please.outputs.release_created }}
+    if: ${{ needs.release-please.outputs.should_publish }}
     runs-on: ubuntu-latest
     name: "Publish to PyPi"
     environment:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -50,6 +50,15 @@
           "type": "toml",
           "path": "src/storage/pyproject.toml",
           "jsonpath": "$.project.version"
+        },
+        {
+          "type": "generic",
+          "path": "src/realtime/src/realtime/version.py"
+        },
+        {
+          "type": "toml",
+          "path": "src/realtime/pyproject.toml",
+          "jsonpath": "$.project.version"
         }
       ]
     }

--- a/src/realtime/pyproject.toml
+++ b/src/realtime/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "realtime"
-version = "2.20.0" # {x-release-please-version}
+version = "2.21.0" # {x-release-please-version}
 description = ""
 authors = [
     { name = "Joel Lee", email="joel@joellee.org"},


### PR DESCRIPTION
## What kind of change does this PR introduce?

Small fix to publish job to check for the correct path, and to declare the output of release please action as an output of the release-please step. Also forgot to include realtime's path into release-please-config, so adding it too.

## What is the current behavior?

The variable is not declared as an output and thus it does not recognize it and does not publish the version when a new one is published.

## What is the new behavior?

New package versions should be published to pypi when a new release is created on github.