### PR TITLE
Accept native scalar values in PostgREST JSON

### DIFF
--- a/src/postgrest/src/postgrest/types.py
+++ b/src/postgrest/src/postgrest/types.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import sys
 from collections.abc import Mapping, Sequence
+from datetime import date, datetime, time
 from typing import Union
+from uuid import UUID
 
 from httpx import AsyncClient, BasicAuth, Client, Headers, QueryParams
 from pydantic import TypeAdapter
@@ -16,7 +18,8 @@ else:
 
 # https://docs.pydantic.dev/2.11/concepts/types/#named-recursive-types
 JSON = TypeAliasType(
-    "JSON", "Union[None, bool, str, int, float, Sequence[JSON], Mapping[str, JSON]]"
+    "JSON",
+    "Union[None, bool, str, int, float, date, datetime, time, UUID, Sequence[JSON], Mapping[str, JSON]]",
 )
 JSONAdapter: TypeAdapter = TypeAdapter(JSON)
 

--- a/src/postgrest/tests/test_types.py
+++ b/src/postgrest/tests/test_types.py
@@ -1,0 +1,20 @@
+from datetime import date, datetime, time, timezone
+from uuid import UUID
+
+from postgrest.types import JSONAdapter
+
+
+def test_json_adapter_accepts_python_serializable_scalars():
+    payload = {
+        "created_at": datetime(2026, 5, 21, 7, 30, tzinfo=timezone.utc),
+        "birthday": date(2026, 5, 21),
+        "starts_at": time(7, 30),
+        "user_id": UUID("12345678-1234-5678-1234-567812345678"),
+        "nested": [
+            {
+                "updated_at": datetime(2026, 5, 22, 7, 30, tzinfo=timezone.utc),
+            }
+        ],
+    }
+
+    assert JSONAdapter.validate_python(payload) == payload


### PR DESCRIPTION
Closes #1443

## Summary
- Extend the recursive PostgREST JSON type alias to accept Python native scalar values that generated Supabase types commonly include: date, datetime, time, and UUID.
- Add coverage for nested payloads containing those values.

## Verification
- ============================= test session starts ==============================
platform darwin -- Python 3.13.12, pytest-8.4.2, pluggy-1.6.0
rootdir: /Users/huly64/Documents/GITHUB_ISSUE_KILLER/upstreams/supabase-py/src/postgrest
configfile: pyproject.toml
plugins: anyio-4.11.0, cov-6.3.0, asyncio-1.0.0, depends-1.0.1
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 1 item

tests/test_types.py .                                                    [100%]

============================== 1 passed in 0.11s ===============================
- All checks passed!
- 