### PR TITLE
fix(postgrest): serialize generated typed dict payloads (#1443)

### DIFF
--- a/src/postgrest/src/postgrest/_async/request_builder.py
+++ b/src/postgrest/src/postgrest/_async/request_builder.py
@@ -23,7 +23,7 @@ from ..base_request_builder import (
     pre_upsert,
 )
 from ..exceptions import APIError, APIErrorFromJSON, generate_default_error_message
-from ..types import JSON, ReturnMethod
+from ..types import ReturnMethod, WriteJSON
 from ..utils import model_validate_json
 
 ReqConfig = RequestConfig[AsyncClient]
@@ -326,7 +326,7 @@ class AsyncRequestBuilder:  #
 
     def insert(
         self,
-        json: JSON,
+        json: WriteJSON,
         *,
         count: Optional[CountMethod] = None,
         returning: ReturnMethod = ReturnMethod.representation,
@@ -367,7 +367,7 @@ class AsyncRequestBuilder:  #
 
     def upsert(
         self,
-        json: JSON,
+        json: WriteJSON,
         *,
         count: Optional[CountMethod] = None,
         returning: ReturnMethod = ReturnMethod.representation,
@@ -412,7 +412,7 @@ class AsyncRequestBuilder:  #
 
     def update(
         self,
-        json: JSON,
+        json: WriteJSON,
         *,
         count: Optional[CountMethod] = None,
         returning: ReturnMethod = ReturnMethod.representation,

--- a/src/postgrest/src/postgrest/_sync/request_builder.py
+++ b/src/postgrest/src/postgrest/_sync/request_builder.py
@@ -23,7 +23,7 @@ from ..base_request_builder import (
     pre_upsert,
 )
 from ..exceptions import APIError, APIErrorFromJSON, generate_default_error_message
-from ..types import JSON, ReturnMethod
+from ..types import ReturnMethod, WriteJSON
 from ..utils import model_validate_json
 
 ReqConfig = RequestConfig[Client]
@@ -326,7 +326,7 @@ class SyncRequestBuilder:  #
 
     def insert(
         self,
-        json: JSON,
+        json: WriteJSON,
         *,
         count: Optional[CountMethod] = None,
         returning: ReturnMethod = ReturnMethod.representation,
@@ -367,7 +367,7 @@ class SyncRequestBuilder:  #
 
     def upsert(
         self,
-        json: JSON,
+        json: WriteJSON,
         *,
         count: Optional[CountMethod] = None,
         returning: ReturnMethod = ReturnMethod.representation,
@@ -412,7 +412,7 @@ class SyncRequestBuilder:  #
 
     def update(
         self,
-        json: JSON,
+        json: WriteJSON,
         *,
         count: Optional[CountMethod] = None,
         returning: ReturnMethod = ReturnMethod.representation,

--- a/src/postgrest/src/postgrest/base_request_builder.py
+++ b/src/postgrest/src/postgrest/base_request_builder.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import sys
+from datetime import date, datetime, time
 from json import JSONDecodeError
 from re import search
 from typing import (
@@ -20,6 +21,7 @@ from typing import (
     Union,
     overload,
 )
+from uuid import UUID
 
 from httpx import AsyncClient, BasicAuth, Client, Headers, QueryParams
 from httpx import Response as RequestResponse
@@ -39,8 +41,36 @@ except ImportError:
     from pydantic import validator as field_validator  # type: ignore
 
 from .base_client import BasePostgrestClient
-from .types import JSON, CountMethod, Filters, JSONAdapter, RequestMethod, ReturnMethod
+from .types import (
+    JSON,
+    CountMethod,
+    Filters,
+    JSONAdapter,
+    RequestMethod,
+    ReturnMethod,
+    WriteJSON,
+)
 from .utils import sanitize_param
+
+
+def _request_json_default(value: Any) -> str:
+    if isinstance(value, UUID):
+        return str(value)
+    if isinstance(value, (datetime, date, time)):
+        return value.isoformat()
+    raise TypeError(
+        f"Object of type {value.__class__.__name__} is not JSON serializable"
+    )
+
+
+def _request_json_content(value: object) -> bytes:
+    return json.dumps(
+        value,
+        default=_request_json_default,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
 
 
 class QueryArgs(NamedTuple):
@@ -48,7 +78,7 @@ class QueryArgs(NamedTuple):
     method: RequestMethod
     params: QueryParams
     headers: Headers
-    json: JSON
+    json: object
 
 
 C = TypeVar("C", Client, AsyncClient)
@@ -64,7 +94,7 @@ class RequestConfig(Generic[C]):
         headers: Headers,
         params: QueryParams,
         auth: BasicAuth | None,
-        json: JSON,
+        json: object,
         retry_enabled: bool = True,
     ) -> None:
         self.session: C = session
@@ -87,6 +117,17 @@ class RequestConfig(Generic[C]):
 
     def send(self: RequestConfig[C], additional_headers: Headers):
         additional_headers.update(self.headers)
+        if self.json is not None:
+            if "content-type" not in additional_headers:
+                additional_headers["Content-Type"] = "application/json"
+            return self.session.request(
+                self.http_method,
+                str(self.path),
+                content=_request_json_content(self.json),
+                params=self.params,
+                headers=additional_headers,
+                auth=self.auth,
+            )
         return self.session.request(
             self.http_method,
             str(self.path),
@@ -141,7 +182,7 @@ def pre_select(
 
 
 def pre_insert(
-    json: JSON,
+    json: WriteJSON,
     *,
     count: Optional[CountMethod],
     returning: ReturnMethod,
@@ -164,7 +205,7 @@ def pre_insert(
 
 
 def pre_upsert(
-    json: JSON,
+    json: WriteJSON,
     *,
     count: Optional[CountMethod],
     returning: ReturnMethod,
@@ -190,7 +231,7 @@ def pre_upsert(
 
 
 def pre_update(
-    json: JSON,
+    json: WriteJSON,
     *,
     count: Optional[CountMethod],
     returning: ReturnMethod,

--- a/src/postgrest/src/postgrest/types.py
+++ b/src/postgrest/src/postgrest/types.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import sys
 from collections.abc import Mapping, Sequence
+from datetime import date, datetime, time
 from typing import Union
+from uuid import UUID
 
 from httpx import AsyncClient, BasicAuth, Client, Headers, QueryParams
 from pydantic import TypeAdapter
@@ -19,6 +21,14 @@ JSON = TypeAliasType(
     "JSON", "Union[None, bool, str, int, float, Sequence[JSON], Mapping[str, JSON]]"
 )
 JSONAdapter: TypeAdapter = TypeAdapter(JSON)
+RequestJSON = TypeAliasType(
+    "RequestJSON",
+    "Union[None, bool, str, int, float, UUID, datetime, date, time, Sequence[RequestJSON], Mapping[str, RequestJSON]]",
+)
+# TypedDict is exposed by type checkers as Mapping[str, object], so the object
+# fallback keeps generated row types assignable while runtime serialization
+# still rejects unsupported objects.
+WriteJSON = Union[Mapping[str, object], Sequence[Mapping[str, object]]]
 
 
 class CountMethod(StrEnum):

--- a/src/postgrest/tests/_async/test_request_builder.py
+++ b/src/postgrest/tests/_async/test_request_builder.py
@@ -1,13 +1,43 @@
+from datetime import date, datetime, time, timezone
 from typing import Any, AsyncIterable, Dict, List
+from uuid import UUID, uuid4
 
 import pytest
-from httpx import AsyncClient, Headers, QueryParams, Request, Response
+from httpx import AsyncClient, Headers, MockTransport, QueryParams, Request, Response
+from typing_extensions import TypedDict
 from yarl import URL
 
 from postgrest import AsyncRequestBuilder, AsyncSingleRequestBuilder
 from postgrest._async.request_builder import RequestConfig
 from postgrest.base_request_builder import APIResponse, SingleAPIResponse
 from postgrest.types import JSON, CountMethod, ReturnMethod
+
+
+class GeneratedMovieInsert(TypedDict):
+    id: UUID
+    created_at: datetime
+    release_date: date
+    starts_at: time
+    name: str
+
+
+def generated_movie_payload() -> tuple[GeneratedMovieInsert, bytes]:
+    inserted_id = uuid4()
+    payload: GeneratedMovieInsert = {
+        "id": inserted_id,
+        "created_at": datetime(2026, 4, 6, 12, 30, tzinfo=timezone.utc),
+        "release_date": date(2026, 4, 6),
+        "starts_at": time(12, 30),
+        "name": "Inception",
+    }
+    expected_content = (
+        b'{"id":"'
+        + str(inserted_id).encode()
+        + b'","created_at":"2026-04-06T12:30:00+00:00",'
+        + b'"release_date":"2026-04-06","starts_at":"12:30:00",'
+        + b'"name":"Inception"}'
+    )
+    return payload, expected_content
 
 
 @pytest.fixture
@@ -158,6 +188,48 @@ class TestInsert:
             '"key1","key2","key3"'.split(",")
         )
 
+    async def test_insert_serializes_generated_typeddict_values(self):
+        payload, expected_content = generated_movie_payload()
+
+        async def handler(request: Request) -> Response:
+            assert request.headers["content-type"] == "application/json"
+            assert request.headers["content-length"] == str(len(request.content))
+            assert request.content == expected_content
+            return Response(201, json=[{"id": str(payload["id"])}], request=request)
+
+        async with AsyncClient(transport=MockTransport(handler)) as client:
+            builder = AsyncRequestBuilder(
+                client,
+                URL("https://example.supabase.co/rest/v1/movies"),
+                Headers(),
+                None,
+            )
+
+            response = await builder.insert(payload).execute()
+
+        assert response.data == [{"id": str(payload["id"])}]
+
+    async def test_upsert_serializes_generated_typeddict_values(self):
+        payload, expected_content = generated_movie_payload()
+
+        async def handler(request: Request) -> Response:
+            assert request.headers["content-type"] == "application/json"
+            assert request.headers["content-length"] == str(len(request.content))
+            assert request.content == expected_content
+            return Response(201, json=[{"id": str(payload["id"])}], request=request)
+
+        async with AsyncClient(transport=MockTransport(handler)) as client:
+            builder = AsyncRequestBuilder(
+                client,
+                URL("https://example.supabase.co/rest/v1/movies"),
+                Headers(),
+                None,
+            )
+
+            response = await builder.upsert(payload).execute()
+
+        assert response.data == [{"id": str(payload["id"])}]
+
 
 class TestUpdate:
     def test_update(self, request_builder: AsyncRequestBuilder):
@@ -193,6 +265,29 @@ class TestUpdate:
 
         assert builder.request.params["id"] == "eq.1"
         assert builder.request.params["select"] == "id"
+
+    async def test_update_serializes_generated_typeddict_values(self):
+        payload, expected_content = generated_movie_payload()
+
+        async def handler(request: Request) -> Response:
+            assert request.headers["content-type"] == "application/json"
+            assert request.headers["content-length"] == str(len(request.content))
+            assert request.content == expected_content
+            return Response(200, json=[{"id": str(payload["id"])}], request=request)
+
+        async with AsyncClient(transport=MockTransport(handler)) as client:
+            builder = AsyncRequestBuilder(
+                client,
+                URL("https://example.supabase.co/rest/v1/movies"),
+                Headers(),
+                None,
+            )
+
+            response = (
+                await builder.update(payload).eq("id", str(payload["id"])).execute()
+            )
+
+        assert response.data == [{"id": str(payload["id"])}]
 
 
 class TestDelete:

--- a/src/postgrest/tests/_sync/test_request_builder.py
+++ b/src/postgrest/tests/_sync/test_request_builder.py
@@ -1,13 +1,44 @@
+from datetime import date, datetime, time, timezone
+from math import nan
 from typing import Any, Dict, Iterable, List
+from uuid import UUID, uuid4
 
 import pytest
-from httpx import Client, Headers, QueryParams, Request, Response
+from httpx import Client, Headers, MockTransport, QueryParams, Request, Response
+from typing_extensions import TypedDict
 from yarl import URL
 
 from postgrest import SyncRequestBuilder, SyncSingleRequestBuilder
 from postgrest._async.request_builder import RequestConfig
 from postgrest.base_request_builder import APIResponse, SingleAPIResponse
 from postgrest.types import JSON, CountMethod, ReturnMethod
+
+
+class GeneratedMovieInsert(TypedDict):
+    id: UUID
+    created_at: datetime
+    release_date: date
+    starts_at: time
+    name: str
+
+
+def generated_movie_payload() -> tuple[GeneratedMovieInsert, bytes]:
+    inserted_id = uuid4()
+    payload: GeneratedMovieInsert = {
+        "id": inserted_id,
+        "created_at": datetime(2026, 4, 6, 12, 30, tzinfo=timezone.utc),
+        "release_date": date(2026, 4, 6),
+        "starts_at": time(12, 30),
+        "name": "Inception",
+    }
+    expected_content = (
+        b'{"id":"'
+        + str(inserted_id).encode()
+        + b'","created_at":"2026-04-06T12:30:00+00:00",'
+        + b'"release_date":"2026-04-06","starts_at":"12:30:00",'
+        + b'"name":"Inception"}'
+    )
+    return payload, expected_content
 
 
 @pytest.fixture
@@ -158,6 +189,113 @@ class TestInsert:
             '"key1","key2","key3"'.split(",")
         )
 
+    def test_insert_accepts_generated_typeddict_with_datetime_and_uuid(
+        self, request_builder: SyncRequestBuilder
+    ):
+        payload: GeneratedMovieInsert = {
+            "id": uuid4(),
+            "created_at": datetime(2026, 4, 6, 12, 30, tzinfo=timezone.utc),
+            "release_date": date(2026, 4, 6),
+            "starts_at": time(12, 30),
+            "name": "Inception",
+        }
+
+        builder = request_builder.insert(payload)
+
+        assert builder.request.json == payload
+
+    def test_insert_serializes_generated_typeddict_values(self):
+        payload, expected_content = generated_movie_payload()
+
+        def handler(request: Request) -> Response:
+            assert request.headers["content-type"] == "application/json"
+            assert request.headers["content-length"] == str(len(request.content))
+            assert request.content == expected_content
+            return Response(201, json=[{"id": str(payload["id"])}], request=request)
+
+        with Client(transport=MockTransport(handler)) as client:
+            builder = SyncRequestBuilder(
+                client,
+                URL("https://example.supabase.co/rest/v1/movies"),
+                Headers(),
+                None,
+            )
+
+            response = builder.insert(payload).execute()
+
+        assert response.data == [{"id": str(payload["id"])}]
+
+    def test_upsert_serializes_generated_typeddict_values(self):
+        payload, expected_content = generated_movie_payload()
+
+        def handler(request: Request) -> Response:
+            assert request.headers["content-type"] == "application/json"
+            assert request.headers["content-length"] == str(len(request.content))
+            assert request.content == expected_content
+            return Response(201, json=[{"id": str(payload["id"])}], request=request)
+
+        with Client(transport=MockTransport(handler)) as client:
+            builder = SyncRequestBuilder(
+                client,
+                URL("https://example.supabase.co/rest/v1/movies"),
+                Headers(),
+                None,
+            )
+
+            response = builder.upsert(payload).execute()
+
+        assert response.data == [{"id": str(payload["id"])}]
+
+    def test_insert_preserves_existing_content_type(self):
+        payload = {"key1": "val1"}
+
+        def handler(request: Request) -> Response:
+            assert request.headers["content-type"] == "application/custom+json"
+            assert request.content == b'{"key1":"val1"}'
+            return Response(201, json=[payload], request=request)
+
+        with Client(transport=MockTransport(handler)) as client:
+            builder = SyncRequestBuilder(
+                client,
+                URL("https://example.supabase.co/rest/v1/movies"),
+                Headers({"Content-Type": "application/custom+json"}),
+                None,
+            )
+
+            response = builder.insert(payload).execute()
+
+        assert response.data == [payload]
+
+    def test_insert_rejects_non_finite_float(self):
+        def handler(request: Request) -> Response:
+            raise AssertionError("request should fail before reaching transport")
+
+        with Client(transport=MockTransport(handler)) as client:
+            builder = SyncRequestBuilder(
+                client,
+                URL("https://example.supabase.co/rest/v1/movies"),
+                Headers(),
+                None,
+            )
+
+            with pytest.raises(ValueError, match="Out of range float values"):
+                builder.insert({"value": nan}).execute()
+
+    def test_insert_rejects_unsupported_object(self):
+        def handler(request: Request) -> Response:
+            raise AssertionError("request should fail before reaching transport")
+
+        with Client(transport=MockTransport(handler)) as client:
+            builder = SyncRequestBuilder(
+                client,
+                URL("https://example.supabase.co/rest/v1/movies"),
+                Headers(),
+                None,
+            )
+
+            with pytest.raises(TypeError, match="Object of type object"):
+                builder.insert({"value": object()}).execute()
+
 
 class TestUpdate:
     def test_update(self, request_builder: SyncRequestBuilder):
@@ -193,6 +331,27 @@ class TestUpdate:
 
         assert builder.request.params["id"] == "eq.1"
         assert builder.request.params["select"] == "id"
+
+    def test_update_serializes_generated_typeddict_values(self):
+        payload, expected_content = generated_movie_payload()
+
+        def handler(request: Request) -> Response:
+            assert request.headers["content-type"] == "application/json"
+            assert request.headers["content-length"] == str(len(request.content))
+            assert request.content == expected_content
+            return Response(200, json=[{"id": str(payload["id"])}], request=request)
+
+        with Client(transport=MockTransport(handler)) as client:
+            builder = SyncRequestBuilder(
+                client,
+                URL("https://example.supabase.co/rest/v1/movies"),
+                Headers(),
+                None,
+            )
+
+            response = builder.update(payload).eq("id", str(payload["id"])).execute()
+
+        assert response.data == [{"id": str(payload["id"])}]
 
 
 class TestDelete:


### PR DESCRIPTION
## What kind of change does this PR introduce?
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Issue
Fixes #1443

## What is the current behavior?
Generated Python REST types can produce `TypedDict` write payloads with PostgreSQL-derived Python values such as `UUID`, `datetime`, `date`, and `time`.

The current `insert`, `upsert`, and `update` signatures only accept the recursive response `JSON` type, so generated `TypedDict` payloads are rejected by type checkers. Widening the annotation alone does not fix the runtime path because request execution still relies on stdlib JSON serialization through HTTPX, which raises `TypeError` for `UUID` and `datetime` values.

## What is the new behavior?
This PR keeps response `JSON` parsing strict and adds a separate write payload type for row-shaped request bodies.

Write methods now accept generated-style payloads, and PostgREST serializes supported generated values before sending the HTTP request body:

* `UUID` is serialized with `str(value)`.
* `datetime`, `date`, and `time` are serialized with `value.isoformat()`.
* Existing HTTPX JSON behavior is preserved: compact separators, UTF-8 output, `Content-Type: application/json` when absent, and `allow_nan=False`.

**Changes made:**
* Added `WriteJSON` for `Mapping[str, Any] | Sequence[Mapping[str, Any]]` write payloads.
* Updated sync and async `insert`, `upsert`, and `update` to use `WriteJSON`.
* Encoded request JSON in PostgREST before calling HTTPX so generated `TypedDict` values serialize correctly at runtime.
* Added sync and async tests for generated-style `TypedDict` payloads containing `UUID`, `datetime`, `date`, and `time`.
* Added coverage for preserving an existing `Content-Type` and rejecting non-finite floats.

## Verification
* `uv run --package postgrest mypy src/postgrest tests`
* `uv run --package postgrest pytest --cov=./ --cov-report=xml -vv` - 292 passed
* `uv run ruff check <touched files>`
* `uv run ruff format --check <touched files>`
* Pyright probe for generated-style `TypedDict` payloads - 0 errors

## Checklist:
- [x] I have read the [CONTRIBUTING](https://github.com/supabase/supabase-py/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.