### PR TITLE
fix(storage): remove v1 from path concatenation

### DIFF
--- a/src/storage/src/storage3/_async/client.py
+++ b/src/storage/src/storage3/_async/client.py
@@ -86,7 +86,7 @@ class AsyncStorageClient(AsyncStorageBucketAPI):
 
     def vectors(self) -> AsyncStorageVectorsClient:
         return AsyncStorageVectorsClient(
-            url=self._base_url.joinpath("v1", "vector"),
+            url=self._base_url.joinpath("vector"),
             headers=self._headers,
             session=self.session,
         )
@@ -95,6 +95,6 @@ class AsyncStorageClient(AsyncStorageBucketAPI):
         request = AsyncRequestBuilder(
             session=self.session,
             headers=self._headers,
-            base_url=self._base_url.joinpath("v1", "iceberg"),
+            base_url=self._base_url.joinpath("iceberg"),
         )
         return AsyncStorageAnalyticsClient(request=request)

--- a/src/storage/src/storage3/_sync/client.py
+++ b/src/storage/src/storage3/_sync/client.py
@@ -86,7 +86,7 @@ class SyncStorageClient(SyncStorageBucketAPI):
 
     def vectors(self) -> SyncStorageVectorsClient:
         return SyncStorageVectorsClient(
-            url=self._base_url.joinpath("v1", "vector"),
+            url=self._base_url.joinpath("vector"),
             headers=self._headers,
             session=self.session,
         )
@@ -95,6 +95,6 @@ class SyncStorageClient(SyncStorageBucketAPI):
         request = SyncRequestBuilder(
             session=self.session,
             headers=self._headers,
-            base_url=self._base_url.joinpath("v1", "iceberg"),
+            base_url=self._base_url.joinpath("iceberg"),
         )
         return SyncStorageAnalyticsClient(request=request)


### PR DESCRIPTION
## What kind of change does this PR introduce?

`v1` is already added to the path in the supabase client, so no need to do that again on the storage client side. Fixes #1329.
