### PR TITLE
fix(storage): reconstruct path back instead of returning a tuple

### DIFF
--- a/src/storage/src/storage3/_async/file_api.py
+++ b/src/storage/src/storage3/_async/file_api.py
@@ -180,7 +180,7 @@ class AsyncBucketActionsMixin:
         )
         data: UploadData = response.json()
 
-        return UploadResponse(path=path, Key=data.get("Key"))
+        return UploadResponse(path=path, Key=data["Key"])
 
     def _make_signed_url(
         self, signed_url: str, download_query: dict[str, str]
@@ -520,7 +520,7 @@ class AsyncBucketActionsMixin:
 
         data: UploadData = response.json()
 
-        return UploadResponse(path=path, Key=data.get("Key"))
+        return UploadResponse(path="/".join(path), Key=data["Key"])
 
     async def upload(
         self,

--- a/src/storage/src/storage3/_sync/file_api.py
+++ b/src/storage/src/storage3/_sync/file_api.py
@@ -180,7 +180,7 @@ class SyncBucketActionsMixin:
         )
         data: UploadData = response.json()
 
-        return UploadResponse(path=path, Key=data.get("Key"))
+        return UploadResponse(path=path, Key=data["Key"])
 
     def _make_signed_url(
         self, signed_url: str, download_query: dict[str, str]
@@ -520,7 +520,7 @@ class SyncBucketActionsMixin:
 
         data: UploadData = response.json()
 
-        return UploadResponse(path=path, Key=data.get("Key"))
+        return UploadResponse(path="/".join(path), Key=data["Key"])
 
     def upload(
         self,

--- a/src/storage/src/storage3/types.py
+++ b/src/storage/src/storage3/types.py
@@ -104,7 +104,7 @@ class UploadResponse:
     full_path: str
     fullPath: str
 
-    def __init__(self, path, Key):
+    def __init__(self, path: str, Key: str):
         self.path = path
         self.full_path = Key
         self.fullPath = Key


### PR DESCRIPTION
## What kind of change does this PR introduce?

Return string instead of tuple inside `_upload_or_update`.`

## Additional context

This happened because `UploadResponse.__init__()` was actually untyped, so mypy treated the arguments as `Any` and did not complain at all. Goes to show the importance of getting rid of Any in the code.
