### PR TITLE
docs: fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ make install-hooks # install all commit hooks into the local .git folder
 make stop-infra    # stops all running containers from all packages
 make clean         # delete all intermediary files created by testing
 ```
-All the subpackages command are available from the main root by prefixing the command with `{package_name}.`. Examples:
+All the subpackages command are available from the main root by prefixing the command with `{package_name}.`.Examples:
 ```bash
 make realtime.tests # run only realtime tests
 make storage.clean  # delete temporary files only in the storage package


### PR DESCRIPTION


Changes made:
- There is a double space on before example I just make a single space after the full stop.