### PR TITLE
Add docstrings for Functions error classes

### DIFF
--- a/src/functions/src/supabase_functions/errors.py
+++ b/src/functions/src/supabase_functions/errors.py
@@ -4,19 +4,34 @@ from typing import TypedDict
 
 
 class FunctionsApiErrorDict(TypedDict):
+    """Typed dictionary representing a Functions API error."""
     name: str
     message: str
     status: int
 
 
 class FunctionsError(Exception):
+    """Base exception class for Supabase Functions errors."""
     def __init__(self, message: str, name: str, status: int) -> None:
+        """
+        Initialize a functionserror.
+        args:
+             message (str):HUman-readable error message.
+             name (str): Error type name.
+             status (init): HTTP status code.
+        """
         super().__init__(message)
         self.message = message
         self.name = name
         self.status = status
 
     def to_dict(self) -> FunctionsApiErrorDict:
+        """
+        Convert the error into a dictionary representation.
+
+        Returns:
+            FunctionsApiErrorDict: Dictionary containing error details.
+        """
         return {
             "name": self.name,
             "message": self.message,
@@ -25,8 +40,17 @@ class FunctionsError(Exception):
 
 
 class FunctionsHttpError(FunctionsError):
-    def __init__(self, message: str, code: int | None = None) -> None:
-        super().__init__(
+     """Error raised for HTTP-related Functions failures."""
+
+     def __init__(self, message: str, code: int | None = None) -> None:
+         """
+        Initialize a FunctionsHttpError.
+
+        Args:
+            message (str): Error message.
+            code (int | None): Optional HTTP status code.
+        """
+         super().__init__(
             message,
             "FunctionsHttpError",
             400 if code is None else code,
@@ -34,10 +58,17 @@ class FunctionsHttpError(FunctionsError):
 
 
 class FunctionsRelayError(FunctionsError):
-    """Base exception for relay errors."""
+     """Error raised for relay-related Functions failures."""
 
-    def __init__(self, message: str, code: int | None = None) -> None:
-        super().__init__(
+     def __init__(self, message: str, code: int | None = None) -> None:
+         """
+        Initialize a FunctionsRelayError.
+
+        Args:
+            message (str): Error message.
+            code (int | None): Optional HTTP status code.
+        """
+         super().__init__(
             message,
             "FunctionsRelayError",
             400 if code is None else code,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Documentation update.

## What is the current behavior?

Functions-related error classes exist without detailed docstrings, which makes
their purpose and parameters less clear to users and contributors.

## What is the new behavior?

This PR adds clear, PEP 257–compliant docstrings to Functions error classes,
improving readability and developer experience.

## Additional context

No functional changes are included.
