### PR TITLE
fix: ensure storage_url has trailing slash to prevent warning

### DIFF
--- a/src/supabase/src/supabase/_async/client.py
+++ b/src/supabase/src/supabase/_async/client.py
@@ -81,7 +81,7 @@ class AsyncClient:
             "wss" if self.supabase_url.scheme == "https" else "ws"
         )
         self.auth_url = self.supabase_url.joinpath("auth", "v1")
-        self.storage_url = self.supabase_url.joinpath("storage", "v1")
+        self.storage_url = self.supabase_url.joinpath("storage", "v1", "")
         self.functions_url = self.supabase_url.joinpath("functions", "v1")
 
         # Instantiate clients.

--- a/src/supabase/src/supabase/_sync/client.py
+++ b/src/supabase/src/supabase/_sync/client.py
@@ -80,7 +80,7 @@ class Client:
             "wss" if self.supabase_url.scheme == "https" else "ws"
         )
         self.auth_url = self.supabase_url.joinpath("auth", "v1")
-        self.storage_url = self.supabase_url.joinpath("storage", "v1")
+        self.storage_url = self.supabase_url.joinpath("storage", "v1", "")
         self.functions_url = self.supabase_url.joinpath("functions", "v1")
 
         # Instantiate clients.


### PR DESCRIPTION
Fixes #1360

## Problem
The storage_url was being constructed without a trailing slash, causing the storage3 library to print a warning message every time the storage client was initialized:
```
Storage endpoint URL should have a trailing slash.
```

## Solution
Changed both sync and async clients to use `joinpath("storage", "v1", "")` instead of `joinpath("storage", "v1")`. Adding an empty string parameter to joinpath ensures the URL ends with a trailing slash (e.g., `https://example.supabase.co/storage/v1/`).

## Changes
- Modified `src/supabase/src/supabase/_sync/client.py` line 83
- Modified `src/supabase/src/supabase/_async/client.py` line 84

cc @olirice @silentworks for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed storage URL formatting to ensure consistent trailing slash handling across endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->