### PR TITLE
docs: fix GitHub Issues link in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ use GitHub pull requests for this purpose. After filing a pull request, please t
 
 Before opening a new issue or request, please take a moment to check the existing issues and discussions to see if your topic has already been addressed. This helps us avoid duplicate issues and keeps the conversation focused.
 
-Report all issues and file all feature requests through [GitHub Issues](./issues).
+Report all issues and file all feature requests through [GitHub Issues](https://github.com/supabase/supabase-py/issues).
 
 ## Create a pull request
 


### PR DESCRIPTION
## Summary

This PR fixes a broken GitHub Issues link in `CONTRIBUTING.md`.

The link currently points to `./issues`, which can resolve to a 404 page. It has been updated to the repository issues page:

`https://github.com/supabase/supabase-py/issues`

## Type of change

- Documentation-only change
- No code changes
- No dependency changes

## Validation

- Checked the diff
- Confirmed that only `CONTRIBUTING.md` was changed
- Ran `git diff --check`
- Docs build was previously checked: normal build passed, while `-W` failed due to existing unrelated documentation warnings