### PR TITLE
fix(storage): make signedURL an optional string

### DIFF
--- a/src/storage/src/storage3/_async/file_api.py
+++ b/src/storage/src/storage3/_async/file_api.py
@@ -201,8 +201,10 @@ class AsyncBucketActionsMixin:
         return UploadResponse(path=path, Key=data["Key"])
 
     def _make_signed_url(
-        self, signed_url: str, download_query: dict[str, str]
+        self, signed_url: Optional[str], download_query: dict[str, str]
     ) -> SignedUrlResponse:
+        if signed_url is None:
+            return {"signedURL": None, "signedUrl": None}
         url = URL(signed_url[1:])  # ignore starting slash
         signedURL = self._base_url.join(url).extend_query(download_query)
         return {"signedURL": str(signedURL), "signedUrl": str(signedURL)}

--- a/src/storage/src/storage3/_sync/file_api.py
+++ b/src/storage/src/storage3/_sync/file_api.py
@@ -201,8 +201,10 @@ class SyncBucketActionsMixin:
         return UploadResponse(path=path, Key=data["Key"])
 
     def _make_signed_url(
-        self, signed_url: str, download_query: dict[str, str]
+        self, signed_url: Optional[str], download_query: dict[str, str]
     ) -> SignedUrlResponse:
+        if signed_url is None:
+            return {"signedURL": None, "signedUrl": None}
         url = URL(signed_url[1:])  # ignore starting slash
         signedURL = self._base_url.join(url).extend_query(download_query)
         return {"signedURL": str(signedURL), "signedUrl": str(signedURL)}

--- a/src/storage/src/storage3/types.py
+++ b/src/storage/src/storage3/types.py
@@ -152,15 +152,15 @@ class UploadResponse:
 
 
 class SignedUrlResponse(TypedDict):
-    signedURL: str
-    signedUrl: str
+    signedURL: Optional[str]
+    signedUrl: Optional[str]
 
 
 class CreateSignedUrlResponse(TypedDict):
     error: Optional[str]
     path: str
-    signedURL: str
-    signedUrl: str
+    signedURL: Optional[str]
+    signedUrl: Optional[str]
 
 
 class SignedUrlJsonResponse(BaseModel, extra="ignore"):

--- a/src/storage/src/storage3/types.py
+++ b/src/storage/src/storage3/types.py
@@ -170,7 +170,7 @@ class SignedUrlJsonResponse(BaseModel, extra="ignore"):
 class SignedUrlsJsonItem(BaseModel, extra="ignore"):
     error: Optional[str]
     path: str
-    signedURL: str
+    signedURL: Optional[str]
 
 
 SignedUrlsJsonResponse = TypeAdapter(list[SignedUrlsJsonItem])

--- a/src/storage/tests/_async/test_client.py
+++ b/src/storage/tests/_async/test_client.py
@@ -412,6 +412,7 @@ async def test_client_create_signed_url(
 
     # Test basic signed URL
     signed_url = await storage_file_client.create_signed_url(file.bucket_path, 60)
+    assert signed_url["signedURL"]
     async with HttpxClient(timeout=None) as client:
         response = await client.get(signed_url["signedURL"])
     response.raise_for_status()
@@ -421,6 +422,7 @@ async def test_client_create_signed_url(
     download_signed_url = await storage_file_client.create_signed_url(
         file.bucket_path, 60, options={"download": "custom_download.svg"}
     )
+    assert download_signed_url["signedURL"]
     async with HttpxClient(timeout=None) as client:
         response = await client.get(download_signed_url["signedURL"])
 
@@ -441,6 +443,7 @@ async def test_client_create_signed_url(
     # assert "height=200" in transform_signed_url["signedURL"]
     # assert "resize=cover" in transform_signed_url["signedURL"]
     # assert "format=png" in transform_signed_url["signedURL"]
+    assert transform_signed_url["signedURL"]
     async with HttpxClient(timeout=None) as client:
         response = await client.get(transform_signed_url["signedURL"])
     response.raise_for_status()
@@ -461,6 +464,7 @@ async def test_client_create_signed_urls(
 
     async with HttpxClient() as client:
         for url in signed_urls:
+            assert url["signedURL"]
             response = await client.get(url["signedURL"])
             response.raise_for_status()
             assert response.content == multi_file[0].file_content
@@ -734,6 +738,7 @@ async def test_client_create_signed_urls_with_download(
 
     async with HttpxClient() as client:
         for i, url in enumerate(signed_urls):
+            assert url["signedURL"]
             response = await client.get(url["signedURL"])
             response.raise_for_status()
             assert response.content == multi_file[i].file_content

--- a/src/storage/tests/_sync/test_client.py
+++ b/src/storage/tests/_sync/test_client.py
@@ -410,6 +410,7 @@ def test_client_create_signed_url(
 
     # Test basic signed URL
     signed_url = storage_file_client.create_signed_url(file.bucket_path, 60)
+    assert signed_url["signedURL"]
     with HttpxClient(timeout=None) as client:
         response = client.get(signed_url["signedURL"])
     response.raise_for_status()
@@ -419,6 +420,7 @@ def test_client_create_signed_url(
     download_signed_url = storage_file_client.create_signed_url(
         file.bucket_path, 60, options={"download": "custom_download.svg"}
     )
+    assert download_signed_url["signedURL"]
     with HttpxClient(timeout=None) as client:
         response = client.get(download_signed_url["signedURL"])
 
@@ -439,6 +441,7 @@ def test_client_create_signed_url(
     # assert "height=200" in transform_signed_url["signedURL"]
     # assert "resize=cover" in transform_signed_url["signedURL"]
     # assert "format=png" in transform_signed_url["signedURL"]
+    assert transform_signed_url["signedURL"]
     with HttpxClient(timeout=None) as client:
         response = client.get(transform_signed_url["signedURL"])
     response.raise_for_status()
@@ -459,6 +462,7 @@ def test_client_create_signed_urls(
 
     with HttpxClient() as client:
         for url in signed_urls:
+            assert url["signedURL"]
             response = client.get(url["signedURL"])
             response.raise_for_status()
             assert response.content == multi_file[0].file_content
@@ -732,6 +736,7 @@ def test_client_create_signed_urls_with_download(
 
     with HttpxClient() as client:
         for i, url in enumerate(signed_urls):
+            assert url["signedURL"]
             response = client.get(url["signedURL"])
             response.raise_for_status()
             assert response.content == multi_file[i].file_content
@@ -770,3 +775,34 @@ def test_client_list_v2_folder(
     assert len(result.folders) == 1
     folder = result.folders[0]
     assert folder.key == file.bucket_folder
+
+
+def test_client_list_v2_paginated(
+    storage_file_client: SyncBucketProxy, file: FileForTesting
+) -> None:
+    """Ensure we can upload files to a bucket"""
+    suffixes = ["zz", "bb", "xx", "ww", "cc", "aa", "yy", "oo"]
+    for suffix in suffixes:
+        storage_file_client.upload(
+            file.bucket_path + suffix, file.local_path, {"content-type": file.mime_type}
+        )
+
+    has_next = True
+    cursor = ""
+    pages = 0
+    while has_next:
+        result = storage_file_client.list_v2(
+            {
+                "with_delimiter": True,
+                "prefix": f"{file.bucket_folder}/",
+                "limit": 2,
+                "cursor": cursor,
+            }
+        )
+        has_next = result.hasNext
+        cursor = result.nextCursor or ""
+
+        assert len(result.objects) == 2
+        assert all(f.name.startswith(file.bucket_path) for f in result.objects)
+        pages += 1
+    assert pages == 4


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes https://github.com/supabase/supabase-py/issues/1455, by making `signedUrl` an `Optional[str]`.

## What is the current behavior?

When a path that does not exist is passed to `create_signed_urls`, it will return an item with `error` set and `signedURL: null`, and when we try to validate the payload, a validation error is thrown. 

## What is the new behavior?

No errors are thrown, and the item will have `signedUrl=None`.

## Additional context

This error originates from the JS type annotations being wrong. The corresponding fix for it is contained [here](https://github.com/supabase/supabase-js/pull/2254)
