### PR TITLE
fix(realtime): wait for subscribe ack before returning

### DIFF
--- a/src/realtime/tests/test_channel.py
+++ b/src/realtime/tests/test_channel.py
@@ -1,0 +1,71 @@
+import asyncio
+from typing import Any, Optional, cast
+
+import pytest
+
+from realtime import AsyncRealtimeClient
+from realtime.message import ReplyPostgresChanges
+from realtime.types import RealtimeAcknowledgementStatus, RealtimeSubscribeStates
+
+
+@pytest.mark.asyncio
+async def test_subscribe_waits_for_ack_before_returning():
+    socket = AsyncRealtimeClient("ws://localhost:54321/realtime/v1", "test-key")
+    socket._ws_connection = cast(
+        Any, object()
+    )  # mark socket as connected without network traffic
+    channel = socket.channel("test-channel")
+
+    subscribed = asyncio.Event()
+
+    def on_subscribe(state: RealtimeSubscribeStates, error: Optional[Exception]):
+        if state == RealtimeSubscribeStates.SUBSCRIBED and error is None:
+            subscribed.set()
+
+    async def fake_rejoin():
+        async def delayed_ack():
+            await asyncio.sleep(0.05)
+            channel.join_push.trigger(
+                RealtimeAcknowledgementStatus.Ok,
+                ReplyPostgresChanges(postgres_changes=[]),
+            )
+
+        asyncio.create_task(delayed_ack())
+
+    channel._rejoin = fake_rejoin  # type: ignore[method-assign]
+
+    subscribe_task = asyncio.create_task(channel.subscribe(on_subscribe))
+
+    await asyncio.sleep(0.01)
+    assert not subscribe_task.done()
+
+    await asyncio.wait_for(subscribe_task, 1)
+    assert subscribed.is_set()
+
+
+@pytest.mark.asyncio
+async def test_subscribe_propagates_callback_errors():
+    socket = AsyncRealtimeClient("ws://localhost:54321/realtime/v1", "test-key")
+    socket._ws_connection = cast(
+        Any, object()
+    )  # mark socket as connected without network traffic
+    channel = socket.channel("test-channel")
+
+    async def fake_rejoin():
+        async def delayed_ack():
+            await asyncio.sleep(0.01)
+            channel.join_push.trigger(
+                RealtimeAcknowledgementStatus.Ok,
+                ReplyPostgresChanges(postgres_changes=[]),
+            )
+
+        asyncio.create_task(delayed_ack())
+
+    channel._rejoin = fake_rejoin  # type: ignore[method-assign]
+
+    def raising_callback(state: RealtimeSubscribeStates, error: Optional[Exception]):
+        if state == RealtimeSubscribeStates.SUBSCRIBED and error is None:
+            raise RuntimeError("subscribe callback failed")
+
+    with pytest.raises(RuntimeError, match="subscribe callback failed"):
+        await channel.subscribe(raising_callback)


### PR DESCRIPTION
## Summary
- make `AsyncRealtimeChannel.subscribe()` wait for a definitive subscribe outcome before returning
- capture subscribe outcomes (`SUBSCRIBED`, `CHANNEL_ERROR`, `TIMED_OUT`) in an internal future
- propagate callback exceptions through `await subscribe(...)` instead of returning early
- add unit tests verifying: (1) subscribe does not return before ack, and (2) callback exceptions are raised to caller

## Why
Issue #1209 reports `await channel.subscribe(callback)` returning before the server reply is handled, causing race conditions. This change ensures await semantics match subscription acknowledgement lifecycle.

## Testing
- `uv run --package realtime pytest tests/test_channel.py tests/test_timer.py` (run in `src/realtime`)
- `make realtime.mypy`
- `uv run ruff check src/realtime/src/realtime/_async/channel.py src/realtime/tests/test_channel.py`

Closes #1209