### PR TITLE
fix: evaluate output of release-please correctly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     name: "Run release-please"
     outputs:
-      should_publish: steps.release.outputs.release_created
+      should_publish: ${{ steps.release.outputs.release_created == 'true' }}
     permissions:
       id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
       contents: write # needed for github actions bot to write to repo
@@ -82,7 +82,7 @@ jobs:
           manifest-file: .release-please-manifest.json
   publish:
     needs: release-please
-    if: ${{ needs.release-please.outputs.should_publish }}
+    if: ${{ needs.release-please.outputs.should_publish == 'true' }}
     runs-on: ubuntu-latest
     name: "Publish to PyPi"
     environment:


### PR DESCRIPTION
  ## Summary

  Fixes the release workflow condition that was causing the publish job to run even when no release was created.

  ## Problem

 The original workflow had this configuration:

  ```yaml
  outputs:
    should_publish: steps.release.outputs.release_created

  # Later...
  if: ${{ needs.release-please.outputs.should_publish }}
```

 release_created returns the string "false" (not a boolean). When evaluated in the if condition with ${{ }}, GitHub Actions treats it as a JavaScript expression where any non-empty string is truthy - including the string "false". This caused the publish job to run even when no release was created.

##  Solution

 Updated the workflow to explicitly compare string values:

```yaml
  outputs:
    should_publish: ${{ steps.release.outputs.release_created == 'true' }}

  # Later...
  if: ${{ needs.release-please.outputs.should_publish == 'true' }}
```

  Now the condition correctly evaluates:
  - When no release: "false" == "true" → false → publish job skips 
  - When release created: "true" == "true" → true → publish job runs 

##  Testing

See this repo: https://github.com/mandarini/test-release

**Verified that:**
  - Publish job skips when pushing regular commits to main (only Release PR is created)
  - Publish job runs when merging a Release PR (actual release is created)
