### PR TITLE
feat(functions): support custom HTTP methods in invoke

### DIFF
--- a/src/functions/src/supabase_functions/_async/functions_client.py
+++ b/src/functions/src/supabase_functions/_async/functions_client.py
@@ -120,7 +120,12 @@ class AsyncFunctionsClient:
         self.headers["Authorization"] = f"Bearer {token}"
 
     async def invoke(
-        self, function_name: str, invoke_options: Optional[Dict] = None
+        self,
+        function_name: str,
+        invoke_options: Optional[Dict] = None,
+        method: Literal[
+            "GET", "OPTIONS", "HEAD", "POST", "PUT", "PATCH", "DELETE"
+        ] = "POST",
     ) -> Union[Dict, bytes]:
         """Invokes a function
 
@@ -131,6 +136,7 @@ class AsyncFunctionsClient:
             `headers`: object representing the headers to send with the request
             `body`: the body of the request
             `responseType`: how the response should be parsed. The default is `json`
+        method : HTTP method to use for invoking the function. The default is `POST`.
         """
         if not is_valid_str_arg(function_name):
             raise ValueError("function_name must a valid string value.")
@@ -161,7 +167,7 @@ class AsyncFunctionsClient:
                 headers["Content-Type"] = "application/json"
 
         response = await self._request(
-            "POST", [function_name], headers=headers, json=body, params=params
+            method, [function_name], headers=headers, json=body, params=params
         )
         is_relay_error = response.headers.get("x-relay-header")
 

--- a/src/functions/src/supabase_functions/_sync/functions_client.py
+++ b/src/functions/src/supabase_functions/_sync/functions_client.py
@@ -120,7 +120,12 @@ class SyncFunctionsClient:
         self.headers["Authorization"] = f"Bearer {token}"
 
     def invoke(
-        self, function_name: str, invoke_options: Optional[Dict] = None
+        self,
+        function_name: str,
+        invoke_options: Optional[Dict] = None,
+        method: Literal[
+            "GET", "OPTIONS", "HEAD", "POST", "PUT", "PATCH", "DELETE"
+        ] = "POST",
     ) -> Union[Dict, bytes]:
         """Invokes a function
 
@@ -131,6 +136,7 @@ class SyncFunctionsClient:
             `headers`: object representing the headers to send with the request
             `body`: the body of the request
             `responseType`: how the response should be parsed. The default is `json`
+        method : HTTP method to use for invoking the function. The default is `POST`.
         """
         if not is_valid_str_arg(function_name):
             raise ValueError("function_name must a valid string value.")
@@ -161,7 +167,7 @@ class SyncFunctionsClient:
                 headers["Content-Type"] = "application/json"
 
         response = self._request(
-            "POST", [function_name], headers=headers, json=body, params=params
+            method, [function_name], headers=headers, json=body, params=params
         )
         is_relay_error = response.headers.get("x-relay-header")
 

--- a/src/functions/tests/_async/test_function_client.py
+++ b/src/functions/tests/_async/test_function_client.py
@@ -93,6 +93,29 @@ async def test_invoke_success_binary(client: AsyncFunctionsClient) -> None:
 
         assert result == b"binary content"
         mock_request.assert_called_once()
+        args, _ = mock_request.call_args
+        assert args[0] == "POST"
+
+
+async def test_invoke_with_custom_method(client: AsyncFunctionsClient) -> None:
+    mock_response = Mock(spec=Response)
+    mock_response.content = b"binary content"
+    mock_response.raise_for_status = Mock()
+    mock_response.headers = {}
+
+    with patch.object(
+        client._client, "request", new_callable=AsyncMock
+    ) as mock_request:
+        mock_request.return_value = mock_response
+
+        result = await client.invoke(
+            "test-function", {"body": {"test": "data"}}, method="PUT"
+        )
+
+        assert result == b"binary content"
+        args, kwargs = mock_request.call_args
+        assert args[0] == "PUT"
+        assert kwargs["json"] == {"test": "data"}
 
 
 async def test_invoke_with_region(client: AsyncFunctionsClient) -> None:

--- a/src/functions/tests/_sync/test_function_client.py
+++ b/src/functions/tests/_sync/test_function_client.py
@@ -89,6 +89,27 @@ def test_invoke_success_binary(client: SyncFunctionsClient) -> None:
 
         assert result == b"binary content"
         mock_request.assert_called_once()
+        args, _ = mock_request.call_args
+        assert args[0] == "POST"
+
+
+def test_invoke_with_custom_method(client: SyncFunctionsClient) -> None:
+    mock_response = Mock(spec=Response)
+    mock_response.content = b"binary content"
+    mock_response.raise_for_status = Mock()
+    mock_response.headers = {}
+
+    with patch.object(client._client, "request", new_callable=Mock) as mock_request:
+        mock_request.return_value = mock_response
+
+        result = client.invoke(
+            "test-function", {"body": {"test": "data"}}, method="PUT"
+        )
+
+        assert result == b"binary content"
+        args, kwargs = mock_request.call_args
+        assert args[0] == "PUT"
+        assert kwargs["json"] == {"test": "data"}
 
 
 def test_invoke_with_region(client: SyncFunctionsClient) -> None:


### PR DESCRIPTION
## Summary
- add a `method` argument to `invoke()` in both sync and async functions clients
- keep backward compatibility by defaulting `method` to `"POST"`
- pass the selected method through to the underlying `_request(...)` call
- add tests to verify default POST behavior and custom method behavior in both sync and async clients

## Why
Issue #1372 reports that edge functions may need methods other than POST (for example PUT/DELETE), but `invoke()` currently hardcodes POST.

## Testing
- `make functions.tests`
- `uv run ruff check src/functions/src/supabase_functions/_sync/functions_client.py src/functions/src/supabase_functions/_async/functions_client.py src/functions/tests/_sync/test_function_client.py src/functions/tests/_async/test_function_client.py`

Closes #1372

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Function invocation now supports specifying custom HTTP methods (GET, PUT, DELETE, OPTIONS, HEAD, PATCH) in addition to the default POST method, enhancing flexibility for API interactions.

* **Tests**
  * Added comprehensive test coverage for custom HTTP method invocation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->