### PR TITLE
fix(realtime): ensure remove_channel removes channel from channels dict

### DIFF
--- a/src/realtime/src/realtime/_async/client.py
+++ b/src/realtime/src/realtime/_async/client.py
@@ -302,6 +302,7 @@ class AsyncRealtimeClient:
         """
         if channel.topic in self.channels:
             await self.channels[channel.topic].unsubscribe()
+            self._remove_channel(channel)
 
         if len(self.channels) == 0:
             await self.close()


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

`remove_channel()` unsubscribes the channel but does **not** remove it from the internal `channels` dictionary.  
As a result, the channel remains registered in memory even after being unsubscribed, which can cause inconsistent state and prevent proper cleanup.

Related issue: #1371

## What is the new behavior?

`remove_channel()` now correctly removes the channel from the `channels` dictionary after unsubscribing by calling `_remove_channel(channel)`.

This ensures:
- The channel is fully removed from the internal registry.
- The socket closes correctly when no channels remain.
- Internal state stays consistent with actual subscriptions.

### Code change summary

Before:
```py
async def remove_channel(self, channel: AsyncRealtimeChannel) -> None:
    """
    Unsubscribes and removes a channel from the socket
    :param channel: Channel to remove
    :return: None
    """
    if channel.topic in self.channels:
        await self.channels[channel.topic].unsubscribe()

    if len(self.channels) == 0:
        await self.close()
```

After:
```py
async def remove_channel(self, channel: AsyncRealtimeChannel) -> None:
    """
    Unsubscribes and removes a channel from the socket
    :param channel: Channel to remove
    :return: None
    """
    if channel.topic in self.channels:
        await self.channels[channel.topic].unsubscribe()
        self._remove_channel(channel)

    if len(self.channels) == 0:
        await self.close()
```

## Additional context

This fix prevents stale channel references and potential memory/state leaks in the realtime channel management logic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved channel cleanup in the realtime client to ensure channels are properly removed from the internal registry when unsubscribed from.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->