### PR TITLE
fix(auth): provide default storage when none provided in client options

### DIFF
--- a/src/supabase/src/supabase/_async/client.py
+++ b/src/supabase/src/supabase/_async/client.py
@@ -272,11 +272,13 @@ class AsyncClient:
         proxy: Optional[str] = None,
     ) -> AsyncSupabaseAuthClient:
         """Creates a wrapped instance of the GoTrue Client."""
+        # If storage is None (which happens when using base ClientOptions), provide async default
+        storage = client_options.storage if client_options.storage is not None else AsyncMemoryStorage()
         return AsyncSupabaseAuthClient(
             url=auth_url,
             auto_refresh_token=client_options.auto_refresh_token,
             persist_session=client_options.persist_session,
-            storage=client_options.storage,
+            storage=storage,
             headers=client_options.headers,
             flow_type=client_options.flow_type,
             verify=verify,

--- a/src/supabase/src/supabase/_sync/client.py
+++ b/src/supabase/src/supabase/_sync/client.py
@@ -271,11 +271,13 @@ class Client:
         proxy: Optional[str] = None,
     ) -> SyncSupabaseAuthClient:
         """Creates a wrapped instance of the GoTrue Client."""
+        # If storage is None (which happens when using base ClientOptions), provide sync default
+        storage = client_options.storage if client_options.storage is not None else SyncMemoryStorage()
         return SyncSupabaseAuthClient(
             url=auth_url,
             auto_refresh_token=client_options.auto_refresh_token,
             persist_session=client_options.persist_session,
-            storage=client_options.storage,
+            storage=storage,
             headers=client_options.headers,
             flow_type=client_options.flow_type,
             verify=verify,

--- a/src/supabase/src/supabase/lib/client_options.py
+++ b/src/supabase/src/supabase/lib/client_options.py
@@ -39,6 +39,12 @@ class ClientOptions:
     persist_session: bool = True
     """Whether to persist a logged in session to storage."""
 
+    storage: Optional[Union[AsyncSupportedStorage, SyncSupportedStorage]] = None
+    """A storage provider. Used to store the logged in session."""
+
+    httpx_client: Optional[Union[AsyncHttpxClient, SyncHttpxClient]] = None
+    """httpx client instance to be used by the PostgREST, functions, auth and storage clients."""
+
     realtime: Optional[RealtimeClientOptions] = None
     """Options passed to the realtime-py instance"""
 
@@ -88,7 +94,7 @@ class AsyncClientOptions(ClientOptions):
             auto_refresh_token or self.auto_refresh_token
         )
         client_options.persist_session = persist_session or self.persist_session
-        client_options.storage = storage or self.storage
+        client_options.storage = storage or self.storage or AsyncMemoryStorage()
         client_options.realtime = realtime or self.realtime
         client_options.httpx_client = httpx_client or self.httpx_client
         client_options.postgrest_client_timeout = (
@@ -131,7 +137,7 @@ class SyncClientOptions(ClientOptions):
             auto_refresh_token or self.auto_refresh_token
         )
         client_options.persist_session = persist_session or self.persist_session
-        client_options.storage = storage or self.storage
+        client_options.storage = storage or self.storage or SyncMemoryStorage()
         client_options.realtime = realtime or self.realtime
         client_options.httpx_client = httpx_client or self.httpx_client
         client_options.postgrest_client_timeout = (


### PR DESCRIPTION
# Overview
This PR fixes issue #1306 by ensuring that a default storage provider is used when none is explicitly provided in the client options. Previously, the auth client would receive `None` as the storage provider, which could cause issues. Now, the async client uses `AsyncMemoryStorage()` and the sync client uses `SyncMemoryStorage()` as fallbacks.

# Checklist
- [x] Code changes have been made to handle missing storage in client options
- [x] Default storage providers are set appropriately for async and sync clients
- [x] Changes maintain backward compatibility
- [ ] Tests have been added/updated to verify the fix
- [ ] Documentation has been updated (if applicable)

# Proof
The fix ensures that when `client_options.storage` is `None` (which happens when using base `ClientOptions`), the appropriate default memory storage is provided to the auth client. This prevents any potential issues from a missing storage provider while maintaining the existing behavior when a storage provider is explicitly configured.

# Closes
Closes #1306