### PR TITLE
fix(auth): add missing is_sso_user, deleted_at, banned_until to User model

### DIFF
--- a/src/auth/src/supabase_auth/types.py
+++ b/src/auth/src/supabase_auth/types.py
@@ -235,7 +235,10 @@ class User(BaseModel):
     updated_at: Optional[datetime] = None
     identities: Optional[List[UserIdentity]] = None
     is_anonymous: bool = False
+    is_sso_user: bool = False
     factors: Optional[List[Factor]] = None
+    deleted_at: Optional[str] = None
+    banned_until: Optional[str] = None
 
 
 class UserAttributes(TypedDict):


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix

## What is the current behavior?
The User class in src/auth/src/supabase_auth/types.py is missing three fields (is_sso_user, deleted_at, banned_until) that are returned by the Supabase Auth API and present in the JS SDK's User type. Pydantic silently drops these fields when parsing the API response, causing AttributeError on access.

Related issue: [#1374](https://github.com/supabase/supabase-py/issues/1374)

## What is the new behavior?
Three fields are added to the User model:
is_sso_user: bool = False
deleted_at: Optional[str] = None
banned_until: Optional[str] = None

is_sso_user follows the same pattern as the existing is_anonymous field. deleted_at and banned_until use Optional[str] to match the JS SDK's string typing.

## Additional context
banned_until was previously missing from the JS SDK as well and was added in supabase/supabase-js#1989. deleted_at and is_sso_user were already present in the JS SDK but never ported to the Python model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended user profile with improved account management capabilities, including support for SSO user identification, account deletion tracking, and suspension management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->