### PR TITLE
Speed up postgrest JSON validation

### DIFF
--- a/src/postgrest/src/postgrest/types.py
+++ b/src/postgrest/src/postgrest/types.py
@@ -6,6 +6,7 @@ from typing import Union
 
 from httpx import AsyncClient, BasicAuth, Client, Headers, QueryParams
 from pydantic import TypeAdapter
+from pydantic.types import JsonValue
 from typing_extensions import TypeAliasType
 from yarl import URL
 
@@ -18,7 +19,7 @@ else:
 JSON = TypeAliasType(
     "JSON", "Union[None, bool, str, int, float, Sequence[JSON], Mapping[str, JSON]]"
 )
-JSONAdapter: TypeAdapter = TypeAdapter(JSON)
+JSONAdapter: TypeAdapter = TypeAdapter(JsonValue)
 
 
 class CountMethod(StrEnum):

--- a/src/postgrest/tests/test_types.py
+++ b/src/postgrest/tests/test_types.py
@@ -1,10 +1,11 @@
+from pydantic import TypeAdapter
+from pydantic.types import JsonValue
+
 from postgrest.types import JSONAdapter
 
 
-def test_json_adapter_uses_pydantic_json_value_schema():
-    assert JSONAdapter.core_schema["schema"]["schema_ref"].startswith(
-        "pydantic.types.JsonValue:"
-    )
+def test_json_adapter_schema_matches_pydantic_json_value():
+    assert JSONAdapter.core_schema == TypeAdapter(JsonValue).core_schema
 
 
 def test_json_adapter_validates_nested_json_bytes():

--- a/src/postgrest/tests/test_types.py
+++ b/src/postgrest/tests/test_types.py
@@ -1,0 +1,24 @@
+from postgrest.types import JSONAdapter
+
+
+def test_json_adapter_uses_pydantic_json_value_schema():
+    assert JSONAdapter.core_schema["schema"]["schema_ref"].startswith(
+        "pydantic.types.JsonValue:"
+    )
+
+
+def test_json_adapter_validates_nested_json_bytes():
+    payload = (
+        b'{"items":[{"id":1,"tags":["a","b"],'
+        b'"meta":{"score":0.9,"active":true,"note":null}}]}'
+    )
+
+    assert JSONAdapter.validate_json(payload) == {
+        "items": [
+            {
+                "id": 1,
+                "tags": ["a", "b"],
+                "meta": {"score": 0.9, "active": True, "note": None},
+            }
+        ]
+    }


### PR DESCRIPTION
Fixes #1486

## Summary
- switch `postgrest.types.JSONAdapter` to Pydantic's optimized `JsonValue` schema
- keep the public `JSON` type alias unchanged for request typing
- add regression coverage that guards the `JsonValue` adapter path and nested JSON byte validation

## Local validation
- Before fix benchmark from the issue payload: `JSONAdapter.validate_json(payload)` averaged `44.78 ms`; `TypeAdapter(JsonValue)` averaged `3.93 ms`
- After fix benchmark from the issue payload: `JSONAdapter.validate_json(payload)` averaged `3.56 ms`; `TypeAdapter(JsonValue)` averaged `3.74 ms`
- `uv run --project src/postgrest pytest src/postgrest/tests/test_types.py -q`
- `uv run --project src/postgrest pytest src/postgrest/tests/test_types.py src/postgrest/tests/test_utils.py src/postgrest/tests/_sync/test_request_builder.py src/postgrest/tests/_async/test_request_builder.py -q`
- `uv run --project src/postgrest ruff check src/postgrest/src/postgrest/types.py src/postgrest/tests/test_types.py`

## Notes
- I tried the full `src/postgrest/tests` suite locally, but it did not finish before the 4-minute timeout in my Windows environment. The targeted request-builder/type tests above completed successfully.
- `uv run --locked` currently reports that the existing workspace lockfile needs an update, so the PR intentionally does not include lockfile changes.