### PR TITLE
fix(postgrest): handle maybe_single zero-row responses correctly

### DIFF
--- a/src/postgrest/src/postgrest/_sync/request_builder.py
+++ b/src/postgrest/src/postgrest/_sync/request_builder.py
@@ -104,23 +104,20 @@ class SyncMaybeSingleRequestBuilder:
     def __init__(self, request: ReqConfig):
         self.request = request
 
+    @staticmethod
+    def _is_zero_rows_error(error: APIError) -> bool:
+        return any(
+            field is not None and "0 rows" in field
+            for field in (error.details, error.message, error.hint)
+        )
+
     def execute(self) -> Optional[SingleAPIResponse]:
-        r = None
         try:
-            r = SyncSingleRequestBuilder(self.request).execute()
-        except APIError as e:
-            if e.details and "The result contains 0 rows" in e.details:
+            return SyncSingleRequestBuilder(self.request).execute()
+        except APIError as error:
+            if self._is_zero_rows_error(error):
                 return None
-        if not r:
-            raise APIError(
-                {
-                    "message": "Missing response",
-                    "code": "204",
-                    "hint": "Please check traceback of the code",
-                    "details": "Postgrest couldn't retrieve response, please check traceback of the code. Please create an issue in `supabase-community/postgrest-py` if needed.",
-                }
-            )
-        return r
+            raise
 
 
 class SyncFilterRequestBuilder(

--- a/src/postgrest/tests/_sync/test_client.py
+++ b/src/postgrest/tests/_sync/test_client.py
@@ -136,11 +136,18 @@ def test_response_status_code_outside_ok(postgrest_client: SyncPostgrestClient):
         assert exc_response["errors"][0].get("code") == 400
 
 
-def test_response_maybe_single(postgrest_client: SyncPostgrestClient):
+def test_response_maybe_single_returns_none_on_zero_rows(
+    postgrest_client: SyncPostgrestClient,
+):
     with patch(
         "postgrest._sync.request_builder.SyncSingleRequestBuilder.execute",
         side_effect=APIError(
-            {"message": "mock error", "code": "400", "hint": "mock", "details": "mock"}
+            {
+                "message": "JSON object requested, multiple (or no) rows returned",
+                "code": "PGRST116",
+                "hint": None,
+                "details": "The result contains 0 rows",
+            }
         ),
     ):
         client = (
@@ -150,12 +157,30 @@ def test_response_maybe_single(postgrest_client: SyncPostgrestClient):
         assert (
             client.request.headers.get("Accept") == "application/vnd.pgrst.object+json"
         )
+        assert client.execute() is None
+
+
+def test_response_maybe_single_raises_non_zero_rows_error(
+    postgrest_client: SyncPostgrestClient,
+):
+    with patch(
+        "postgrest._sync.request_builder.SyncSingleRequestBuilder.execute",
+        side_effect=APIError(
+            {
+                "message": "JSON object requested, multiple (or no) rows returned",
+                "code": "PGRST116",
+                "hint": None,
+                "details": "The result contains 2 rows",
+            }
+        ),
+    ):
+        client = (
+            postgrest_client.from_("test").select("a", "b").eq("c", "d").maybe_single()
+        )
         with pytest.raises(APIError) as exc_info:
             client.execute()
-        assert isinstance(exc_info, pytest.ExceptionInfo)
-        exc_response = exc_info.value.json()
-        assert isinstance(exc_response.get("message"), str)
-        assert "code" in exc_response and int(exc_response["code"]) == 204
+        assert exc_info.value.code == "PGRST116"
+        assert exc_info.value.details == "The result contains 2 rows"
 
 
 # https://github.com/supabase/postgrest-py/issues/595


### PR DESCRIPTION
## Summary
- update sync/async `maybe_single()` builders to return `None` when the API error clearly indicates zero rows
- detect zero-row conditions across `details`, `message`, and `hint` fields
- preserve real errors by re-raising original `APIError` for non-zero-row failures (instead of replacing with a generic 204 error)
- add sync/async tests for both zero-row and non-zero-row behaviors

## Why
Issue #1207 reports `maybe_single()` raising an error when zero rows are returned. The current implementation only checks one exact message location and can incorrectly produce a synthetic `204 Missing response` error.

## Testing
- `uv run --package postgrest pytest tests/_sync/test_client.py tests/_async/test_client.py` (run in `src/postgrest`)
- `make postgrest.mypy`
- `uv run ruff check src/postgrest/src/postgrest/_sync/request_builder.py src/postgrest/src/postgrest/_async/request_builder.py src/postgrest/tests/_sync/test_client.py src/postgrest/tests/_async/test_client.py`

Closes #1207

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified error handling for single-record queries. Zero-row query results now return `None` instead of raising an exception, while preserving proper error propagation for other API errors.

* **Tests**
  * Added comprehensive test coverage for single-record query behaviors, including zero-row scenarios and non-zero-row error cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->