### PR TITLE
fix(realtime): use pop with default in _handle_message to prevent KeyError

### DIFF
--- a/src/realtime/src/realtime/_async/channel.py
+++ b/src/realtime/src/realtime/_async/channel.py
@@ -525,7 +525,7 @@ class AsyncRealtimeChannel:
                 self.on_error(dict(message.payload))
         elif isinstance(message, ReplyMessage):
             reply_payload = message.payload
-            if message.ref and (push := self.messages_waiting_for_ack.pop(message.ref)):
+            if message.ref and (push := self.messages_waiting_for_ack.pop(message.ref, None)):
                 if reply_payload.status == "ok":
                     push.trigger(
                         RealtimeAcknowledgementStatus.Ok, reply_payload.response


### PR DESCRIPTION
Fixes #1387

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

After a WebSocket reconnect, `_handle_message` can receive a `ReplyMessage` with a `ref` that is not in `messages_waiting_for_ack` (stale reply from the previous connection). Since `dict.pop()` is called without a default value, this raises a `KeyError`.

`_listen` only catches `ConnectionClosedError`, so the unhandled `KeyError` kills the `_listen` task entirely. The rejoin response can never be processed, and the channel gets permanently stuck in `joining` state with no recovery possible.

## What is the new behavior?

`pop(message.ref, None)` is used instead of `pop(message.ref)`. Unknown refs are silently ignored instead of crashing the listener, allowing the reconnection to complete successfully.

## Additional context

Related to #1311 (fixed in #1346). The reconnect logic was fixed to not unsubscribe before rejoining, but `messages_waiting_for_ack` can still contain stale refs after a reconnect, causing this crash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling in real-time channel message processing to gracefully handle missing message references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->