### PR TITLE
fix(realtime): ammend reconnect logic to not unsubscribe

### DIFF
--- a/src/realtime/src/realtime/_async/channel.py
+++ b/src/realtime/src/realtime/_async/channel.py
@@ -505,6 +505,7 @@ class AsyncRealtimeChannel:
     async def _rejoin(self) -> None:
         if self.is_leaving:
             return
+        logger.info(f"Rejoining channel after reconnection: {self.topic}")
         self.state = ChannelStates.JOINING
         await self.join_push.resend()
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes #1311.  The core of the problem is explained in the issue thread, but to summarize: 
1. If the websocket connection is lost and subsequently restated, the client needs to re-subscribe to all existing channels, given that they're now invalid. 
2. In order to keep the same object references valid, it does not create a new channel. Instead, there's a custom `_rejoin` function that is called on all existing channels, which resubscribes by re-sending the same payload as the first time. 
3. The problem is that the `_rejoin` first tries to `unsubscribe` each channel before re-sending the original `join_push`, and `unsubscribe` removes the channel from the `channels` field, and only after that does it send the `join_push`.
4. When the eventual ack comes back, the channel is not registered anymore in the channels field, so the ack message (`phx_reply`) is completly ignored, leaving it in a `CLOSED` state forever.

## The fix

Given that the websocket connection is new, we can just ignore the `unsubscribe` call and just re-send the `join_push` again. This way, the external channel references still remain valid, and the state is correctly set. 

As a bonus, I've added a state change when the reconnect tries to rejoin to signal that an error occured.