### PR TITLE
chore: add missing @ prefix to o-santi in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* o-santi @supabase/sdk
+* @o-santi @supabase/sdk


### PR DESCRIPTION
## What changed

Added the missing `@` prefix to `o-santi` in `.github/CODEOWNERS`. Without it, GitHub does not recognize the handle as a valid owner and won't request reviews from that user.

## Before

```
* o-santi @supabase/sdk
```

## After

```
* @o-santi @supabase/sdk
```