### PR TITLE
fix(postgrest): use JsonValue for JSON adapter

### DIFF
--- a/src/postgrest/src/postgrest/types.py
+++ b/src/postgrest/src/postgrest/types.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
 import sys
-from collections.abc import Mapping, Sequence
-from typing import Union
 
 from httpx import AsyncClient, BasicAuth, Client, Headers, QueryParams
 from pydantic import TypeAdapter
-from typing_extensions import TypeAliasType
+from pydantic.types import JsonValue
 from yarl import URL
 
 if sys.version_info >= (3, 11):
@@ -14,11 +12,8 @@ if sys.version_info >= (3, 11):
 else:
     from strenum import StrEnum
 
-# https://docs.pydantic.dev/2.11/concepts/types/#named-recursive-types
-JSON = TypeAliasType(
-    "JSON", "Union[None, bool, str, int, float, Sequence[JSON], Mapping[str, JSON]]"
-)
-JSONAdapter: TypeAdapter = TypeAdapter(JSON)
+JSON = JsonValue
+JSONAdapter: TypeAdapter = TypeAdapter(JsonValue)
 
 
 class CountMethod(StrEnum):


### PR DESCRIPTION
## Summary

Addresses #1486.

I updated the PostgREST `JSONAdapter` to use Pydantic's built-in `JsonValue` instead of the custom recursive JSON `TypeAliasType`.

The issue showed that the current adapter was much slower than `TypeAdapter(JsonValue)` for the same payload. Since `JsonValue` already represents valid JSON types and performs much faster in this case, I changed `JSONAdapter` to use it directly while keeping the exported `JSON` name available.

## Verification

I checked that basic JSON validation still works:

```bash
PYTHONPATH=src/postgrest/src python -c "from postgrest.types import JSONAdapter; print(JSONAdapter.validate_json(b'{\"a\":1,\"b\":[true,null]}'))"
```

Output:

```python
{'a': 1, 'b': [True, None]}
```

I also reran the benchmark from the issue after making the change:

```text
payload_size=200,780 bytes
postgrest JSONAdapter        2.05 ms
pydantic.JsonValue           2.07 ms
json.loads                   1.25 ms
```

After the change, PostgREST `JSONAdapter` is roughly the same speed as `pydantic.JsonValue` in this benchmark.

## Notes

I kept this PR limited to the PostgREST JSON adapter and did not change unrelated files or release/changelog files.