### PR TITLE
fix(json): add datetime and UUID to JSON simple types

### DIFF
--- a/src/postgrest/src/postgrest/types.py
+++ b/src/postgrest/src/postgrest/types.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import sys
 from collections.abc import Mapping, Sequence
+from datetime import date, datetime, time
 from typing import Union
+from uuid import UUID
 
 from httpx import AsyncClient, BasicAuth, Client, Headers, QueryParams
 from pydantic import TypeAdapter
@@ -15,9 +17,8 @@ else:
     from strenum import StrEnum
 
 # https://docs.pydantic.dev/2.11/concepts/types/#named-recursive-types
-JSON = TypeAliasType(
-    "JSON", "Union[None, bool, str, int, float, Sequence[JSON], Mapping[str, JSON]]"
-)
+JSONSimple = Union[None, bool, str, int, float, datetime, time, date, UUID]
+JSON = TypeAliasType("JSON", "Union[JSONSimple, Sequence[JSON], Mapping[str, JSON]]")
 JSONAdapter: TypeAdapter = TypeAdapter(JSON)
 
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes #1443, adding `datetime`, `date`, `time` and `uuid` as valid `JSON` types regarding `postgrest`, in order to support generated classes that have these types as fields. 
