### PR TITLE
fix(ci): run CI when .github files change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ name: CI/CD
 on:
   push:
     paths-ignore:
-      - '.github/**'
       - '.devcontainer/**'
       - 'CHANGELOG.md'
       - 'MAINTAINERS.md'


### PR DESCRIPTION
## What kind of change does this PR introduce?

Small change to run CI again when files in `.github/**` change. Right now, changes to CI can't be tested directly because PR that don't touch other files do not trigger a re-run.