### PR TITLE
docs: add example for updating user metadata

### DIFF
--- a/src/auth/docs/source/examples/index.rst
+++ b/src/auth/docs/source/examples/index.rst
@@ -10,6 +10,6 @@ Examples(WIP)
    :maxdepth: 2
    :caption: API Reference:
 
-      API </api/api>
-      Client </api/client>
+   API </api/api>
+   Client </api/client>
    Metadata Update </examples/metadata_update>

--- a/src/auth/docs/source/examples/metadata_update.rst
+++ b/src/auth/docs/source/examples/metadata_update.rst
@@ -18,7 +18,7 @@ Example
     key: str = os.environ.get("SUPABASE_KEY")
     supabase: Client = create_client(url, key)
 
-    def update_user_metadata(user_id: str):
+    def update_user_metadata():
         # Metadata fields accept dictionaries/JSON
         new_app_metadata = {
             "plan": "premium",
@@ -30,17 +30,15 @@ Example
             "language": "en"
         }
 
-        # Update the user
-        response = supabase.auth.update_user({
-            "id": user_id,
-            "app_metadata": new_app_metadata,
-            "user_metadata": new_user_metadata,
-        }).execute()
-
-        if response.error:
-            print(f"Error: {response.error}")
-        else:
+        try:
+            # Update the currently authenticated user
+            response = supabase.auth.update_user({
+                "app_metadata": new_app_metadata,
+                "user_metadata": new_user_metadata,
+            })
             print("Successfully updated metadata.")
+        except Exception as e:
+            print(f"Error: {e}")
 
     if __name__ == "__main__":
-        update_user_metadata("your-user-id")
+        update_user_metadata()


### PR DESCRIPTION
This PR adds a specific code example and documentation for updating user `app_metadata` and `user_metadata` via the `auth.update_user()` method. This addresses common confusion regarding how to handle these dictionary-based fields in the Python client.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "Metadata Update" example showing how to update app_metadata and user_metadata (includes a Python usage snippet).
  * Reflowed documentation navigation entries to improve the examples index formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->