### PR TITLE
chore(ci): disable fail-on-error for coveralls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true
+          fail-on-error: false
 
   release-please:
     needs: test


### PR DESCRIPTION
## What kind of change does this PR introduce?

Dont fail tests on coverall upload failures. The service is failing fairly often, and we dont want upload errors to result in test failures in CI.