### PR TITLE
fix: updated type annotations for insert methods to support TypedDict

### DIFF
--- a/src/postgrest/src/postgrest/_async/request_builder.py
+++ b/src/postgrest/src/postgrest/_async/request_builder.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Generic, Literal, Optional, TypeVar, Union, overload
+from typing import Any, Generic, Literal, Optional, TypeVar, Union, overload, Mapping, Sequence
 
 from httpx import AsyncClient, BasicAuth, Headers, QueryParams, Response
 from pydantic import ValidationError
@@ -271,7 +271,7 @@ class AsyncRequestBuilder:  #
 
     def insert(
         self,
-        json: JSON,
+        json: Union[Mapping[str, Any], Sequence[Mapping[str, Any]]],
         *,
         count: Optional[CountMethod] = None,
         returning: ReturnMethod = ReturnMethod.representation,
@@ -312,7 +312,7 @@ class AsyncRequestBuilder:  #
 
     def upsert(
         self,
-        json: JSON,
+        json: Union[Mapping[str, Any], Sequence[Mapping[str, Any]]],
         *,
         count: Optional[CountMethod] = None,
         returning: ReturnMethod = ReturnMethod.representation,
@@ -357,7 +357,7 @@ class AsyncRequestBuilder:  #
 
     def update(
         self,
-        json: JSON,
+        json: Union[Mapping[str, Any], Sequence[Mapping[str, Any]]],
         *,
         count: Optional[CountMethod] = None,
         returning: ReturnMethod = ReturnMethod.representation,

--- a/src/postgrest/src/postgrest/_sync/request_builder.py
+++ b/src/postgrest/src/postgrest/_sync/request_builder.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Generic, Literal, Optional, TypeVar, Union, overload
+from typing import Any, Generic, Literal, Optional, TypeVar, Union, overload, Mapping, Sequence
 
 from httpx import BasicAuth, Client, Headers, QueryParams, Response
 from pydantic import ValidationError
@@ -271,7 +271,7 @@ class SyncRequestBuilder:  #
 
     def insert(
         self,
-        json: JSON,
+        json: Union[Mapping[str, Any], Sequence[Mapping[str, Any]]],
         *,
         count: Optional[CountMethod] = None,
         returning: ReturnMethod = ReturnMethod.representation,
@@ -312,7 +312,7 @@ class SyncRequestBuilder:  #
 
     def upsert(
         self,
-        json: JSON,
+        json: Union[Mapping[str, Any], Sequence[Mapping[str, Any]]],
         *,
         count: Optional[CountMethod] = None,
         returning: ReturnMethod = ReturnMethod.representation,
@@ -357,7 +357,7 @@ class SyncRequestBuilder:  #
 
     def update(
         self,
-        json: JSON,
+        json: Union[Mapping[str, Any], Sequence[Mapping[str, Any]]],
         *,
         count: Optional[CountMethod] = None,
         returning: ReturnMethod = ReturnMethod.representation,

--- a/src/postgrest/src/postgrest/base_request_builder.py
+++ b/src/postgrest/src/postgrest/base_request_builder.py
@@ -19,6 +19,8 @@ from typing import (
     TypeVar,
     Union,
     overload,
+    Mapping,
+    Sequence,
 )
 
 from httpx import AsyncClient, BasicAuth, Client, Headers, QueryParams
@@ -126,7 +128,7 @@ def pre_select(
 
 
 def pre_insert(
-    json: JSON,
+    json: Union[Mapping[str, Any], Sequence[Mapping[str, Any]]],
     *,
     count: Optional[CountMethod],
     returning: ReturnMethod,
@@ -149,7 +151,7 @@ def pre_insert(
 
 
 def pre_upsert(
-    json: JSON,
+    json: Union[Mapping[str, Any], Sequence[Mapping[str, Any]]],
     *,
     count: Optional[CountMethod],
     returning: ReturnMethod,
@@ -175,7 +177,7 @@ def pre_upsert(
 
 
 def pre_update(
-    json: JSON,
+    json: Union[Mapping[str, Any], Sequence[Mapping[str, Any]]],
     *,
     count: Optional[CountMethod],
     returning: ReturnMethod,

--- a/src/postgrest/tests/test_typed_dict_insert.py
+++ b/src/postgrest/tests/test_typed_dict_insert.py
@@ -1,0 +1,39 @@
+from typing import TypedDict
+from postgrest._sync.client import SyncPostgrestClient
+
+
+class MovieInsert(TypedDict):
+    name: str
+    description: str
+
+
+def test_insert_accepts_typeddict():
+    """
+    TypedDict instances should be accepted by insert() without type errors.
+    TypedDict is a subclass of dict at runtime so this should work fine.
+    """
+    client = SyncPostgrestClient("http://localhost:3000")
+    builder = client.from_("movies")
+
+    # This should not raise any type errors
+    movie: MovieInsert = {"name": "Inception", "description": "A dream movie"}
+    query = builder.insert(movie)
+
+    # Verify the json body was set correctly
+    assert query.request.json == movie
+
+
+def test_insert_accepts_list_of_typeddict():
+    """
+    A list of TypedDict instances should also be accepted.
+    """
+    client = SyncPostgrestClient("http://localhost:3000")
+    builder = client.from_("movies")
+
+    movies: list[MovieInsert] = [
+        {"name": "Inception", "description": "A dream movie"},
+        {"name": "Interstellar", "description": "A space movie"},
+    ]
+    query = builder.insert(movies)
+
+    assert query.request.json == movies


### PR DESCRIPTION
## Description

Resolves #1443

The `insert()`, `upsert()`, and `update()` methods only accepted plain
`dict` in their type annotations. Supabase's official CLI generates
`TypedDict` classes for database tables and the docs encourage users to
pass them directly to these methods. However type checkers (mypy/pyright)
rejected this with a type error even though it works fine at runtime.

**Example of the problem:**
```python
class MovieInsert(TypedDict):
    name: str

# Type checker incorrectly rejects this even though it works at runtime
movies.insert(MovieInsert(name="foo")).execute()
```

## Fix

Changed the type annotations for payload arguments to use
`Union[Mapping[str, Any], Sequence[Mapping[str, Any]]]`, which correctly
covers plain dicts, lists of dicts, and TypedDict instances.

Files updated:
- `src/postgrest/base_request_builder.py` (`pre_insert`, `pre_update`, `pre_upsert`)
- `src/postgrest/_sync/request_builder.py` (`insert`, `update`, `upsert`)
- `src/postgrest/_async/request_builder.py` (`insert`, `update`, `upsert`)

## Tests

- Added `tests/test_typed_dict_insert.py` verifying TypedDict instances
  are accepted by `insert()` for both single rows and lists
- `make postgrest.mypy` passes cleanly
- `uv run pytest tests/_sync/test_request_builder.py tests/_async/test_request_builder.py -v`