### PR TITLE
fix: narrow auth session lookup errors

### DIFF
--- a/src/supabase/src/supabase/_async/client.py
+++ b/src/supabase/src/supabase/_async/client.py
@@ -15,6 +15,7 @@ from realtime import AsyncRealtimeChannel, AsyncRealtimeClient, RealtimeChannelO
 from storage3 import AsyncStorageClient
 from storage3.constants import DEFAULT_TIMEOUT as DEFAULT_STORAGE_CLIENT_TIMEOUT
 from supabase_auth import AsyncMemoryStorage
+from supabase_auth.errors import AuthError
 from supabase_auth.types import AuthChangeEvent, Session
 from supabase_functions import AsyncFunctionsClient
 from yarl import URL
@@ -117,7 +118,7 @@ class AsyncClient:
                     if session
                     else None
                 )
-            except Exception:
+            except AuthError:
                 session_access_token = None
 
             client.options.headers.update(

--- a/src/supabase/src/supabase/_sync/client.py
+++ b/src/supabase/src/supabase/_sync/client.py
@@ -14,6 +14,7 @@ from realtime import RealtimeChannelOptions, SyncRealtimeChannel, SyncRealtimeCl
 from storage3 import SyncStorageClient
 from storage3.constants import DEFAULT_TIMEOUT as DEFAULT_STORAGE_CLIENT_TIMEOUT
 from supabase_auth import SyncMemoryStorage
+from supabase_auth.errors import AuthError
 from supabase_auth.types import AuthChangeEvent, Session
 from supabase_functions import SyncFunctionsClient
 from yarl import URL
@@ -116,7 +117,7 @@ class Client:
                     if session
                     else None
                 )
-            except Exception:
+            except AuthError:
                 session_access_token = None
 
             client.options.headers.update(

--- a/src/supabase/tests/_async/test_client.py
+++ b/src/supabase/tests/_async/test_client.py
@@ -6,6 +6,7 @@ import pytest
 from httpx import AsyncClient as AsyncHttpxClient
 from httpx import AsyncHTTPTransport, Limits, Timeout
 from supabase_auth import AsyncMemoryStorage
+from supabase_auth.errors import AuthSessionMissingError
 
 from supabase import (
     AsyncClient,
@@ -13,6 +14,7 @@ from supabase import (
     AsyncSupabaseException,
     create_async_client,
 )
+from supabase._async.auth_client import AsyncSupabaseAuthClient
 
 
 @pytest.mark.xfail(
@@ -77,6 +79,37 @@ async def test_uses_key_as_authorization_header_by_default() -> None:
 
     assert client.storage.session.headers.get("apiKey") == key
     assert client.storage.session.headers.get("Authorization") == f"Bearer {key}"
+
+
+async def test_create_ignores_expected_auth_session_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    url = os.environ["SUPABASE_TEST_URL"]
+    key = os.environ["SUPABASE_TEST_KEY"]
+
+    async def raise_auth_error(self: AsyncSupabaseAuthClient) -> None:
+        raise AuthSessionMissingError()
+
+    monkeypatch.setattr(AsyncSupabaseAuthClient, "get_session", raise_auth_error)
+
+    client = await create_async_client(url, key)
+
+    assert client.options.headers.get("Authorization") == f"Bearer {key}"
+
+
+async def test_create_propagates_unexpected_auth_session_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    url = os.environ["SUPABASE_TEST_URL"]
+    key = os.environ["SUPABASE_TEST_KEY"]
+
+    async def raise_runtime_error(self: AsyncSupabaseAuthClient) -> None:
+        raise RuntimeError("storage backend unavailable")
+
+    monkeypatch.setattr(AsyncSupabaseAuthClient, "get_session", raise_runtime_error)
+
+    with pytest.raises(RuntimeError, match="storage backend unavailable"):
+        await create_async_client(url, key)
 
 
 async def test_schema_update() -> None:

--- a/src/supabase/tests/_sync/test_client.py
+++ b/src/supabase/tests/_sync/test_client.py
@@ -6,6 +6,7 @@ import pytest
 from httpx import Client as SyncHttpxClient
 from httpx import HTTPTransport, Limits, Timeout
 from supabase_auth import SyncMemoryStorage
+from supabase_auth.errors import AuthSessionMissingError
 
 from supabase import (
     Client,
@@ -13,6 +14,7 @@ from supabase import (
     SyncSupabaseException,
     create_client,
 )
+from supabase._sync.auth_client import SyncSupabaseAuthClient
 
 
 @pytest.mark.xfail(
@@ -77,6 +79,35 @@ def test_uses_key_as_authorization_header_by_default() -> None:
 
     assert client.storage.session.headers.get("apiKey") == key
     assert client.storage.session.headers.get("Authorization") == f"Bearer {key}"
+
+
+def test_create_ignores_expected_auth_session_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    url = os.environ["SUPABASE_TEST_URL"]
+    key = os.environ["SUPABASE_TEST_KEY"]
+
+    def raise_auth_error(self: SyncSupabaseAuthClient) -> None:
+        raise AuthSessionMissingError()
+
+    monkeypatch.setattr(SyncSupabaseAuthClient, "get_session", raise_auth_error)
+
+    client = create_client(url, key)
+
+    assert client.options.headers.get("Authorization") == f"Bearer {key}"
+
+
+def test_create_propagates_unexpected_auth_session_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    url = os.environ["SUPABASE_TEST_URL"]
+    key = os.environ["SUPABASE_TEST_KEY"]
+
+    def raise_runtime_error(self: SyncSupabaseAuthClient) -> None:
+        raise RuntimeError("storage backend unavailable")
+
+    monkeypatch.setattr(SyncSupabaseAuthClient, "get_session", raise_runtime_error)
+
+    with pytest.raises(RuntimeError, match="storage backend unavailable"):
+        create_client(url, key)
 
 
 def test_schema_update() -> None:


### PR DESCRIPTION
## What changed

- Narrows the startup auth session lookup fallback from `Exception` to `AuthError` for sync and async Supabase clients.
- Keeps expected auth/session failures on the existing anon-key fallback path.
- Lets unexpected failures, such as storage/backend errors, surface instead of being silently ignored.

Addresses #1489.

## Verification

- `SUPABASE_TEST_URL=http://localhost:54321 SUPABASE_TEST_KEY=test-key uv run --project src/supabase pytest src/supabase/tests/_sync/test_client.py::test_create_ignores_expected_auth_session_errors src/supabase/tests/_sync/test_client.py::test_create_propagates_unexpected_auth_session_errors src/supabase/tests/_async/test_client.py::test_create_ignores_expected_auth_session_errors src/supabase/tests/_async/test_client.py::test_create_propagates_unexpected_auth_session_errors`
- `uv run --project src/supabase ruff check src/supabase/src/supabase/_sync/client.py src/supabase/src/supabase/_async/client.py src/supabase/tests/_sync/test_client.py src/supabase/tests/_async/test_client.py`