### PR TITLE
feat(functions): support configurable HTTP method in invoke()

### DIFF
--- a/src/functions/src/supabase_functions/_async/functions_client.py
+++ b/src/functions/src/supabase_functions/_async/functions_client.py
@@ -131,6 +131,7 @@ class AsyncFunctionsClient:
             `headers`: object representing the headers to send with the request
             `body`: the body of the request
             `responseType`: how the response should be parsed. The default is `json`
+            `method`: the HTTP method to use. Defaults to `POST`
         """
         if not is_valid_str_arg(function_name):
             raise ValueError("function_name must a valid string value.")
@@ -138,10 +139,12 @@ class AsyncFunctionsClient:
         params = QueryParams()
         body = None
         response_type = "text/plain"
+        method: Literal["GET", "OPTIONS", "HEAD", "POST", "PUT", "PATCH", "DELETE"] = "POST"
 
         if invoke_options is not None:
             headers.update(invoke_options.get("headers", {}))
             response_type = invoke_options.get("responseType", "text/plain")
+            method = invoke_options.get("method", "POST")
 
             region = invoke_options.get("region")
             if region:
@@ -161,7 +164,7 @@ class AsyncFunctionsClient:
                 headers["Content-Type"] = "application/json"
 
         response = await self._request(
-            "POST", [function_name], headers=headers, json=body, params=params
+            method, [function_name], headers=headers, json=body, params=params
         )
         is_relay_error = response.headers.get("x-relay-header")
 

--- a/src/functions/src/supabase_functions/_sync/functions_client.py
+++ b/src/functions/src/supabase_functions/_sync/functions_client.py
@@ -131,6 +131,7 @@ class SyncFunctionsClient:
             `headers`: object representing the headers to send with the request
             `body`: the body of the request
             `responseType`: how the response should be parsed. The default is `json`
+            `method`: the HTTP method to use. Defaults to `POST`
         """
         if not is_valid_str_arg(function_name):
             raise ValueError("function_name must a valid string value.")
@@ -138,10 +139,12 @@ class SyncFunctionsClient:
         params = QueryParams()
         body = None
         response_type = "text/plain"
+        method: Literal["GET", "OPTIONS", "HEAD", "POST", "PUT", "PATCH", "DELETE"] = "POST"
 
         if invoke_options is not None:
             headers.update(invoke_options.get("headers", {}))
             response_type = invoke_options.get("responseType", "text/plain")
+            method = invoke_options.get("method", "POST")
 
             region = invoke_options.get("region")
             if region:
@@ -161,7 +164,7 @@ class SyncFunctionsClient:
                 headers["Content-Type"] = "application/json"
 
         response = self._request(
-            "POST", [function_name], headers=headers, json=body, params=params
+            method, [function_name], headers=headers, json=body, params=params
         )
         is_relay_error = response.headers.get("x-relay-header")
 

--- a/src/functions/tests/_async/test_function_client.py
+++ b/src/functions/tests/_async/test_function_client.py
@@ -205,6 +205,61 @@ async def test_invoke_with_json_body(client: AsyncFunctionsClient) -> None:
         assert kwargs["headers"]["Content-Type"] == "application/json"
 
 
+async def test_invoke_with_get_method(client: AsyncFunctionsClient) -> None:
+    mock_response = Mock(spec=Response)
+    mock_response.content = b"get response"
+    mock_response.raise_for_status = Mock()
+    mock_response.headers = {}
+
+    with patch.object(
+        client._client, "request", new_callable=AsyncMock
+    ) as mock_request:
+        mock_request.return_value = mock_response
+
+        result = await client.invoke("test-function", {"method": "GET"})
+
+        assert result == b"get response"
+        args, _ = mock_request.call_args
+        assert args[0] == "GET"
+
+
+async def test_invoke_with_put_method(client: AsyncFunctionsClient) -> None:
+    mock_response = Mock(spec=Response)
+    mock_response.json.return_value = {"updated": True}
+    mock_response.raise_for_status = Mock()
+    mock_response.headers = {}
+
+    with patch.object(
+        client._client, "request", new_callable=AsyncMock
+    ) as mock_request:
+        mock_request.return_value = mock_response
+
+        result = await client.invoke(
+            "test-function", {"method": "PUT", "responseType": "json", "body": {"key": "value"}}
+        )
+
+        assert result == {"updated": True}
+        args, _ = mock_request.call_args
+        assert args[0] == "PUT"
+
+
+async def test_invoke_defaults_to_post(client: AsyncFunctionsClient) -> None:
+    mock_response = Mock(spec=Response)
+    mock_response.content = b"response"
+    mock_response.raise_for_status = Mock()
+    mock_response.headers = {}
+
+    with patch.object(
+        client._client, "request", new_callable=AsyncMock
+    ) as mock_request:
+        mock_request.return_value = mock_response
+
+        await client.invoke("test-function")
+
+        args, _ = mock_request.call_args
+        assert args[0] == "POST"
+
+
 async def test_init_with_httpx_client() -> None:
     # Create a custom httpx client with specific options
     headers = {"x-user-agent": "my-app/0.0.1"}

--- a/src/functions/tests/_sync/test_function_client.py
+++ b/src/functions/tests/_sync/test_function_client.py
@@ -189,6 +189,55 @@ def test_invoke_with_json_body(client: SyncFunctionsClient) -> None:
         assert kwargs["headers"]["Content-Type"] == "application/json"
 
 
+def test_invoke_with_get_method(client: SyncFunctionsClient) -> None:
+    mock_response = Mock(spec=Response)
+    mock_response.content = b"get response"
+    mock_response.raise_for_status = Mock()
+    mock_response.headers = {}
+
+    with patch.object(client._client, "request", new_callable=Mock) as mock_request:
+        mock_request.return_value = mock_response
+
+        result = client.invoke("test-function", {"method": "GET"})
+
+        assert result == b"get response"
+        args, _ = mock_request.call_args
+        assert args[0] == "GET"
+
+
+def test_invoke_with_put_method(client: SyncFunctionsClient) -> None:
+    mock_response = Mock(spec=Response)
+    mock_response.json.return_value = {"updated": True}
+    mock_response.raise_for_status = Mock()
+    mock_response.headers = {}
+
+    with patch.object(client._client, "request", new_callable=Mock) as mock_request:
+        mock_request.return_value = mock_response
+
+        result = client.invoke(
+            "test-function", {"method": "PUT", "responseType": "json", "body": {"key": "value"}}
+        )
+
+        assert result == {"updated": True}
+        args, _ = mock_request.call_args
+        assert args[0] == "PUT"
+
+
+def test_invoke_defaults_to_post(client: SyncFunctionsClient) -> None:
+    mock_response = Mock(spec=Response)
+    mock_response.content = b"response"
+    mock_response.raise_for_status = Mock()
+    mock_response.headers = {}
+
+    with patch.object(client._client, "request", new_callable=Mock) as mock_request:
+        mock_request.return_value = mock_response
+
+        client.invoke("test-function")
+
+        args, _ = mock_request.call_args
+        assert args[0] == "POST"
+
+
 def test_init_with_httpx_client() -> None:
     # Create a custom httpx client with specific options
     headers = {"x-user-agent": "my-app/0.0.1"}


### PR DESCRIPTION
## Summary

Closes #1372

Edge functions that respond to `GET`, `PUT`, `PATCH`, or `DELETE` were unreachable through the Python client because `invoke()` hardcoded the HTTP method to `POST`.

This PR reads a `method` key from `invoke_options`, defaulting to `"POST"` for full backwards compatibility. The underlying `_request()` method already accepted all HTTP verbs — this change simply plumbs the option through one extra layer.

## Changes

- `_async/functions_client.py`: read `method` from `invoke_options` and pass it to `_request()`
- `_sync/functions_client.py`: same change for the sync client
- `tests/_async/test_function_client.py`: added tests for `GET`, `PUT`, and default `POST` behavior
- `tests/_sync/test_function_client.py`: same tests for sync client

## Usage

```python
# GET edge function
data = await client.functions.invoke("my-function", {"method": "GET"})

# PUT edge function
data = await client.functions.invoke("my-function", {
    "method": "PUT",
    "body": {"key": "value"},
    "responseType": "json",
})

# Default behavior unchanged
data = await client.functions.invoke("my-function")  # still POST
```

## Test plan

- [x] All 69 existing tests pass
- [x] New tests verify `GET` and `PUT` methods are forwarded correctly
- [x] New test verifies default remains `POST` when `method` is not provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)