### PR TITLE
fix(storage3): Handle None for non-existent signed URLs

### DIFF
--- a/src/storage/src/storage3/_async/file_api.py
+++ b/src/storage/src/storage3/_async/file_api.py
@@ -273,14 +273,23 @@ class AsyncBucketActionsMixin:
         data = SignedUrlsJsonResponse.validate_json(response.content)
         signed_urls = []
         for item in data:
-            # Prepare URL
-            url = self._make_signed_url(item.signedURL, download_query)
-            signed_item: CreateSignedUrlResponse = {
-                "error": item.error,
-                "path": item.path,
-                "signedURL": url["signedURL"],
-                "signedUrl": url["signedURL"],
-            }
+            signed_url: Optional[str] = item.signedURL
+            if signed_url:
+                # Prepare URL
+                url = self._make_signed_url(signed_url, download_query)
+                signed_item: CreateSignedUrlResponse = {
+                    "error": item.error,
+                    "path": item.path,
+                    "signedURL": url["signedURL"],
+                    "signedUrl": url["signedURL"],
+                }
+            else:
+                signed_item: CreateSignedUrlResponse = {
+                    "error": item.error,
+                    "path": item.path,
+                    "signedURL": None,
+                    "signedUrl": None,
+                }
             signed_urls.append(signed_item)
         return signed_urls
 
@@ -307,7 +316,8 @@ class AsyncBucketActionsMixin:
 
         path_parts = relative_path_to_parts(path)
         url = (
-            self._base_url.joinpath(*render_path, "public", self.id, *path_parts)
+            self._base_url
+            .joinpath(*render_path, "public", self.id, *path_parts)
             .with_query(download_query)
             .extend_query(transformation)
         )

--- a/src/storage/src/storage3/_sync/file_api.py
+++ b/src/storage/src/storage3/_sync/file_api.py
@@ -273,14 +273,23 @@ class SyncBucketActionsMixin:
         data = SignedUrlsJsonResponse.validate_json(response.content)
         signed_urls = []
         for item in data:
-            # Prepare URL
-            url = self._make_signed_url(item.signedURL, download_query)
-            signed_item: CreateSignedUrlResponse = {
-                "error": item.error,
-                "path": item.path,
-                "signedURL": url["signedURL"],
-                "signedUrl": url["signedURL"],
-            }
+            signed_url: Optional[str] = item.signedURL
+            if signed_url:
+                # Prepare URL
+                url = self._make_signed_url(signed_url, download_query)
+                signed_item: CreateSignedUrlResponse = {
+                    "error": item.error,
+                    "path": item.path,
+                    "signedURL": url["signedURL"],
+                    "signedUrl": url["signedURL"],
+                }
+            else:
+                signed_item: CreateSignedUrlResponse = {
+                    "error": item.error,
+                    "path": item.path,
+                    "signedURL": None,
+                    "signedUrl": None,
+                }
             signed_urls.append(signed_item)
         return signed_urls
 
@@ -305,7 +314,8 @@ class SyncBucketActionsMixin:
 
         path_parts = relative_path_to_parts(path)
         url = (
-            self._base_url.joinpath(*render_path, "public", self.id, *path_parts)
+            self._base_url
+            .joinpath(*render_path, "public", self.id, *path_parts)
             .with_query(download_query)
             .extend_query(transformation)
         )

--- a/src/storage/src/storage3/types.py
+++ b/src/storage/src/storage3/types.py
@@ -159,8 +159,8 @@ class SignedUrlResponse(TypedDict):
 class CreateSignedUrlResponse(TypedDict):
     error: Optional[str]
     path: str
-    signedURL: str
-    signedUrl: str
+    signedURL: Optional[str]
+    signedUrl: Optional[str]
 
 
 class SignedUrlJsonResponse(BaseModel, extra="ignore"):
@@ -170,7 +170,7 @@ class SignedUrlJsonResponse(BaseModel, extra="ignore"):
 class SignedUrlsJsonItem(BaseModel, extra="ignore"):
     error: Optional[str]
     path: str
-    signedURL: str
+    signedURL: Optional[str]
 
 
 SignedUrlsJsonResponse = TypeAdapter(list[SignedUrlsJsonItem])


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The `create_signed_urls` function raises a `pydantic_core._pydantic_core.ValidationError` when attempting to generate signed URLs for files that do not exist in a Supabase storage bucket. This occurs because the Supabase API returns null for the `signedURL` field for non-existent files, but the SDK's `SignedUrlsJsonItem` Pydantic model expects a string.

**Relevant issue**: [#1455](https://github.com/supabase/supabase-py/issues/1455)

## What is the new behavior?

This PR updates the `SignedUrlsJsonItem` Pydantic model to correctly mark the `signedURL` field as `Optional[str]`. Additionally, the `create_signed_urls` methods in both the asynchronous and synchronous file API implementations have been modified to gracefully handle `None` values for `signedURL` from the API response.

Now, if a requested file does not exist, the corresponding entry in the `CreateSignedUrlResponse` list will correctly reflect `None` for `signedURL` and `signedUrl`, without causing a validation error.

## Additional context

This fix enhances the robustness of the storage client, preventing crashes when querying for signed URLs of potentially non-existent files. Users can now safely request signed URLs for a list of files, even if some are missing, without the application crashing due to Pydantic validation failures.

