### PR TITLE
fix(auth): pass ConfigDict into with_config instead of kwargs

### DIFF
--- a/src/auth/src/supabase_auth/types.py
+++ b/src/auth/src/supabase_auth/types.py
@@ -819,7 +819,9 @@ class SignOutOptions(TypedDict):
     scope: NotRequired[SignOutScope]
 
 
-@with_config(extra="allow")
+@with_config(
+    ConfigDict(extra="allow")
+)  # pydantic <2.7.0 with_config does not accept kwargs
 class JWTHeader(TypedDict):
     alg: Literal["RS256", "ES256", "HS256"]
     typ: str
@@ -838,7 +840,9 @@ class RequiredClaims(TypedDict):
     session_id: str
 
 
-@with_config(extra="allow")
+@with_config(
+    ConfigDict(extra="allow")
+)  # pydantic <2.7.0 with_config does not accept kwargs
 class JWTPayload(TypedDict, total=False):
     iss: str
     sub: str
@@ -857,7 +861,9 @@ class ClaimsResponse(TypedDict):
     signature: bytes
 
 
-@with_config(extra="allow")
+@with_config(
+    ConfigDict(extra="allow")
+)  # pydantic <2.7.0 with_config does not accept kwargs
 class JWK(TypedDict, total=False):
     kty: Literal["RSA", "EC", "oct"]
     key_ops: List[str]


### PR DESCRIPTION
## What kind of change does this PR introduce?

`with_config` only accepts kwargs from pydantic 2.7.0 onward, so our code is not compatible with those versions, even though it is advertised on the pydantic.toml. To fix it, we pass in the whole config dict instead. 

Fixes https://github.com/supabase/supabase-py/issues/1291.

## Additional context

We do need a cutoff date to stop supporting old pydantic versions. Not sure how to decide on that though.
