### PR TITLE
refactor: rename anon key → publishable key, service role key → secret key

### DIFF
--- a/src/auth/src/supabase_auth/_async/gotrue_admin_api.py
+++ b/src/auth/src/supabase_auth/_async/gotrue_admin_api.py
@@ -122,7 +122,7 @@ class AsyncGoTrueAdminAPI(AsyncGoTrueBaseAPI):
         Creates a new user.
 
         This function should only be called on a server.
-        Never expose your `service_role` key in the browser.
+        Never expose your `secret` key in the browser.
         """
         response = await self._request(
             "POST",
@@ -138,7 +138,7 @@ class AsyncGoTrueAdminAPI(AsyncGoTrueBaseAPI):
         Get a list of users.
 
         This function should only be called on a server.
-        Never expose your `service_role` key in the browser.
+        Never expose your `secret` key in the browser.
         """
         response = await self._request(
             "GET",
@@ -152,7 +152,7 @@ class AsyncGoTrueAdminAPI(AsyncGoTrueBaseAPI):
         Get user by id.
 
         This function should only be called on a server.
-        Never expose your `service_role` key in the browser.
+        Never expose your `secret` key in the browser.
         """
         validate_uuid(uid)
 
@@ -171,7 +171,7 @@ class AsyncGoTrueAdminAPI(AsyncGoTrueBaseAPI):
         Updates the user data.
 
         This function should only be called on a server.
-        Never expose your `service_role` key in the browser.
+        Never expose your `secret` key in the browser.
         """
         validate_uuid(uid)
         response = await self._request(
@@ -183,10 +183,10 @@ class AsyncGoTrueAdminAPI(AsyncGoTrueBaseAPI):
 
     async def delete_user(self, id: str, should_soft_delete: bool = False) -> None:
         """
-        Delete a user. Requires a `service_role` key.
+        Delete a user. Requires a `secret` key.
 
         This function should only be called on a server.
-        Never expose your `service_role` key in the browser.
+        Never expose your `secret` key in the browser.
         """
         validate_uuid(id)
         body = {"should_soft_delete": should_soft_delete}
@@ -224,7 +224,7 @@ class AsyncGoTrueAdminAPI(AsyncGoTrueBaseAPI):
         Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
 
         This function should only be called on a server.
-        Never expose your `service_role` key in the browser.
+        Never expose your `secret` key in the browser.
         """
         if params:
             query = QueryParams(page=params.page, per_page=params.per_page)
@@ -269,7 +269,7 @@ class AsyncGoTrueAdminAPI(AsyncGoTrueBaseAPI):
         Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
 
         This function should only be called on a server.
-        Never expose your `service_role` key in the browser.
+        Never expose your `secret` key in the browser.
         """
         response = await self._request(
             "POST",
@@ -288,7 +288,7 @@ class AsyncGoTrueAdminAPI(AsyncGoTrueBaseAPI):
         Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
 
         This function should only be called on a server.
-        Never expose your `service_role` key in the browser.
+        Never expose your `secret` key in the browser.
         """
         validate_uuid(client_id)
         response = await self._request(
@@ -307,7 +307,7 @@ class AsyncGoTrueAdminAPI(AsyncGoTrueBaseAPI):
         Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
 
         This function should only be called on a server.
-        Never expose your `service_role` key in the browser.
+        Never expose your `secret` key in the browser.
         """
         validate_uuid(client_id)
         response = await self._request(
@@ -326,7 +326,7 @@ class AsyncGoTrueAdminAPI(AsyncGoTrueBaseAPI):
         Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
 
         This function should only be called on a server.
-        Never expose your `service_role` key in the browser.
+        Never expose your `secret` key in the browser.
         """
         validate_uuid(client_id)
         await self._request(
@@ -343,7 +343,7 @@ class AsyncGoTrueAdminAPI(AsyncGoTrueBaseAPI):
         Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
 
         This function should only be called on a server.
-        Never expose your `service_role` key in the browser.
+        Never expose your `secret` key in the browser.
         """
         validate_uuid(client_id)
         response = await self._request(

--- a/src/auth/src/supabase_auth/_async/gotrue_admin_oauth_api.py
+++ b/src/auth/src/supabase_auth/_async/gotrue_admin_oauth_api.py
@@ -24,7 +24,7 @@ class AsyncGoTrueAdminOAuthAPI:
         Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
 
         This function should only be called on a server.
-        Never expose your `service_role` key in the browser.
+        Never expose your `secret` key in the browser.
         """
         raise NotImplementedError()  # pragma: no cover
 
@@ -37,7 +37,7 @@ class AsyncGoTrueAdminOAuthAPI:
         Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
 
         This function should only be called on a server.
-        Never expose your `service_role` key in the browser.
+        Never expose your `secret` key in the browser.
         """
         raise NotImplementedError()  # pragma: no cover
 
@@ -50,7 +50,7 @@ class AsyncGoTrueAdminOAuthAPI:
         Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
 
         This function should only be called on a server.
-        Never expose your `service_role` key in the browser.
+        Never expose your `secret` key in the browser.
         """
         raise NotImplementedError()  # pragma: no cover
 
@@ -64,7 +64,7 @@ class AsyncGoTrueAdminOAuthAPI:
         Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
 
         This function should only be called on a server.
-        Never expose your `service_role` key in the browser.
+        Never expose your `secret` key in the browser.
         """
         raise NotImplementedError()  # pragma: no cover
 
@@ -77,7 +77,7 @@ class AsyncGoTrueAdminOAuthAPI:
         Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
 
         This function should only be called on a server.
-        Never expose your `service_role` key in the browser.
+        Never expose your `secret` key in the browser.
         """
         raise NotImplementedError()  # pragma: no cover
 
@@ -90,6 +90,6 @@ class AsyncGoTrueAdminOAuthAPI:
         Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
 
         This function should only be called on a server.
-        Never expose your `service_role` key in the browser.
+        Never expose your `secret` key in the browser.
         """
         raise NotImplementedError()  # pragma: no cover

--- a/src/auth/src/supabase_auth/_sync/gotrue_admin_api.py
+++ b/src/auth/src/supabase_auth/_sync/gotrue_admin_api.py
@@ -122,7 +122,7 @@ class SyncGoTrueAdminAPI(SyncGoTrueBaseAPI):
         Creates a new user.
 
         This function should only be called on a server.
-        Never expose your `service_role` key in the browser.
+        Never expose your `secret` key in the browser.
         """
         response = self._request(
             "POST",
@@ -138,7 +138,7 @@ class SyncGoTrueAdminAPI(SyncGoTrueBaseAPI):
         Get a list of users.
 
         This function should only be called on a server.
-        Never expose your `service_role` key in the browser.
+        Never expose your `secret` key in the browser.
         """
         response = self._request(
             "GET",
@@ -152,7 +152,7 @@ class SyncGoTrueAdminAPI(SyncGoTrueBaseAPI):
         Get user by id.
 
         This function should only be called on a server.
-        Never expose your `service_role` key in the browser.
+        Never expose your `secret` key in the browser.
         """
         validate_uuid(uid)
 
@@ -171,7 +171,7 @@ class SyncGoTrueAdminAPI(SyncGoTrueBaseAPI):
         Updates the user data.
 
         This function should only be called on a server.
-        Never expose your `service_role` key in the browser.
+        Never expose your `secret` key in the browser.
         """
         validate_uuid(uid)
         response = self._request(
@@ -183,10 +183,10 @@ class SyncGoTrueAdminAPI(SyncGoTrueBaseAPI):
 
     def delete_user(self, id: str, should_soft_delete: bool = False) -> None:
         """
-        Delete a user. Requires a `service_role` key.
+        Delete a user. Requires a `secret` key.
 
         This function should only be called on a server.
-        Never expose your `service_role` key in the browser.
+        Never expose your `secret` key in the browser.
         """
         validate_uuid(id)
         body = {"should_soft_delete": should_soft_delete}
@@ -224,7 +224,7 @@ class SyncGoTrueAdminAPI(SyncGoTrueBaseAPI):
         Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
 
         This function should only be called on a server.
-        Never expose your `service_role` key in the browser.
+        Never expose your `secret` key in the browser.
         """
         if params:
             query = QueryParams(page=params.page, per_page=params.per_page)
@@ -269,7 +269,7 @@ class SyncGoTrueAdminAPI(SyncGoTrueBaseAPI):
         Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
 
         This function should only be called on a server.
-        Never expose your `service_role` key in the browser.
+        Never expose your `secret` key in the browser.
         """
         response = self._request(
             "POST",
@@ -288,7 +288,7 @@ class SyncGoTrueAdminAPI(SyncGoTrueBaseAPI):
         Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
 
         This function should only be called on a server.
-        Never expose your `service_role` key in the browser.
+        Never expose your `secret` key in the browser.
         """
         validate_uuid(client_id)
         response = self._request(
@@ -307,7 +307,7 @@ class SyncGoTrueAdminAPI(SyncGoTrueBaseAPI):
         Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
 
         This function should only be called on a server.
-        Never expose your `service_role` key in the browser.
+        Never expose your `secret` key in the browser.
         """
         validate_uuid(client_id)
         response = self._request(
@@ -326,7 +326,7 @@ class SyncGoTrueAdminAPI(SyncGoTrueBaseAPI):
         Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
 
         This function should only be called on a server.
-        Never expose your `service_role` key in the browser.
+        Never expose your `secret` key in the browser.
         """
         validate_uuid(client_id)
         self._request(
@@ -343,7 +343,7 @@ class SyncGoTrueAdminAPI(SyncGoTrueBaseAPI):
         Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
 
         This function should only be called on a server.
-        Never expose your `service_role` key in the browser.
+        Never expose your `secret` key in the browser.
         """
         validate_uuid(client_id)
         response = self._request(

--- a/src/auth/src/supabase_auth/_sync/gotrue_admin_oauth_api.py
+++ b/src/auth/src/supabase_auth/_sync/gotrue_admin_oauth_api.py
@@ -24,7 +24,7 @@ class SyncGoTrueAdminOAuthAPI:
         Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
 
         This function should only be called on a server.
-        Never expose your `service_role` key in the browser.
+        Never expose your `secret` key in the browser.
         """
         raise NotImplementedError()  # pragma: no cover
 
@@ -37,7 +37,7 @@ class SyncGoTrueAdminOAuthAPI:
         Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
 
         This function should only be called on a server.
-        Never expose your `service_role` key in the browser.
+        Never expose your `secret` key in the browser.
         """
         raise NotImplementedError()  # pragma: no cover
 
@@ -50,7 +50,7 @@ class SyncGoTrueAdminOAuthAPI:
         Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
 
         This function should only be called on a server.
-        Never expose your `service_role` key in the browser.
+        Never expose your `secret` key in the browser.
         """
         raise NotImplementedError()  # pragma: no cover
 
@@ -64,7 +64,7 @@ class SyncGoTrueAdminOAuthAPI:
         Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
 
         This function should only be called on a server.
-        Never expose your `service_role` key in the browser.
+        Never expose your `secret` key in the browser.
         """
         raise NotImplementedError()  # pragma: no cover
 
@@ -77,7 +77,7 @@ class SyncGoTrueAdminOAuthAPI:
         Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
 
         This function should only be called on a server.
-        Never expose your `service_role` key in the browser.
+        Never expose your `secret` key in the browser.
         """
         raise NotImplementedError()  # pragma: no cover
 
@@ -90,6 +90,6 @@ class SyncGoTrueAdminOAuthAPI:
         Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
 
         This function should only be called on a server.
-        Never expose your `service_role` key in the browser.
+        Never expose your `secret` key in the browser.
         """
         raise NotImplementedError()  # pragma: no cover

--- a/src/auth/tests/_async/clients.py
+++ b/src/auth/tests/_async/clients.py
@@ -14,7 +14,7 @@ def mock_access_token() -> str:
     return encode(
         {
             "sub": "1234567890",
-            "role": "anon_key",
+            "role": "anon",
         },
         GOTRUE_JWT_SECRET,
     )
@@ -82,7 +82,7 @@ async def create_new_user_with_email(
             "password": password,
         }
     )
-    response = await service_role_api_client().create_user(
+    response = await secret_key_api_client().create_user(
         {
             "email": credentials.email,
             "password": credentials.password,
@@ -197,7 +197,7 @@ def auth_admin_api_auto_confirm_disabled_client() -> AsyncGoTrueAdminAPI:
     )
 
 
-SERVICE_ROLE_JWT = encode(
+SECRET_KEY_JWT = encode(
     {
         "role": "service_role",
     },
@@ -205,28 +205,28 @@ SERVICE_ROLE_JWT = encode(
 )
 
 
-def service_role_api_client() -> AsyncGoTrueAdminAPI:
+def secret_key_api_client() -> AsyncGoTrueAdminAPI:
     return AsyncGoTrueAdminAPI(
         url=GOTRUE_URL_SIGNUP_ENABLED_AUTO_CONFIRM_ON,
         headers={
-            "Authorization": f"Bearer {SERVICE_ROLE_JWT}",
+            "Authorization": f"Bearer {SECRET_KEY_JWT}",
         },
     )
 
 
-def service_role_api_client_with_sms() -> AsyncGoTrueAdminAPI:
+def secret_key_api_client_with_sms() -> AsyncGoTrueAdminAPI:
     return AsyncGoTrueAdminAPI(
         url=GOTRUE_URL_SIGNUP_ENABLED_AUTO_CONFIRM_OFF,
         headers={
-            "Authorization": f"Bearer {SERVICE_ROLE_JWT}",
+            "Authorization": f"Bearer {SECRET_KEY_JWT}",
         },
     )
 
 
-def service_role_api_client_no_sms() -> AsyncGoTrueAdminAPI:
+def secret_key_api_client_no_sms() -> AsyncGoTrueAdminAPI:
     return AsyncGoTrueAdminAPI(
         url=GOTRUE_URL_SIGNUP_DISABLED_AUTO_CONFIRM_OFF,
         headers={
-            "Authorization": f"Bearer {SERVICE_ROLE_JWT}",
+            "Authorization": f"Bearer {SECRET_KEY_JWT}",
         },
     )

--- a/src/auth/tests/_async/test_gotrue_admin_api.py
+++ b/src/auth/tests/_async/test_gotrue_admin_api.py
@@ -17,7 +17,7 @@ from .clients import (
     mock_user_credentials,
     mock_user_metadata,
     mock_verification_otp,
-    service_role_api_client,
+    secret_key_api_client,
 )
 
 
@@ -30,7 +30,7 @@ async def test_create_user_should_create_a_new_user() -> None:
 async def test_create_user_with_user_metadata() -> None:
     user_metadata = mock_user_metadata()
     credentials = mock_user_credentials()
-    response = await service_role_api_client().create_user(
+    response = await secret_key_api_client().create_user(
         {
             "email": credentials.email,
             "password": credentials.password,
@@ -46,7 +46,7 @@ async def test_create_user_with_user_and_app_metadata() -> None:
     user_metadata = mock_user_metadata()
     app_metadata = mock_app_metadata()
     credentials = mock_user_credentials()
-    response = await service_role_api_client().create_user(
+    response = await secret_key_api_client().create_user(
         {
             "email": credentials.email,
             "password": credentials.password,
@@ -63,7 +63,7 @@ async def test_create_user_with_user_and_app_metadata() -> None:
 async def test_list_users_should_return_registered_users() -> None:
     credentials = mock_user_credentials()
     await create_new_user_with_email(email=credentials.email)
-    users = await service_role_api_client().list_users()
+    users = await secret_key_api_client().list_users()
     assert users
     emails = [user.email for user in users]
     assert emails
@@ -76,14 +76,14 @@ async def test_get_user_by_id_should_a_registered_user_given_its_user_identifier
     credentials = mock_user_credentials()
     user = await create_new_user_with_email(email=credentials.email)
     assert user.id
-    response = await service_role_api_client().get_user_by_id(user.id)
+    response = await secret_key_api_client().get_user_by_id(user.id)
     assert response.user.email == credentials.email
 
 
 async def test_modify_email_using_update_user_by_id() -> None:
     credentials = mock_user_credentials()
     user = await create_new_user_with_email(email=credentials.email)
-    response = await service_role_api_client().update_user_by_id(
+    response = await secret_key_api_client().update_user_by_id(
         user.id,
         {
             "email": f"new_{user.email}",
@@ -96,7 +96,7 @@ async def test_modify_user_metadata_using_update_user_by_id() -> None:
     credentials = mock_user_credentials()
     user = await create_new_user_with_email(email=credentials.email)
     user_metadata = {"favorite_color": "yellow"}
-    response = await service_role_api_client().update_user_by_id(
+    response = await secret_key_api_client().update_user_by_id(
         user.id,
         {
             "user_metadata": user_metadata,
@@ -110,7 +110,7 @@ async def test_modify_app_metadata_using_update_user_by_id() -> None:
     credentials = mock_user_credentials()
     user = await create_new_user_with_email(email=credentials.email)
     app_metadata = {"roles": ["admin", "publisher"]}
-    response = await service_role_api_client().update_user_by_id(
+    response = await secret_key_api_client().update_user_by_id(
         user.id,
         {
             "app_metadata": app_metadata,
@@ -130,7 +130,7 @@ async def test_modify_confirm_email_using_update_user_by_id() -> None:
     )
     assert response.user
     assert not response.user.email_confirmed_at
-    auth_response = await service_role_api_client().update_user_by_id(
+    auth_response = await secret_key_api_client().update_user_by_id(
         response.user.id,
         {
             "email_confirm": True,
@@ -226,8 +226,8 @@ async def test_sign_in_anonymously() -> None:
 async def test_delete_user_should_be_able_delete_an_existing_user() -> None:
     credentials = mock_user_credentials()
     user = await create_new_user_with_email(email=credentials.email)
-    await service_role_api_client().delete_user(user.id)
-    users = await service_role_api_client().list_users()
+    await secret_key_api_client().delete_user(user.id)
+    users = await secret_key_api_client().list_users()
     emails = [user.email for user in users]
     assert credentials.email not in emails
 
@@ -238,7 +238,7 @@ async def test_generate_link_supports_sign_up_with_generate_confirmation_signup_
     credentials = mock_user_credentials()
     redirect_to = "http://localhost:9999/welcome"
     user_metadata = {"status": "alpha"}
-    response = await service_role_api_client().generate_link(
+    response = await secret_key_api_client().generate_link(
         {
             "type": "signup",
             "email": credentials.email,
@@ -261,7 +261,7 @@ async def test_generate_link_supports_updating_emails_with_generate_email_change
     assert user.email == credentials.email
     credentials = mock_user_credentials()
     redirect_to = "http://localhost:9999/welcome"
-    response = await service_role_api_client().generate_link(
+    response = await secret_key_api_client().generate_link(
         {
             "type": "email_change_current",
             "email": user.email,
@@ -280,7 +280,7 @@ async def test_invite_user_by_email_creates_a_new_user_with_an_invited_at_timest
     credentials = mock_user_credentials()
     redirect_to = "http://localhost:9999/welcome"
     user_metadata = {"status": "alpha"}
-    response = await service_role_api_client().invite_user_by_email(
+    response = await secret_key_api_client().invite_user_by_email(
         credentials.email,
         {
             "data": user_metadata,
@@ -300,12 +300,12 @@ async def test_sign_out_with_an_valid_access_token() -> None:
         },
     )
     assert response.session
-    await service_role_api_client().sign_out(response.session.access_token)
+    await secret_key_api_client().sign_out(response.session.access_token)
 
 
 async def test_sign_out_with_an_invalid_access_token() -> None:
     try:
-        await service_role_api_client().sign_out("this-is-a-bad-token")
+        await secret_key_api_client().sign_out("this-is-a-bad-token")
         raise AssertionError()
     except AuthError:
         pass
@@ -529,7 +529,7 @@ async def test_update_user() -> None:
 async def test_create_user_with_app_metadata() -> None:
     app_metadata = mock_app_metadata()
     credentials = mock_user_credentials()
-    response = await service_role_api_client().create_user(
+    response = await secret_key_api_client().create_user(
         {
             "email": credentials.email,
             "password": credentials.password,
@@ -600,7 +600,7 @@ async def test_admin_list_factors() -> None:
             "code": totp.now(),
         }
     )
-    admin_client = service_role_api_client()
+    admin_client = secret_key_api_client()
     factors = await admin_client.mfa.list_factors(
         {
             "user_id": res.user.id,
@@ -621,7 +621,7 @@ async def test_admin_list_factors() -> None:
 
 async def test_create_oauth_client() -> None:
     """Test creating an OAuth client."""
-    response = await service_role_api_client().oauth.create_client(
+    response = await secret_key_api_client().oauth.create_client(
         CreateOAuthClientParams(
             client_name="Test OAuth Client",
             redirect_uris=["https://example.com/callback"],
@@ -634,7 +634,7 @@ async def test_create_oauth_client() -> None:
 
 async def test_list_oauth_clients() -> None:
     """Test listing OAuth clients."""
-    client = service_role_api_client()
+    client = secret_key_api_client()
     await client.oauth.create_client(
         CreateOAuthClientParams(
             client_name="Test OAuth Client",
@@ -650,7 +650,7 @@ async def test_list_oauth_clients() -> None:
 async def test_get_oauth_client() -> None:
     """Test getting an OAuth client by ID."""
     # First create a client
-    create_response = await service_role_api_client().oauth.create_client(
+    create_response = await secret_key_api_client().oauth.create_client(
         CreateOAuthClientParams(
             client_name="Test OAuth Client for Get",
             redirect_uris=["https://example.com/callback"],
@@ -658,7 +658,7 @@ async def test_get_oauth_client() -> None:
     )
     if create_response.client:
         client_id = create_response.client.client_id
-        response = await service_role_api_client().oauth.get_client(client_id)
+        response = await secret_key_api_client().oauth.get_client(client_id)
         assert response.client is not None
         assert response.client.client_id == client_id
 
@@ -667,7 +667,7 @@ async def test_get_oauth_client() -> None:
 async def test_update_oauth_client() -> None:
     """Test updating an OAuth client."""
     # First create a client
-    client = service_role_api_client()
+    client = secret_key_api_client()
     create_response = await client.oauth.create_client(
         CreateOAuthClientParams(
             client_name="Test OAuth Client for Update",
@@ -689,7 +689,7 @@ async def test_update_oauth_client() -> None:
 async def test_delete_oauth_client() -> None:
     """Test deleting an OAuth client."""
     # First create a client
-    client = service_role_api_client()
+    client = secret_key_api_client()
     create_response = await client.oauth.create_client(
         CreateOAuthClientParams(
             client_name="Test OAuth Client for Delete",
@@ -704,7 +704,7 @@ async def test_delete_oauth_client() -> None:
 async def test_regenerate_oauth_client_secret() -> None:
     """Test regenerating an OAuth client secret."""
     # First create a client
-    create_response = await service_role_api_client().oauth.create_client(
+    create_response = await secret_key_api_client().oauth.create_client(
         CreateOAuthClientParams(
             client_name="Test OAuth Client for Regenerate",
             redirect_uris=["https://example.com/callback"],
@@ -712,7 +712,7 @@ async def test_regenerate_oauth_client_secret() -> None:
     )
     if create_response.client:
         client_id = create_response.client.client_id
-        response = await service_role_api_client().oauth.regenerate_client_secret(
+        response = await secret_key_api_client().oauth.regenerate_client_secret(
             client_id
         )
         assert response.client is not None

--- a/src/auth/tests/_sync/clients.py
+++ b/src/auth/tests/_sync/clients.py
@@ -14,7 +14,7 @@ def mock_access_token() -> str:
     return encode(
         {
             "sub": "1234567890",
-            "role": "anon_key",
+            "role": "anon",
         },
         GOTRUE_JWT_SECRET,
     )
@@ -82,7 +82,7 @@ def create_new_user_with_email(
             "password": password,
         }
     )
-    response = service_role_api_client().create_user(
+    response = secret_key_api_client().create_user(
         {
             "email": credentials.email,
             "password": credentials.password,
@@ -197,7 +197,7 @@ def auth_admin_api_auto_confirm_disabled_client() -> SyncGoTrueAdminAPI:
     )
 
 
-SERVICE_ROLE_JWT = encode(
+SECRET_KEY_JWT = encode(
     {
         "role": "service_role",
     },
@@ -205,28 +205,28 @@ SERVICE_ROLE_JWT = encode(
 )
 
 
-def service_role_api_client() -> SyncGoTrueAdminAPI:
+def secret_key_api_client() -> SyncGoTrueAdminAPI:
     return SyncGoTrueAdminAPI(
         url=GOTRUE_URL_SIGNUP_ENABLED_AUTO_CONFIRM_ON,
         headers={
-            "Authorization": f"Bearer {SERVICE_ROLE_JWT}",
+            "Authorization": f"Bearer {SECRET_KEY_JWT}",
         },
     )
 
 
-def service_role_api_client_with_sms() -> SyncGoTrueAdminAPI:
+def secret_key_api_client_with_sms() -> SyncGoTrueAdminAPI:
     return SyncGoTrueAdminAPI(
         url=GOTRUE_URL_SIGNUP_ENABLED_AUTO_CONFIRM_OFF,
         headers={
-            "Authorization": f"Bearer {SERVICE_ROLE_JWT}",
+            "Authorization": f"Bearer {SECRET_KEY_JWT}",
         },
     )
 
 
-def service_role_api_client_no_sms() -> SyncGoTrueAdminAPI:
+def secret_key_api_client_no_sms() -> SyncGoTrueAdminAPI:
     return SyncGoTrueAdminAPI(
         url=GOTRUE_URL_SIGNUP_DISABLED_AUTO_CONFIRM_OFF,
         headers={
-            "Authorization": f"Bearer {SERVICE_ROLE_JWT}",
+            "Authorization": f"Bearer {SECRET_KEY_JWT}",
         },
     )

--- a/src/auth/tests/_sync/test_gotrue_admin_api.py
+++ b/src/auth/tests/_sync/test_gotrue_admin_api.py
@@ -17,7 +17,7 @@ from .clients import (
     mock_user_credentials,
     mock_user_metadata,
     mock_verification_otp,
-    service_role_api_client,
+    secret_key_api_client,
 )
 
 
@@ -30,7 +30,7 @@ def test_create_user_should_create_a_new_user() -> None:
 def test_create_user_with_user_metadata() -> None:
     user_metadata = mock_user_metadata()
     credentials = mock_user_credentials()
-    response = service_role_api_client().create_user(
+    response = secret_key_api_client().create_user(
         {
             "email": credentials.email,
             "password": credentials.password,
@@ -46,7 +46,7 @@ def test_create_user_with_user_and_app_metadata() -> None:
     user_metadata = mock_user_metadata()
     app_metadata = mock_app_metadata()
     credentials = mock_user_credentials()
-    response = service_role_api_client().create_user(
+    response = secret_key_api_client().create_user(
         {
             "email": credentials.email,
             "password": credentials.password,
@@ -63,7 +63,7 @@ def test_create_user_with_user_and_app_metadata() -> None:
 def test_list_users_should_return_registered_users() -> None:
     credentials = mock_user_credentials()
     create_new_user_with_email(email=credentials.email)
-    users = service_role_api_client().list_users()
+    users = secret_key_api_client().list_users()
     assert users
     emails = [user.email for user in users]
     assert emails
@@ -74,14 +74,14 @@ def test_get_user_by_id_should_a_registered_user_given_its_user_identifier() -> 
     credentials = mock_user_credentials()
     user = create_new_user_with_email(email=credentials.email)
     assert user.id
-    response = service_role_api_client().get_user_by_id(user.id)
+    response = secret_key_api_client().get_user_by_id(user.id)
     assert response.user.email == credentials.email
 
 
 def test_modify_email_using_update_user_by_id() -> None:
     credentials = mock_user_credentials()
     user = create_new_user_with_email(email=credentials.email)
-    response = service_role_api_client().update_user_by_id(
+    response = secret_key_api_client().update_user_by_id(
         user.id,
         {
             "email": f"new_{user.email}",
@@ -94,7 +94,7 @@ def test_modify_user_metadata_using_update_user_by_id() -> None:
     credentials = mock_user_credentials()
     user = create_new_user_with_email(email=credentials.email)
     user_metadata = {"favorite_color": "yellow"}
-    response = service_role_api_client().update_user_by_id(
+    response = secret_key_api_client().update_user_by_id(
         user.id,
         {
             "user_metadata": user_metadata,
@@ -108,7 +108,7 @@ def test_modify_app_metadata_using_update_user_by_id() -> None:
     credentials = mock_user_credentials()
     user = create_new_user_with_email(email=credentials.email)
     app_metadata = {"roles": ["admin", "publisher"]}
-    response = service_role_api_client().update_user_by_id(
+    response = secret_key_api_client().update_user_by_id(
         user.id,
         {
             "app_metadata": app_metadata,
@@ -128,7 +128,7 @@ def test_modify_confirm_email_using_update_user_by_id() -> None:
     )
     assert response.user
     assert not response.user.email_confirmed_at
-    auth_response = service_role_api_client().update_user_by_id(
+    auth_response = secret_key_api_client().update_user_by_id(
         response.user.id,
         {
             "email_confirm": True,
@@ -224,8 +224,8 @@ def test_sign_in_anonymously() -> None:
 def test_delete_user_should_be_able_delete_an_existing_user() -> None:
     credentials = mock_user_credentials()
     user = create_new_user_with_email(email=credentials.email)
-    service_role_api_client().delete_user(user.id)
-    users = service_role_api_client().list_users()
+    secret_key_api_client().delete_user(user.id)
+    users = secret_key_api_client().list_users()
     emails = [user.email for user in users]
     assert credentials.email not in emails
 
@@ -236,7 +236,7 @@ def test_generate_link_supports_sign_up_with_generate_confirmation_signup_link()
     credentials = mock_user_credentials()
     redirect_to = "http://localhost:9999/welcome"
     user_metadata = {"status": "alpha"}
-    response = service_role_api_client().generate_link(
+    response = secret_key_api_client().generate_link(
         {
             "type": "signup",
             "email": credentials.email,
@@ -259,7 +259,7 @@ def test_generate_link_supports_updating_emails_with_generate_email_change_links
     assert user.email == credentials.email
     credentials = mock_user_credentials()
     redirect_to = "http://localhost:9999/welcome"
-    response = service_role_api_client().generate_link(
+    response = secret_key_api_client().generate_link(
         {
             "type": "email_change_current",
             "email": user.email,
@@ -276,7 +276,7 @@ def test_invite_user_by_email_creates_a_new_user_with_an_invited_at_timestamp() 
     credentials = mock_user_credentials()
     redirect_to = "http://localhost:9999/welcome"
     user_metadata = {"status": "alpha"}
-    response = service_role_api_client().invite_user_by_email(
+    response = secret_key_api_client().invite_user_by_email(
         credentials.email,
         {
             "data": user_metadata,
@@ -296,12 +296,12 @@ def test_sign_out_with_an_valid_access_token() -> None:
         },
     )
     assert response.session
-    service_role_api_client().sign_out(response.session.access_token)
+    secret_key_api_client().sign_out(response.session.access_token)
 
 
 def test_sign_out_with_an_invalid_access_token() -> None:
     try:
-        service_role_api_client().sign_out("this-is-a-bad-token")
+        secret_key_api_client().sign_out("this-is-a-bad-token")
         raise AssertionError()
     except AuthError:
         pass
@@ -523,7 +523,7 @@ def test_update_user() -> None:
 def test_create_user_with_app_metadata() -> None:
     app_metadata = mock_app_metadata()
     credentials = mock_user_credentials()
-    response = service_role_api_client().create_user(
+    response = secret_key_api_client().create_user(
         {
             "email": credentials.email,
             "password": credentials.password,
@@ -594,7 +594,7 @@ def test_admin_list_factors() -> None:
             "code": totp.now(),
         }
     )
-    admin_client = service_role_api_client()
+    admin_client = secret_key_api_client()
     factors = admin_client.mfa.list_factors(
         {
             "user_id": res.user.id,
@@ -615,7 +615,7 @@ def test_admin_list_factors() -> None:
 
 def test_create_oauth_client() -> None:
     """Test creating an OAuth client."""
-    response = service_role_api_client().oauth.create_client(
+    response = secret_key_api_client().oauth.create_client(
         CreateOAuthClientParams(
             client_name="Test OAuth Client",
             redirect_uris=["https://example.com/callback"],
@@ -628,7 +628,7 @@ def test_create_oauth_client() -> None:
 
 def test_list_oauth_clients() -> None:
     """Test listing OAuth clients."""
-    client = service_role_api_client()
+    client = secret_key_api_client()
     client.oauth.create_client(
         CreateOAuthClientParams(
             client_name="Test OAuth Client",
@@ -644,7 +644,7 @@ def test_list_oauth_clients() -> None:
 def test_get_oauth_client() -> None:
     """Test getting an OAuth client by ID."""
     # First create a client
-    create_response = service_role_api_client().oauth.create_client(
+    create_response = secret_key_api_client().oauth.create_client(
         CreateOAuthClientParams(
             client_name="Test OAuth Client for Get",
             redirect_uris=["https://example.com/callback"],
@@ -652,7 +652,7 @@ def test_get_oauth_client() -> None:
     )
     if create_response.client:
         client_id = create_response.client.client_id
-        response = service_role_api_client().oauth.get_client(client_id)
+        response = secret_key_api_client().oauth.get_client(client_id)
         assert response.client is not None
         assert response.client.client_id == client_id
 
@@ -661,7 +661,7 @@ def test_get_oauth_client() -> None:
 def test_update_oauth_client() -> None:
     """Test updating an OAuth client."""
     # First create a client
-    client = service_role_api_client()
+    client = secret_key_api_client()
     create_response = client.oauth.create_client(
         CreateOAuthClientParams(
             client_name="Test OAuth Client for Update",
@@ -683,7 +683,7 @@ def test_update_oauth_client() -> None:
 def test_delete_oauth_client() -> None:
     """Test deleting an OAuth client."""
     # First create a client
-    client = service_role_api_client()
+    client = secret_key_api_client()
     create_response = client.oauth.create_client(
         CreateOAuthClientParams(
             client_name="Test OAuth Client for Delete",
@@ -698,7 +698,7 @@ def test_delete_oauth_client() -> None:
 def test_regenerate_oauth_client_secret() -> None:
     """Test regenerating an OAuth client secret."""
     # First create a client
-    create_response = service_role_api_client().oauth.create_client(
+    create_response = secret_key_api_client().oauth.create_client(
         CreateOAuthClientParams(
             client_name="Test OAuth Client for Regenerate",
             redirect_uris=["https://example.com/callback"],
@@ -706,6 +706,6 @@ def test_regenerate_oauth_client_secret() -> None:
     )
     if create_response.client:
         client_id = create_response.client.client_id
-        response = service_role_api_client().oauth.regenerate_client_secret(client_id)
+        response = secret_key_api_client().oauth.regenerate_client_secret(client_id)
         assert response.client is not None
         assert response.client.client_secret is not None

--- a/src/functions/README.md
+++ b/src/functions/README.md
@@ -29,7 +29,7 @@ from supabase_functions import AsyncFunctionsClient
 async def run_func():
     # Initialize the client with your project URL and optional headers
     headers = {
-        "Authorization": "Bearer your-anon-key",
+        "Authorization": "Bearer your-publishable-key",
         # Add any other headers you might need
     }
     
@@ -53,7 +53,7 @@ if __name__ == "__main__":
 from supabase_functions import SyncFunctionsClient
 
 # Initialize the client
-headers = {"Authorization": "Bearer your-anon-key"}
+headers = {"Authorization": "Bearer your-publishable-key"}
 fc = SyncFunctionsClient("https://<project_ref>.functions.supabase.co", headers)
 
 # Invoke your Edge Function

--- a/src/realtime/tests/test_connection.py
+++ b/src/realtime/tests/test_connection.py
@@ -21,8 +21,8 @@ load_dotenv()
 
 
 URL = os.getenv("SUPABASE_URL") or "http://127.0.0.1:54321"
-ANON_KEY = (
-    os.getenv("SUPABASE_ANON_KEY")
+PUBLISHABLE_KEY = (
+    os.getenv("SUPABASE_PUBLISHABLE_KEY")
     or "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0"
 )
 
@@ -30,7 +30,7 @@ ANON_KEY = (
 @pytest.fixture
 def socket() -> AsyncRealtimeClient:
     url = f"{URL}/realtime/v1"
-    key = ANON_KEY
+    key = PUBLISHABLE_KEY
     return AsyncRealtimeClient(url, key)
 
 
@@ -44,7 +44,7 @@ class SignupMessageResponse(BaseModel):
 
 async def access_token() -> str:
     url = f"{URL}/auth/v1/signup"
-    headers = {"apikey": ANON_KEY, "Content-Type": "application/json"}
+    headers = {"apikey": PUBLISHABLE_KEY, "Content-Type": "application/json"}
     data = {
         "email": os.getenv("SUPABASE_TEST_EMAIL")
         or f"test_{datetime.datetime.now().strftime('%Y%m%d%H%M%S.%f')}@example.com",
@@ -66,12 +66,12 @@ async def access_token() -> str:
 
 
 def test_init_client():
-    client = AsyncRealtimeClient(URL, ANON_KEY)
+    client = AsyncRealtimeClient(URL, PUBLISHABLE_KEY)
 
     assert client is not None
     assert client.url.startswith("ws://") or client.url.startswith("wss://")
     assert "/websocket" in client.url
-    assert client.url.split("apikey=")[1] == ANON_KEY
+    assert client.url.split("apikey=")[1] == PUBLISHABLE_KEY
     assert client.auto_reconnect is True
     assert client.params == {}
     assert client.hb_interval == DEFAULT_HEARTBEAT_INTERVAL
@@ -317,7 +317,7 @@ class CreateTodoResponse(BaseModel):
 async def create_todo(access_token: str, todo: dict) -> str:
     url = f"{URL}/rest/v1/todos?select=id"
     headers = {
-        "apikey": ANON_KEY,
+        "apikey": PUBLISHABLE_KEY,
         "Authorization": f"Bearer {access_token}",
         "Content-Type": "application/json",
         "Accept": "application/vnd.pgrst.object+json",
@@ -339,7 +339,7 @@ async def create_todo(access_token: str, todo: dict) -> str:
 async def update_todo(access_token: str, id: str, todo: dict):
     url = f"{URL}/rest/v1/todos?id=eq.{id}"
     headers = {
-        "apikey": ANON_KEY,
+        "apikey": PUBLISHABLE_KEY,
         "Authorization": f"Bearer {access_token}",
         "Content-Type": "application/json",
     }
@@ -357,7 +357,7 @@ class CreateMsgResponse(BaseModel):
 async def create_message(access_token: str, message: dict) -> int:
     url = f"{URL}/rest/v1/messages?select=id"
     headers = {
-        "apikey": ANON_KEY,
+        "apikey": PUBLISHABLE_KEY,
         "Authorization": f"Bearer {access_token}",
         "Content-Type": "application/json",
         "Accept": "application/vnd.pgrst.object+json",
@@ -379,7 +379,7 @@ async def create_message(access_token: str, message: dict) -> int:
 async def delete_todo(access_token: str, id: str):
     url = f"{URL}/rest/v1/todos?id=eq.{id}"
     headers = {
-        "apikey": ANON_KEY,
+        "apikey": PUBLISHABLE_KEY,
         "Authorization": f"Bearer {access_token}",
         "Content-Type": "application/json",
     }

--- a/src/realtime/tests/test_presence.py
+++ b/src/realtime/tests/test_presence.py
@@ -12,8 +12,8 @@ from realtime.types import ChannelStates, Presence, RawPresenceState
 load_dotenv()
 
 URL = os.getenv("SUPABASE_URL") or "http://127.0.0.1:54321"
-ANON_KEY = (
-    os.getenv("SUPABASE_ANON_KEY")
+PUBLISHABLE_KEY = (
+    os.getenv("SUPABASE_PUBLISHABLE_KEY")
     or "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0"
 )
 
@@ -21,7 +21,7 @@ ANON_KEY = (
 @pytest.fixture
 def socket() -> AsyncRealtimeClient:
     url = f"{URL}/realtime/v1"
-    return AsyncRealtimeClient(url, ANON_KEY)
+    return AsyncRealtimeClient(url, PUBLISHABLE_KEY)
 
 
 @pytest.mark.asyncio
@@ -218,7 +218,7 @@ async def test_presence_enabled_when_callbacks_attached() -> None:
     """Test that presence.enabled is set correctly based on callback attachment."""
     from unittest.mock import AsyncMock, Mock
 
-    socket = AsyncRealtimeClient(f"{URL}/realtime/v1", ANON_KEY)
+    socket = AsyncRealtimeClient(f"{URL}/realtime/v1", PUBLISHABLE_KEY)
     channel = socket.channel("test")
 
     # Mock the join_push to capture the payload
@@ -255,7 +255,7 @@ async def test_resubscribe_on_presence_callback_addition() -> None:
     import asyncio
     from unittest.mock import AsyncMock
 
-    socket = AsyncRealtimeClient(f"{URL}/realtime/v1", ANON_KEY)
+    socket = AsyncRealtimeClient(f"{URL}/realtime/v1", PUBLISHABLE_KEY)
     channel = socket.channel("test")
 
     # Mock the channel as joined


### PR DESCRIPTION
## Summary

Aligns the codebase terminology with Supabase's updated API key naming conventions:

- **anon key** → **publishable key**
- **service role key** → **secret key**

## Changes

| File | Change |
|------|--------|
| `src/functions/README.md` | Update example Bearer token placeholder from `your-anon-key` to `your-publishable-key` |
| `src/realtime/tests/test_connection.py` | Rename `ANON_KEY` → `PUBLISHABLE_KEY`, `SUPABASE_ANON_KEY` → `SUPABASE_PUBLISHABLE_KEY` |
| `src/realtime/tests/test_presence.py` | Same as above |
| `src/auth/tests/_async/clients.py` | Rename `SERVICE_ROLE_JWT` → `SECRET_KEY_JWT`, `service_role_api_client*` → `secret_key_api_client*`; fix mock JWT role from `"anon_key"` to the correct GoTrue value `"anon"` |
| `src/auth/tests/_sync/clients.py` | Same as above |
| `src/auth/tests/_async/test_gotrue_admin_api.py` | Update import and all usages of renamed helper functions |
| `src/auth/tests/_sync/test_gotrue_admin_api.py` | Same as above |
| `src/auth/src/supabase_auth/_async/gotrue_admin_api.py` | Update docstrings: `service_role key` → `secret key` |
| `src/auth/src/supabase_auth/_sync/gotrue_admin_api.py` | Same as above |
| `src/auth/src/supabase_auth/_async/gotrue_admin_oauth_api.py` | Same as above |
| `src/auth/src/supabase_auth/_sync/gotrue_admin_oauth_api.py` | Same as above |

## Notes for reviewers

- The internal GoTrue JWT role claim values (`"anon"`, `"service_role"`) embedded in JWT payloads were **not** changed — those are server-side values the auth system relies on.
- The mock JWT role `"anon_key"` in the test clients was also corrected to `"anon"` (the actual GoTrue role name) as a bonus fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)