### PR TITLE
chore: add mypy to supabase.tests

### DIFF
--- a/src/supabase/Makefile
+++ b/src/supabase/Makefile
@@ -4,7 +4,7 @@ help::
 	@echo "Available commands"
 	@echo "  help           -- (default) print this message"
 
-tests: pytest
+tests: mypy pytest
 help::
 	@echo "  tests          -- run all tests for supabase package"
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add missing `mypy` rule as part of `supabase.tests`. Should've been done in #1298, but I missed that part about it.