### PR TITLE
fix(postgrest): add date, time, datetime, and UUID to JSON type

### DIFF
--- a/src/postgrest/src/postgrest/types.py
+++ b/src/postgrest/src/postgrest/types.py
@@ -4,7 +4,7 @@ import sys
 from collections.abc import Mapping, Sequence
 from typing import Union
 from uuid import UUID
-from datetime import datetime
+from datetime import datetime, date, time
 
 from httpx import AsyncClient, BasicAuth, Client, Headers, QueryParams
 from pydantic import TypeAdapter
@@ -17,9 +17,8 @@ else:
     from strenum import StrEnum
 
 # https://docs.pydantic.dev/2.11/concepts/types/#named-recursive-types
-JSON = TypeAliasType(
-    "JSON", "Union[None, bool, str, int, float, Sequence[JSON], Mapping[str, JSON], datetime, UUID]"
-)
+JSONSimple = Union[None, bool, str, int, float, datetime, time, date, UUID]
+JSON = TypeAliasType("JSON", "Union[JSONSimple, Sequence[JSON], Mapping[str, JSON]]")
 JSONAdapter: TypeAdapter = TypeAdapter(JSON)
 
 

--- a/src/postgrest/src/postgrest/types.py
+++ b/src/postgrest/src/postgrest/types.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import sys
 from collections.abc import Mapping, Sequence
 from typing import Union
+from uuid import UUID
+from datetime import datetime
 
 from httpx import AsyncClient, BasicAuth, Client, Headers, QueryParams
 from pydantic import TypeAdapter
@@ -16,7 +18,7 @@ else:
 
 # https://docs.pydantic.dev/2.11/concepts/types/#named-recursive-types
 JSON = TypeAliasType(
-    "JSON", "Union[None, bool, str, int, float, Sequence[JSON], Mapping[str, JSON]]"
+    "JSON", "Union[None, bool, str, int, float, Sequence[JSON], Mapping[str, JSON], datetime, UUID]"
 )
 JSONAdapter: TypeAdapter = TypeAdapter(JSON)
 

--- a/src/postgrest/tests/test_types.py
+++ b/src/postgrest/tests/test_types.py
@@ -1,0 +1,9 @@
+from postgrest.types import JSON, JSONAdapter
+
+from datetime import datetime
+from uuid import UUID
+
+def test_json_adapter():
+    assert JSONAdapter.validate_python(None) is None
+    assert JSONAdapter.validate_python(UUID("12345678-1234-5678-1234-567812345678")) is not None
+    assert JSONAdapter.validate_python(datetime.now()) is not None

--- a/src/postgrest/tests/test_types.py
+++ b/src/postgrest/tests/test_types.py
@@ -1,9 +1,11 @@
-from postgrest.types import JSON, JSONAdapter
-
-from datetime import datetime
+from datetime import datetime,date,time
 from uuid import UUID
+
+from postgrest.types import JSONAdapter
 
 def test_json_adapter():
     assert JSONAdapter.validate_python(None) is None
     assert JSONAdapter.validate_python(UUID("12345678-1234-5678-1234-567812345678")) is not None
     assert JSONAdapter.validate_python(datetime.now()) is not None
+    assert JSONAdapter.validate_python(date.today()) is not None
+    assert JSONAdapter.validate_python(time()) is not None


### PR DESCRIPTION
Fixed issue #1443 by adding `date`, `time`, `datetime`, and `UUID` as accepted types to the `JSON` type definition. Also extracted a `JSONSimple` type alias to keep the definition readable. Added tests to verify the new types are accepted.

Closes #1443