### PR TITLE
fix(storage3): replace trailing-slash print notice with warning

### DIFF
--- a/src/storage/src/storage3/_async/bucket.py
+++ b/src/storage/src/storage3/_async/bucket.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Any, Optional
+from warnings import warn
 
 from httpx import AsyncClient, Headers, HTTPStatusError, Response
 from yarl import URL
@@ -17,7 +18,11 @@ class AsyncStorageBucketAPI:
 
     def __init__(self, session: AsyncClient, url: str, headers: Headers) -> None:
         if url and url[-1] != "/":
-            print("Storage endpoint URL should have a trailing slash.")
+            warn(
+                "Storage endpoint URL should have a trailing slash. The URL has been automatically corrected.",
+                UserWarning,
+                stacklevel=2,
+            )
             url += "/"
         self._base_url = URL(url)
         self._client = session

--- a/src/storage/src/storage3/_sync/bucket.py
+++ b/src/storage/src/storage3/_sync/bucket.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Any, Optional
+from warnings import warn
 
 from httpx import Client, Headers, HTTPStatusError, Response
 from yarl import URL
@@ -17,7 +18,11 @@ class SyncStorageBucketAPI:
 
     def __init__(self, session: Client, url: str, headers: Headers) -> None:
         if url and url[-1] != "/":
-            print("Storage endpoint URL should have a trailing slash.")
+            warn(
+                "Storage endpoint URL should have a trailing slash. The URL has been automatically corrected.",
+                UserWarning,
+                stacklevel=2,
+            )
             url += "/"
         self._base_url = URL(url)
         self._client = session

--- a/src/storage/tests/test_client.py
+++ b/src/storage/tests/test_client.py
@@ -8,6 +8,11 @@ from storage3.constants import DEFAULT_TIMEOUT
 
 @pytest.fixture
 def valid_url() -> str:
+    return "https://example.com/storage/v1/"
+
+
+@pytest.fixture
+def url_without_trailing_slash() -> str:
     return "https://example.com/storage/v1"
 
 
@@ -34,6 +39,30 @@ def test_create_sync_client(valid_url, valid_headers) -> None:
         client._client.headers[key] == value for key, value in valid_headers.items()
     )
     assert client._client.timeout == Timeout(DEFAULT_TIMEOUT)
+
+
+def test_create_async_client_warns_without_trailing_slash(
+    url_without_trailing_slash, valid_headers
+) -> None:
+    with pytest.warns(
+        UserWarning, match="Storage endpoint URL should have a trailing slash"
+    ):
+        client = AsyncStorageClient(
+            url=url_without_trailing_slash, headers=valid_headers
+        )
+
+    assert str(client._base_url) == "https://example.com/storage/v1/"
+
+
+def test_create_sync_client_warns_without_trailing_slash(
+    url_without_trailing_slash, valid_headers
+) -> None:
+    with pytest.warns(
+        UserWarning, match="Storage endpoint URL should have a trailing slash"
+    ):
+        client = SyncStorageClient(url=url_without_trailing_slash, headers=valid_headers)
+
+    assert str(client._base_url) == "https://example.com/storage/v1/"
 
 
 def test_async_storage_client(valid_url, valid_headers) -> None:


### PR DESCRIPTION
## Summary
- replace trailing slash `print()` notice with `warnings.warn(...)` in both sync and async `storage3` bucket APIs
- keep auto-correction behavior by appending `/` when missing
- add tests that assert warning emission and URL normalization for both sync and async clients

## Why
Using `print()` in a library pollutes stdout and cannot be filtered. `warnings.warn()` is suppressible and points developers to callsites with `stacklevel=2`.

## Testing
- `uv run pytest tests/test_client.py tests/_sync/test_bucket.py tests/_async/test_bucket.py` (run in `src/storage`)
- `uv run ruff check src/storage/src/storage3/_sync/bucket.py src/storage/src/storage3/_async/bucket.py src/storage/tests/test_client.py`

Closes #1379

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification system for storage endpoint URLs missing trailing slashes. URLs are automatically corrected and users now receive proper warning messages instead of print output.

* **Tests**
  * Added tests verifying warning behavior when creating storage clients with URLs lacking trailing slashes, ensuring proper URL normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->