### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* o-santi @supabase/sdk


### PR DESCRIPTION
## Summary

- Adds `.github/CODEOWNERS` assigning `o-santi` and `@supabase/sdk` as codeowners for all files (`*`).

## Reviewer notes

This mirrors the pattern used in [supabase-js](https://github.com/supabase/supabase-js/blob/develop/CODEOWNERS) but simplified to a single catch-all rule without per-package ownership.