### PR TITLE
fix(storage3): replace print() with warnings.warn() for trailing slash notice

### DIFF
--- a/src/storage/src/storage3/_async/bucket.py
+++ b/src/storage/src/storage3/_async/bucket.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from typing import Any, Optional
 
 from httpx import AsyncClient, Headers, HTTPStatusError, Response
@@ -17,7 +18,12 @@ class AsyncStorageBucketAPI:
 
     def __init__(self, session: AsyncClient, url: str, headers: Headers) -> None:
         if url and url[-1] != "/":
-            print("Storage endpoint URL should have a trailing slash.")
+            warnings.warn(
+                "Storage endpoint URL should have a trailing slash. "
+                "The URL has been automatically corrected.",
+                UserWarning,
+                stacklevel=2,
+            )
             url += "/"
         self._base_url = URL(url)
         self._client = session

--- a/src/storage/src/storage3/_sync/bucket.py
+++ b/src/storage/src/storage3/_sync/bucket.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from typing import Any, Optional
 
 from httpx import Client, Headers, HTTPStatusError, Response
@@ -17,7 +18,12 @@ class SyncStorageBucketAPI:
 
     def __init__(self, session: Client, url: str, headers: Headers) -> None:
         if url and url[-1] != "/":
-            print("Storage endpoint URL should have a trailing slash.")
+            warnings.warn(
+                "Storage endpoint URL should have a trailing slash. "
+                "The URL has been automatically corrected.",
+                UserWarning,
+                stacklevel=2,
+            )
             url += "/"
         self._base_url = URL(url)
         self._client = session


### PR DESCRIPTION
Fixes #1379

## Problem

The `storage3` module uses bare `print()` to emit a notice when the storage endpoint URL lacks a trailing slash:

```python
# _sync/bucket.py and _async/bucket.py
if url and url[-1] != "/":
    print("Storage endpoint URL should have a trailing slash.")
    url += "/"
```

While PR #1367 (v2.27.3) fixed the SDK side by ensuring the URL always ends with `/`, the `print()` call remains problematic for direct consumers of `storage3`:

- **Pollutes stdout** — interferes with piped commands, structured logging, and test output capture
- **Cannot be suppressed** — unlike `warnings.warn()`, consumers have no way to filter or silence it
- **No stack trace context** — developers can't trace where the URL was constructed
- **Library auto-corrects** — the URL is fixed immediately after the print, making the message noise

## Solution

Replace `print()` with `warnings.warn()` using:
- `UserWarning` category (standard for usage notices)
- `stacklevel=2` so the warning points to the caller, not the internal `__init__`

```python
warnings.warn(
    "Storage endpoint URL should have a trailing slash. "
    "The URL has been automatically corrected.",
    UserWarning,
    stacklevel=2,
)
```

This follows Python best practices and gives consumers control via `warnings.filterwarnings()`.

## Changes

- `src/storage/src/storage3/_sync/bucket.py` — `import warnings`, replace `print()` with `warnings.warn()`
- `src/storage/src/storage3/_async/bucket.py` — same change (async variant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Storage endpoint URLs without trailing slashes now issue formal warning notifications. URLs are automatically corrected to include the trailing slash, improving visibility of this automatic correction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->