### PR TITLE
feat(postgrest): add retry logic on cloudflare errors

### DIFF
--- a/src/postgrest/src/postgrest/_async/request_builder.py
+++ b/src/postgrest/src/postgrest/_async/request_builder.py
@@ -60,7 +60,7 @@ class AsyncQueryRequestBuilder:
         self.request = request
 
     def retry(self, enabled: bool) -> Self:
-        self.retry_enabled = enabled
+        self.request.retry_enabled = enabled
         return self
 
     async def execute(self) -> APIResponse:
@@ -91,7 +91,7 @@ class AsyncSingleRequestBuilder:
         self.request = request
 
     def retry(self, enabled: bool) -> Self:
-        self.retry_enabled = enabled
+        self.request.retry_enabled = enabled
         return self
 
     async def execute(self) -> SingleAPIResponse:
@@ -124,7 +124,7 @@ class AsyncExplainRequestBuilder:
         self.request = request
 
     def retry(self, enabled: bool) -> Self:
-        self.retry_enabled = enabled
+        self.request.retry_enabled = enabled
         return self
 
     async def execute(self) -> str:
@@ -144,7 +144,7 @@ class AsyncMaybeSingleRequestBuilder:
         self.request = request
 
     def retry(self, enabled: bool) -> Self:
-        self.retry_enabled = enabled
+        self.request.retry_enabled = enabled
         return self
 
     async def execute(self) -> Optional[SingleAPIResponse]:

--- a/src/postgrest/src/postgrest/_async/request_builder.py
+++ b/src/postgrest/src/postgrest/_async/request_builder.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+import asyncio
 from typing import Any, Generic, Literal, Optional, TypeVar, Union, overload
 
 from httpx import AsyncClient, BasicAuth, Headers, QueryParams, Response
 from pydantic import ValidationError
-from typing_extensions import override
+from typing_extensions import Self, override
 from yarl import URL
 
 from ..base_request_builder import (
@@ -28,9 +29,41 @@ from ..utils import model_validate_json
 ReqConfig = RequestConfig[AsyncClient]
 
 
+def get_retry_delay(resp: Response, attempt_count: int) -> int:
+    if retry_after := resp.headers.get("Retry-After"):
+        return int(retry_after)
+    delay: int = min(2**attempt_count, 30)
+    return delay
+
+
+async def send_with_retry(req: ReqConfig) -> Response:
+    """
+    Retries idempotent requests that failed due to Cloudflare errors.
+    Request method must be either "GET" or "HEAD", and the response status code
+    must be either 503 or 520.
+    """
+    attempt_count = 0
+    while True:
+        headers = (
+            Headers({"X-Retry-Count": str(attempt_count)})
+            if attempt_count > 0
+            else Headers()
+        )
+        resp = await req.send(headers)
+        if resp.is_success or not req.should_retry(resp, attempt_count=attempt_count):
+            break
+        await asyncio.sleep(get_retry_delay(resp, attempt_count))
+        attempt_count += 1
+    return resp
+
+
 class AsyncQueryRequestBuilder:
     def __init__(self, request: ReqConfig):
         self.request = request
+
+    def retry(self, enabled: bool) -> Self:
+        self.retry_enabled = enabled
+        return self
 
     async def execute(self) -> APIResponse:
         """Execute the query.
@@ -44,7 +77,7 @@ class AsyncQueryRequestBuilder:
         Raises:
             :class:`APIError` If the API raised an error.
         """
-        r = await self.request.send()
+        r = await send_with_retry(self.request)
         try:
             if r.is_success:
                 return APIResponse.from_http_request_response(r)
@@ -59,6 +92,10 @@ class AsyncSingleRequestBuilder:
     def __init__(self, request: ReqConfig):
         self.request = request
 
+    def retry(self, enabled: bool) -> Self:
+        self.retry_enabled = enabled
+        return self
+
     async def execute(self) -> SingleAPIResponse:
         """Execute the query.
 
@@ -71,7 +108,7 @@ class AsyncSingleRequestBuilder:
                 Raises:
                     :class:`APIError` If the API raised an error.
         """
-        r = await self.request.send()
+        r = await send_with_retry(self.request)
         try:
             if (
                 200 <= r.status_code <= 299
@@ -88,8 +125,12 @@ class AsyncExplainRequestBuilder:
     def __init__(self, request: ReqConfig):
         self.request = request
 
+    def retry(self, enabled: bool) -> Self:
+        self.retry_enabled = enabled
+        return self
+
     async def execute(self) -> str:
-        r = await self.request.send()
+        r = await send_with_retry(self.request)
         try:
             if r.is_success:
                 return r.text
@@ -104,8 +145,12 @@ class AsyncMaybeSingleRequestBuilder:
     def __init__(self, request: ReqConfig):
         self.request = request
 
+    def retry(self, enabled: bool) -> Self:
+        self.retry_enabled = enabled
+        return self
+
     async def execute(self) -> Optional[SingleAPIResponse]:
-        r = await self.request.send()
+        r = await send_with_retry(self.request)
         try:
             if r.is_success:
                 parsed = APIResponse.from_http_request_response(r)

--- a/src/postgrest/src/postgrest/_async/request_builder.py
+++ b/src/postgrest/src/postgrest/_async/request_builder.py
@@ -30,8 +30,6 @@ ReqConfig = RequestConfig[AsyncClient]
 
 
 def get_retry_delay(resp: Response, attempt_count: int) -> int:
-    if retry_after := resp.headers.get("Retry-After"):
-        return int(retry_after)
     delay: int = min(2**attempt_count, 30)
     return delay
 

--- a/src/postgrest/src/postgrest/_sync/request_builder.py
+++ b/src/postgrest/src/postgrest/_sync/request_builder.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+import time
 from typing import Any, Generic, Literal, Optional, TypeVar, Union, overload
 
 from httpx import BasicAuth, Client, Headers, QueryParams, Response
 from pydantic import ValidationError
-from typing_extensions import override
+from typing_extensions import Self, override
 from yarl import URL
 
 from ..base_request_builder import (
@@ -28,9 +29,41 @@ from ..utils import model_validate_json
 ReqConfig = RequestConfig[Client]
 
 
+def get_retry_delay(resp: Response, attempt_count: int) -> int:
+    if retry_after := resp.headers.get("Retry-After"):
+        return int(retry_after)
+    delay: int = min(2**attempt_count, 30)
+    return delay
+
+
+def send_with_retry(req: ReqConfig) -> Response:
+    """
+    Retries idempotent requests that failed due to Cloudflare errors.
+    Request method must be either "GET" or "HEAD", and the response status code
+    must be either 503 or 520.
+    """
+    attempt_count = 0
+    while True:
+        headers = (
+            Headers({"X-Retry-Count": str(attempt_count)})
+            if attempt_count > 0
+            else Headers()
+        )
+        resp = req.send(headers)
+        if resp.is_success or not req.should_retry(resp, attempt_count=attempt_count):
+            break
+        time.sleep(get_retry_delay(resp, attempt_count))
+        attempt_count += 1
+    return resp
+
+
 class SyncQueryRequestBuilder:
     def __init__(self, request: ReqConfig):
         self.request = request
+
+    def retry(self, enabled: bool) -> Self:
+        self.retry_enabled = enabled
+        return self
 
     def execute(self) -> APIResponse:
         """Execute the query.
@@ -44,7 +77,7 @@ class SyncQueryRequestBuilder:
         Raises:
             :class:`APIError` If the API raised an error.
         """
-        r = self.request.send()
+        r = send_with_retry(self.request)
         try:
             if r.is_success:
                 return APIResponse.from_http_request_response(r)
@@ -59,6 +92,10 @@ class SyncSingleRequestBuilder:
     def __init__(self, request: ReqConfig):
         self.request = request
 
+    def retry(self, enabled: bool) -> Self:
+        self.retry_enabled = enabled
+        return self
+
     def execute(self) -> SingleAPIResponse:
         """Execute the query.
 
@@ -71,7 +108,7 @@ class SyncSingleRequestBuilder:
                 Raises:
                     :class:`APIError` If the API raised an error.
         """
-        r = self.request.send()
+        r = send_with_retry(self.request)
         try:
             if (
                 200 <= r.status_code <= 299
@@ -88,8 +125,12 @@ class SyncExplainRequestBuilder:
     def __init__(self, request: ReqConfig):
         self.request = request
 
+    def retry(self, enabled: bool) -> Self:
+        self.retry_enabled = enabled
+        return self
+
     def execute(self) -> str:
-        r = self.request.send()
+        r = send_with_retry(self.request)
         try:
             if r.is_success:
                 return r.text
@@ -104,8 +145,12 @@ class SyncMaybeSingleRequestBuilder:
     def __init__(self, request: ReqConfig):
         self.request = request
 
+    def retry(self, enabled: bool) -> Self:
+        self.retry_enabled = enabled
+        return self
+
     def execute(self) -> Optional[SingleAPIResponse]:
-        r = self.request.send()
+        r = send_with_retry(self.request)
         try:
             if r.is_success:
                 parsed = APIResponse.from_http_request_response(r)

--- a/src/postgrest/src/postgrest/_sync/request_builder.py
+++ b/src/postgrest/src/postgrest/_sync/request_builder.py
@@ -30,8 +30,6 @@ ReqConfig = RequestConfig[Client]
 
 
 def get_retry_delay(resp: Response, attempt_count: int) -> int:
-    if retry_after := resp.headers.get("Retry-After"):
-        return int(retry_after)
     delay: int = min(2**attempt_count, 30)
     return delay
 
@@ -62,7 +60,7 @@ class SyncQueryRequestBuilder:
         self.request = request
 
     def retry(self, enabled: bool) -> Self:
-        self.retry_enabled = enabled
+        self.request.retry_enabled = enabled
         return self
 
     def execute(self) -> APIResponse:
@@ -93,7 +91,7 @@ class SyncSingleRequestBuilder:
         self.request = request
 
     def retry(self, enabled: bool) -> Self:
-        self.retry_enabled = enabled
+        self.request.retry_enabled = enabled
         return self
 
     def execute(self) -> SingleAPIResponse:
@@ -126,7 +124,7 @@ class SyncExplainRequestBuilder:
         self.request = request
 
     def retry(self, enabled: bool) -> Self:
-        self.retry_enabled = enabled
+        self.request.retry_enabled = enabled
         return self
 
     def execute(self) -> str:
@@ -146,7 +144,7 @@ class SyncMaybeSingleRequestBuilder:
         self.request = request
 
     def retry(self, enabled: bool) -> Self:
-        self.retry_enabled = enabled
+        self.request.retry_enabled = enabled
         return self
 
     def execute(self) -> Optional[SingleAPIResponse]:

--- a/src/postgrest/src/postgrest/base_request_builder.py
+++ b/src/postgrest/src/postgrest/base_request_builder.py
@@ -52,6 +52,7 @@ class QueryArgs(NamedTuple):
 
 
 C = TypeVar("C", Client, AsyncClient)
+MAX_RETRIES = 3
 
 
 class RequestConfig(Generic[C]):
@@ -64,6 +65,7 @@ class RequestConfig(Generic[C]):
         params: QueryParams,
         auth: BasicAuth | None,
         json: JSON,
+        retry_enabled: bool = True,
     ) -> None:
         self.session: C = session
         self.path = path
@@ -72,21 +74,34 @@ class RequestConfig(Generic[C]):
         self.params = params
         self.json = None if http_method in {"GET", "HEAD"} else json
         self.auth = auth
+        self.retry_enabled = retry_enabled
 
     @overload
-    def send(self: RequestConfig[Client]) -> RequestResponse: ...
+    def send(
+        self: RequestConfig[Client], additional_headers: Headers
+    ) -> RequestResponse: ...
     @overload
-    def send(self: RequestConfig[AsyncClient]) -> Awaitable[RequestResponse]: ...
+    def send(
+        self: RequestConfig[AsyncClient], additional_headers: Headers
+    ) -> Awaitable[RequestResponse]: ...
 
-    def send(self: RequestConfig[C]):
+    def send(self: RequestConfig[C], additional_headers: Headers):
+        additional_headers.update(self.headers)
         return self.session.request(
             self.http_method,
             str(self.path),
             json=self.json,
             params=self.params,
-            headers=self.headers,
+            headers=additional_headers,
             auth=self.auth,
         )
+
+    def should_retry(self, response: RequestResponse, attempt_count: int) -> bool:
+        if not self.retry_enabled or attempt_count >= MAX_RETRIES:
+            return False
+        if not (self.http_method == "GET" or self.http_method == "HTTP"):
+            return False
+        return response.status_code == 503 or response.status_code == 520
 
 
 def _unique_columns(json: List[Dict[str, JSON]]):

--- a/src/postgrest/tests/_async/test_filter_request_builder_integration.py
+++ b/src/postgrest/tests/_async/test_filter_request_builder_integration.py
@@ -621,6 +621,7 @@ async def test_get_retry_503() -> None:
 
     async def fake_send(request: Request, **kwargs):
         nonlocal retry_count
+        assert request.headers["X-Retry-Count"] == str(retry_count)
         if retry_count < 3:
             retry_count += 1
             return Response(503)
@@ -641,6 +642,41 @@ async def test_get_retry_503() -> None:
             {"name": "woodwinds", "instruments": []},
         ]
         assert retry_count > 0
+
+
+async def test_get_retry_503_does_not_retry_when_disabled() -> None:
+    from httpx import Request, Response
+
+    retry_count = 0
+    client = rest_client()
+    original_send = client.session.send
+
+    async def fake_send(request: Request, **kwargs):
+        nonlocal retry_count
+        if retry_count > 0:
+            assert request.headers["X-Retry-Count"] == str(retry_count)
+        if retry_count < 3:
+            retry_count += 1
+            return Response(503)
+        return await original_send(request)
+
+    from unittest.mock import Mock, patch
+
+    import pytest
+
+    from postgrest.exceptions import APIError
+
+    with patch.object(client.session, "send", wraps=fake_send) as mock_send:
+        query = (
+            client.from_("orchestral_sections")
+            .select("name, instruments(name)")
+            .order("name", desc=True, foreign_table="instruments")
+            .retry(False)
+        )
+        with pytest.raises(APIError):
+            await query.execute()
+
+        assert retry_count == 1
 
 
 async def test_order_retry_400_doesnt_retry() -> None:

--- a/src/postgrest/tests/_async/test_filter_request_builder_integration.py
+++ b/src/postgrest/tests/_async/test_filter_request_builder_integration.py
@@ -610,3 +610,69 @@ async def test_order_on_foreign_table():
         {"name": "strings", "instruments": [{"name": "violin"}, {"name": "harp"}]},
         {"name": "woodwinds", "instruments": []},
     ]
+
+
+async def test_get_retry_503() -> None:
+    from httpx import Request, Response
+
+    retry_count = 0
+    client = rest_client()
+    original_send = client.session.send
+
+    async def fake_send(request: Request, **kwargs):
+        nonlocal retry_count
+        if retry_count < 3:
+            retry_count += 1
+            return Response(503)
+        return await original_send(request)
+
+    from unittest.mock import Mock, patch
+
+    with patch.object(client.session, "send", wraps=fake_send) as mock_send:
+        query = (
+            client.from_("orchestral_sections")
+            .select("name, instruments(name)")
+            .order("name", desc=True, foreign_table="instruments")
+        )
+        res = await query.execute()
+
+        assert res.data == [
+            {"name": "strings", "instruments": [{"name": "violin"}, {"name": "harp"}]},
+            {"name": "woodwinds", "instruments": []},
+        ]
+        assert retry_count > 0
+
+
+async def test_order_retry_400_doesnt_retry() -> None:
+    from httpx import Request, Response
+
+    retry_count = 0
+    client = rest_client()
+    original_send = client.session.send
+
+    async def fake_send(request: Request, **kwargs):
+        nonlocal retry_count
+        if retry_count < 3:
+            retry_count += 1
+            return Response(
+                400,
+                content=b'{"message": "JSON could not be generated", "code": "400", "hint": "Refer to full message for details", "details": ""}',
+            )
+        return await original_send(request)
+
+    from unittest.mock import Mock, patch
+
+    import pytest
+
+    from postgrest.exceptions import APIError
+
+    with patch.object(client.session, "send", wraps=fake_send) as mock_send:
+        query = (
+            client.from_("orchestral_sections")
+            .select("name, instruments(name)")
+            .order("name", desc=True, foreign_table="instruments")
+        )
+        with pytest.raises(APIError):
+            await query.execute()
+
+        assert retry_count == 1

--- a/src/postgrest/tests/_async/test_filter_request_builder_integration.py
+++ b/src/postgrest/tests/_async/test_filter_request_builder_integration.py
@@ -621,7 +621,8 @@ async def test_get_retry_503() -> None:
 
     async def fake_send(request: Request, **kwargs):
         nonlocal retry_count
-        assert request.headers["X-Retry-Count"] == str(retry_count)
+        if retry_count > 0:
+            assert request.headers["X-Retry-Count"] == str(retry_count)
         if retry_count < 3:
             retry_count += 1
             return Response(503)

--- a/src/postgrest/tests/_sync/test_filter_request_builder_integration.py
+++ b/src/postgrest/tests/_sync/test_filter_request_builder_integration.py
@@ -603,3 +603,69 @@ def test_order_on_foreign_table():
         {"name": "strings", "instruments": [{"name": "violin"}, {"name": "harp"}]},
         {"name": "woodwinds", "instruments": []},
     ]
+
+
+def test_get_retry_503() -> None:
+    from httpx import Request, Response
+
+    retry_count = 0
+    client = rest_client()
+    original_send = client.session.send
+
+    def fake_send(request: Request, **kwargs):
+        nonlocal retry_count
+        if retry_count < 3:
+            retry_count += 1
+            return Response(503)
+        return original_send(request)
+
+    from unittest.mock import Mock, patch
+
+    with patch.object(client.session, "send", wraps=fake_send) as mock_send:
+        query = (
+            client.from_("orchestral_sections")
+            .select("name, instruments(name)")
+            .order("name", desc=True, foreign_table="instruments")
+        )
+        res = query.execute()
+
+        assert res.data == [
+            {"name": "strings", "instruments": [{"name": "violin"}, {"name": "harp"}]},
+            {"name": "woodwinds", "instruments": []},
+        ]
+        assert retry_count > 0
+
+
+def test_order_retry_400_doesnt_retry() -> None:
+    from httpx import Request, Response
+
+    retry_count = 0
+    client = rest_client()
+    original_send = client.session.send
+
+    def fake_send(request: Request, **kwargs):
+        nonlocal retry_count
+        if retry_count < 3:
+            retry_count += 1
+            return Response(
+                400,
+                content=b'{"message": "JSON could not be generated", "code": "400", "hint": "Refer to full message for details", "details": ""}',
+            )
+        return original_send(request)
+
+    from unittest.mock import Mock, patch
+
+    import pytest
+
+    from postgrest.exceptions import APIError
+
+    with patch.object(client.session, "send", wraps=fake_send) as mock_send:
+        query = (
+            client.from_("orchestral_sections")
+            .select("name, instruments(name)")
+            .order("name", desc=True, foreign_table="instruments")
+        )
+        with pytest.raises(APIError):
+            query.execute()
+
+        assert retry_count == 1

--- a/src/postgrest/tests/_sync/test_filter_request_builder_integration.py
+++ b/src/postgrest/tests/_sync/test_filter_request_builder_integration.py
@@ -614,7 +614,8 @@ def test_get_retry_503() -> None:
 
     def fake_send(request: Request, **kwargs):
         nonlocal retry_count
-        assert request.headers["X-Retry-Count"] == str(retry_count)
+        if retry_count > 0:
+            assert request.headers["X-Retry-Count"] == str(retry_count)
         if retry_count < 3:
             retry_count += 1
             return Response(503)

--- a/src/postgrest/tests/_sync/test_filter_request_builder_integration.py
+++ b/src/postgrest/tests/_sync/test_filter_request_builder_integration.py
@@ -614,6 +614,7 @@ def test_get_retry_503() -> None:
 
     def fake_send(request: Request, **kwargs):
         nonlocal retry_count
+        assert request.headers["X-Retry-Count"] == str(retry_count)
         if retry_count < 3:
             retry_count += 1
             return Response(503)
@@ -634,6 +635,41 @@ def test_get_retry_503() -> None:
             {"name": "woodwinds", "instruments": []},
         ]
         assert retry_count > 0
+
+
+def test_get_retry_503_does_not_retry_when_disabled() -> None:
+    from httpx import Request, Response
+
+    retry_count = 0
+    client = rest_client()
+    original_send = client.session.send
+
+    def fake_send(request: Request, **kwargs):
+        nonlocal retry_count
+        if retry_count > 0:
+            assert request.headers["X-Retry-Count"] == str(retry_count)
+        if retry_count < 3:
+            retry_count += 1
+            return Response(503)
+        return original_send(request)
+
+    from unittest.mock import Mock, patch
+
+    import pytest
+
+    from postgrest.exceptions import APIError
+
+    with patch.object(client.session, "send", wraps=fake_send) as mock_send:
+        query = (
+            client.from_("orchestral_sections")
+            .select("name, instruments(name)")
+            .order("name", desc=True, foreign_table="instruments")
+            .retry(False)
+        )
+        with pytest.raises(APIError):
+            query.execute()
+
+        assert retry_count == 1
 
 
 def test_order_retry_400_doesnt_retry() -> None:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds retry logic to retry the HTTP request on postgrest when it receives a cloudflare related error, and the original request was idempotent.
