### PR TITLE
fix(postgrest): prevent filter query builder state leakage

### DIFF
--- a/src/postgrest/tests/_async/test_filter_request_builder.py
+++ b/src/postgrest/tests/_async/test_filter_request_builder.py
@@ -298,3 +298,13 @@ def test_max_affected_returns_self(filter_request_builder):
     builder = filter_request_builder.max_affected(1)
 
     assert builder is filter_request_builder
+
+
+def test_filter_builders_are_immutable(filter_request_builder):
+    base_query = filter_request_builder.eq("account_id", "abc")
+    first_query = base_query.in_("id", ["1", "2", "3"])
+    second_query = base_query.in_("id", ["4", "5", "6"])
+
+    assert str(base_query.request.params) == "account_id=eq.abc"
+    assert str(first_query.request.params) == "account_id=eq.abc&id=in.%281%2C2%2C3%29"
+    assert str(second_query.request.params) == "account_id=eq.abc&id=in.%284%2C5%2C6%29"

--- a/src/postgrest/tests/_sync/test_filter_request_builder.py
+++ b/src/postgrest/tests/_sync/test_filter_request_builder.py
@@ -298,3 +298,13 @@ def test_max_affected_returns_self(filter_request_builder):
     builder = filter_request_builder.max_affected(1)
 
     assert builder is filter_request_builder
+
+
+def test_filter_builders_are_immutable(filter_request_builder):
+    base_query = filter_request_builder.eq("account_id", "abc")
+    first_query = base_query.in_("id", ["1", "2", "3"])
+    second_query = base_query.in_("id", ["4", "5", "6"])
+
+    assert str(base_query.request.params) == "account_id=eq.abc"
+    assert str(first_query.request.params) == "account_id=eq.abc&id=in.%281%2C2%2C3%29"
+    assert str(second_query.request.params) == "account_id=eq.abc&id=in.%284%2C5%2C6%29"


### PR DESCRIPTION
## Summary
- make filter builder operations copy-on-write instead of mutating shared query builder state
- update `not_`, `filter`, and `or_` to return new builder instances with independent request state
- fix `match()` chaining to work with immutable builder semantics
- add sync/async tests reproducing the issue scenario where reusing a base query previously accumulated old filters

## Why
Issue #1208 reports that reusing a query builder leaks previous filters into later queries. This change preserves the base builder and prevents cross-call filter accumulation.

## Testing
- `uv run --package postgrest pytest tests/_sync/test_filter_request_builder.py tests/_async/test_filter_request_builder.py tests/_sync/test_request_builder.py tests/_async/test_request_builder.py` (run in `src/postgrest`)
- `uv run --package postgrest pytest tests/_sync/test_client.py tests/_async/test_client.py` (run in `src/postgrest`)
- `make postgrest.mypy`
- `uv run ruff check src/postgrest/src/postgrest/base_request_builder.py src/postgrest/tests/_sync/test_filter_request_builder.py src/postgrest/tests/_async/test_filter_request_builder.py`

Closes #1208

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed filter builder operations to maintain immutability—chaining operations no longer mutate the original builder, ensuring independent query modifications don't affect each other.

* **Tests**
  * Added tests to verify filter builder immutability across sync and async implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->