### PR TITLE
docs: add Windows development notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,11 @@ All the subpackages command are available from the main root by prefixing the co
 make realtime.tests # run only realtime tests
 make storage.clean  # delete temporary files only in the storage package
 ```
+### Windows Development Notes
+
+If you are developing on Windows, some commands differ from the Unix-based examples above.
+
+#### Python and virtual environment
+- Use the `py` launcher instead of `python`
+- Create and activate a virtual environment with:
+


### PR DESCRIPTION
## What kind of change does this PR introduce?
Docs update

## What is the current behavior?
The README primarily documents Unix-based commands, which can be confusing
for contributors developing on Windows (e.g., python vs py, venv activation).

## What is the new behavior?
Adds Windows-specific notes to clarify Python usage and virtual environment
setup for contributors on Windows.

## Additional context
This aims to reduce onboarding friction for Windows-based contributors.

