### PR TITLE
added trailing slash to storage endpoint

### DIFF
--- a/src/supabase/src/supabase/_sync/client.py
+++ b/src/supabase/src/supabase/_sync/client.py
@@ -80,7 +80,7 @@ class Client:
             "wss" if self.supabase_url.scheme == "https" else "ws"
         )
         self.auth_url = self.supabase_url.joinpath("auth", "v1")
-        self.storage_url = self.supabase_url.joinpath("storage", "v1")
+        self.storage_url = self.supabase_url.joinpath("storage", "v1") / ""
         self.functions_url = self.supabase_url.joinpath("functions", "v1")
 
         # Instantiate clients.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The supabase_client.storage property initializes with a URL missing a trailing slash, causing the storage3 library to print:
Storage endpoint URL should have a trailing slash.

## What is the new behavior?

The storage URL now includes a trailing slash during initialization, eliminating the warning 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed storage URL formatting to ensure proper handling of storage requests and operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->