### PR TITLE
feat(auth): add current_password to UserAttributes

### DIFF
--- a/src/auth/src/supabase_auth/types.py
+++ b/src/auth/src/supabase_auth/types.py
@@ -247,6 +247,7 @@ class UserAttributes(TypedDict):
     password: NotRequired[str]
     data: NotRequired[Any]
     nonce: NotRequired[str]
+    current_password: NotRequired[str]
 
 
 class AdminUserAttributes(UserAttributes, TypedDict):

--- a/src/auth/tests/test_helpers.py
+++ b/src/auth/tests/test_helpers.py
@@ -9,7 +9,6 @@ from pydantic import BaseModel
 from supabase_auth.constants import (
     API_VERSION_HEADER_NAME,
 )
-from supabase_auth.types import UserAttributes
 from supabase_auth.errors import (
     AuthApiError,
     AuthInvalidJwtError,
@@ -384,17 +383,3 @@ def test_handle_exception_weak_password_branch() -> None:
         assert isinstance(result, AuthWeakPasswordError)
         assert result.message == "Password too weak"
         assert result.status == 400
-
-
-def test_user_attributes_current_password_field() -> None:
-    attrs: UserAttributes = {
-        "email": "user@example.com",
-        "password": "newpassword",
-        "current_password": "oldpassword",
-    }
-    assert attrs["current_password"] == "oldpassword"
-
-
-def test_user_attributes_current_password_is_optional() -> None:
-    attrs: UserAttributes = {"email": "user@example.com"}
-    assert "current_password" not in attrs

--- a/src/auth/tests/test_helpers.py
+++ b/src/auth/tests/test_helpers.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel
 from supabase_auth.constants import (
     API_VERSION_HEADER_NAME,
 )
+from supabase_auth.types import UserAttributes
 from supabase_auth.errors import (
     AuthApiError,
     AuthInvalidJwtError,
@@ -383,3 +384,17 @@ def test_handle_exception_weak_password_branch() -> None:
         assert isinstance(result, AuthWeakPasswordError)
         assert result.message == "Password too weak"
         assert result.status == 400
+
+
+def test_user_attributes_current_password_field() -> None:
+    attrs: UserAttributes = {
+        "email": "user@example.com",
+        "password": "newpassword",
+        "current_password": "oldpassword",
+    }
+    assert attrs["current_password"] == "oldpassword"
+
+
+def test_user_attributes_current_password_is_optional() -> None:
+    attrs: UserAttributes = {"email": "user@example.com"}
+    assert "current_password" not in attrs


### PR DESCRIPTION
## Summary

Adds `current_password` (Optional[str]) to the `UserAttributes` TypedDict for parity with supabase-js, which added `currentPassword` in [PR #2131](https://github.com/supabase/supabase-js/pull/2131). This field is used to verify the user's current password when changing it via `update_user`.

## Changes

- **`supabase_auth/types.py`**: Added `current_password: NotRequired[str]` to `UserAttributes` TypedDict
- **`tests/test_helpers.py`**: Added two unit tests verifying the field is accessible and optional

## Testing

### Test Coverage
- `test_user_attributes_current_password_field` — verifies the field can be set and read
- `test_user_attributes_current_password_is_optional` — verifies absence when not provided
- All 24 tests pass

## Acceptance Criteria

- [x] `current_password` field added to `UserAttributes`
- [x] Field is optional (`NotRequired[str]`)
- [x] No breaking changes to existing API
- [x] Type hints updated

## Linear Issue

Closes: [SDK-759](https://linear.app/supabase/issue/SDK-759/parityauth-add-currentpassword-to-userattributes-from-supabase-js)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) `/take`