### PR TITLE
fix: restore storage and httpx_client fields on ClientOptions

### DIFF
--- a/src/supabase/src/supabase/lib/client_options.py
+++ b/src/supabase/src/supabase/lib/client_options.py
@@ -56,6 +56,11 @@ class ClientOptions:
     flow_type: AuthFlowType = "pkce"
     """flow type to use for authentication"""
 
+    storage: Optional[SyncSupportedStorage] = field(default_factory=SyncMemoryStorage)
+    """A storage provider. Used to store the logged in session."""
+
+    httpx_client: Optional[SyncHttpxClient] = None
+    """httpx client instance to be used by the PostgREST, functions, auth and storage clients."""
 
 @dataclass
 class AsyncClientOptions(ClientOptions):


### PR DESCRIPTION
## ClientOptions was missing storage and httpx_client fields in v2.28.3, causing Attribute Error when creating a client with custom options. Fixes #1466

## What kind of change does this PR introduce?
Bug fix

## What is the current behavior?
In v2.28.3, creating a Supabase client with custom ClientOptions raises:

AttributeError: 'ClientOptions' object has no attribute 'storage'

This happens because the base ClientOptions dataclass is missing the storage and httpx_client fields that Client.__init__ tries to access.

Fixes #1466

## What is the new behavior?
The base ClientOptions dataclass now includes storage and httpx_client fields with sensible defaults, consistent with SyncClientOptions and AsyncClientOptions.

Example that now works:

from supabase import create_client
from supabase.lib.client_options import ClientOptions

opts = ClientOptions(headers={"Authorization": "Bearer <jwt>"})
client = create_client("http://localhost:54321", "anon-key", options=opts)

## Additional context
This is a recurring regression — the same bug appeared in v2.22.0, was fixed in v2.23.0, reintroduced in v2.24.0 (issue #1306), and has now reappeared in v2.28.3 (issue #1466).