### PR TITLE
feat(functions): support configurable HTTP method in edge function invocation

### DIFF
--- a/src/functions/src/supabase_functions/_async/functions_client.py
+++ b/src/functions/src/supabase_functions/_async/functions_client.py
@@ -120,7 +120,12 @@ class AsyncFunctionsClient:
         self.headers["Authorization"] = f"Bearer {token}"
 
     async def invoke(
-        self, function_name: str, invoke_options: Optional[Dict] = None
+        self,
+        function_name: str,
+        invoke_options: Optional[Dict] = None,
+        method: Literal[
+            "GET", "OPTIONS", "HEAD", "POST", "PUT", "PATCH", "DELETE"
+        ] = "POST",
     ) -> Union[Dict, bytes]:
         """Invokes a function
 
@@ -131,6 +136,7 @@ class AsyncFunctionsClient:
             `headers`: object representing the headers to send with the request
             `body`: the body of the request
             `responseType`: how the response should be parsed. The default is `json`
+        method : the HTTP method to use when invoking the function. The default is `POST`
         """
         if not is_valid_str_arg(function_name):
             raise ValueError("function_name must a valid string value.")
@@ -161,7 +167,7 @@ class AsyncFunctionsClient:
                 headers["Content-Type"] = "application/json"
 
         response = await self._request(
-            "POST", [function_name], headers=headers, json=body, params=params
+            method, [function_name], headers=headers, json=body, params=params
         )
         is_relay_error = response.headers.get("x-relay-header")
 

--- a/src/functions/src/supabase_functions/_sync/functions_client.py
+++ b/src/functions/src/supabase_functions/_sync/functions_client.py
@@ -120,7 +120,12 @@ class SyncFunctionsClient:
         self.headers["Authorization"] = f"Bearer {token}"
 
     def invoke(
-        self, function_name: str, invoke_options: Optional[Dict] = None
+        self,
+        function_name: str,
+        invoke_options: Optional[Dict] = None,
+        method: Literal[
+            "GET", "OPTIONS", "HEAD", "POST", "PUT", "PATCH", "DELETE"
+        ] = "POST",
     ) -> Union[Dict, bytes]:
         """Invokes a function
 
@@ -131,6 +136,7 @@ class SyncFunctionsClient:
             `headers`: object representing the headers to send with the request
             `body`: the body of the request
             `responseType`: how the response should be parsed. The default is `json`
+        method : the HTTP method to use when invoking the function. The default is `POST`
         """
         if not is_valid_str_arg(function_name):
             raise ValueError("function_name must a valid string value.")
@@ -161,7 +167,7 @@ class SyncFunctionsClient:
                 headers["Content-Type"] = "application/json"
 
         response = self._request(
-            "POST", [function_name], headers=headers, json=body, params=params
+            method, [function_name], headers=headers, json=body, params=params
         )
         is_relay_error = response.headers.get("x-relay-header")
 


### PR DESCRIPTION
## Summary

Closes #1372

Adds a `method` parameter to `invoke()` in both sync and async functions clients, allowing edge functions to be called with any HTTP method (GET, PUT, DELETE, PATCH, etc.) instead of the hardcoded POST.

The parameter defaults to `"POST"` for full backward compatibility — no existing code needs to change.

### Usage

```python
# Existing behavior (unchanged)
supabase.functions.invoke("my-function", invoke_options={"body": data})

# New: specify HTTP method
supabase.functions.invoke("my-function", invoke_options={"body": data}, method="PUT")
supabase.functions.invoke("my-function", method="DELETE")
supabase.functions.invoke("my-function", method="GET")
```

### Files changed

- `src/functions/src/supabase_functions/_sync/functions_client.py` — added `method` param to `SyncFunctionsClient.invoke()`
- `src/functions/src/supabase_functions/_async/functions_client.py` — added `method` param to `AsyncFunctionsClient.invoke()`

The internal `_request` method already accepted all HTTP methods via its `Literal` type, so this change simply exposes that capability through the public `invoke()` API.

## Test plan

- [x] `ruff check` passes on both changed files
- [x] Invoking with default (no `method` arg) still uses POST
- [x] Invoking with `method="PUT"` sends a PUT request
- [x] Invoking with `method="DELETE"` sends a DELETE request
- [x] Invoking with `method="GET"` sends a GET request