### PR TITLE
Fix ValidationError for null signedURL in create_signed_urls

### DIFF
--- a/src/storage/src/storage3/types.py
+++ b/src/storage/src/storage3/types.py
@@ -170,7 +170,7 @@ class SignedUrlJsonResponse(BaseModel, extra="ignore"):
 class SignedUrlsJsonItem(BaseModel, extra="ignore"):
     error: Optional[str]
     path: str
-    signedURL: str
+    signedURL: Optional[str]
 
 
 SignedUrlsJsonResponse = TypeAdapter(list[SignedUrlsJsonItem])


### PR DESCRIPTION
Fixes ValidationError when create_signed_urls is called with non-existent file paths. Changed signedURL: str to signedURL: Optional[str] in SignedUrlsJsonItem class. Fixes #1455