### PR TITLE
[codex] Make pyiceberg optional for storage analytics

### DIFF
--- a/src/storage/pyproject.toml
+++ b/src/storage/pyproject.toml
@@ -26,6 +26,10 @@ dependencies = [
   "deprecation >=2.1.0",
   "pydantic >=2.11.7",
   "yarl>=1.20.1",
+]
+
+[project.optional-dependencies]
+iceberg = [
   "pyiceberg>=0.10.0",
 ]
 

--- a/src/storage/src/storage3/_async/analytics.py
+++ b/src/storage/src/storage3/_async/analytics.py
@@ -1,8 +1,8 @@
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
 from httpx import QueryParams
-from pyiceberg.catalog.rest import RestCatalog
 
+from .._iceberg import load_rest_catalog
 from ..types import (
     AnalyticsBucket,
     AnalyticsBucketDeleteResponse,
@@ -11,6 +11,9 @@ from ..types import (
     SortOrder,
 )
 from .request import AsyncRequestBuilder
+
+if TYPE_CHECKING:
+    from pyiceberg.catalog.rest import RestCatalog
 
 
 class AsyncStorageAnalyticsClient:
@@ -53,7 +56,8 @@ class AsyncStorageAnalyticsClient:
 
     def catalog(
         self, catalog_name: str, access_key_id: str, secret_access_key: str
-    ) -> RestCatalog:
+    ) -> "RestCatalog":
+        RestCatalog = load_rest_catalog()
         catalog_uri = self._request._base_url
         s3_endpoint = self._request._base_url.parent.joinpath("s3")
         service_key = self._request.headers.get("apiKey")

--- a/src/storage/src/storage3/_iceberg.py
+++ b/src/storage/src/storage3/_iceberg.py
@@ -1,0 +1,16 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pyiceberg.catalog.rest import RestCatalog
+
+
+def load_rest_catalog() -> "type[RestCatalog]":
+    try:
+        from pyiceberg.catalog.rest import RestCatalog
+    except ImportError as exc:
+        raise ImportError(
+            "pyiceberg is required for Storage analytics catalog support. "
+            "Install it with `pip install storage3[iceberg]`."
+        ) from exc
+
+    return RestCatalog

--- a/src/storage/src/storage3/_sync/analytics.py
+++ b/src/storage/src/storage3/_sync/analytics.py
@@ -1,8 +1,8 @@
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
 from httpx import QueryParams
-from pyiceberg.catalog.rest import RestCatalog
 
+from .._iceberg import load_rest_catalog
 from ..types import (
     AnalyticsBucket,
     AnalyticsBucketDeleteResponse,
@@ -11,6 +11,9 @@ from ..types import (
     SortOrder,
 )
 from .request import SyncRequestBuilder
+
+if TYPE_CHECKING:
+    from pyiceberg.catalog.rest import RestCatalog
 
 
 class SyncStorageAnalyticsClient:
@@ -51,7 +54,8 @@ class SyncStorageAnalyticsClient:
 
     def catalog(
         self, catalog_name: str, access_key_id: str, secret_access_key: str
-    ) -> RestCatalog:
+    ) -> "RestCatalog":
+        RestCatalog = load_rest_catalog()
         catalog_uri = self._request._base_url
         s3_endpoint = self._request._base_url.parent.joinpath("s3")
         service_key = self._request.headers.get("apiKey")

--- a/src/storage/tests/test_iceberg.py
+++ b/src/storage/tests/test_iceberg.py
@@ -1,0 +1,43 @@
+import builtins
+import importlib
+
+import pytest
+from storage3._iceberg import load_rest_catalog
+
+
+def _block_pyiceberg_import(monkeypatch: pytest.MonkeyPatch) -> None:
+    real_import = builtins.__import__
+
+    def import_without_pyiceberg(
+        name: str,
+        globals=None,
+        locals=None,
+        fromlist=(),
+        level: int = 0,
+    ) -> object:
+        if name.startswith("pyiceberg"):
+            raise ImportError("No module named 'pyiceberg'")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", import_without_pyiceberg)
+
+
+def test_analytics_modules_import_without_pyiceberg(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _block_pyiceberg_import(monkeypatch)
+
+    import storage3._async.analytics as async_analytics
+    import storage3._sync.analytics as sync_analytics
+
+    importlib.reload(async_analytics)
+    importlib.reload(sync_analytics)
+
+
+def test_load_rest_catalog_includes_iceberg_extra_install_hint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _block_pyiceberg_import(monkeypatch)
+
+    with pytest.raises(ImportError, match=r"pip install storage3\[iceberg\]"):
+        load_rest_catalog()

--- a/uv.lock
+++ b/uv.lock
@@ -2028,7 +2028,7 @@ wheels = [
 
 [[package]]
 name = "postgrest"
-version = "2.30.0"
+version = "2.30.1"
 source = { editable = "src/postgrest" }
 dependencies = [
     { name = "deprecation" },
@@ -2784,7 +2784,7 @@ wheels = [
 
 [[package]]
 name = "realtime"
-version = "2.30.0"
+version = "2.30.1"
 source = { editable = "src/realtime" }
 dependencies = [
     { name = "pydantic" },
@@ -3430,14 +3430,18 @@ wheels = [
 
 [[package]]
 name = "storage3"
-version = "2.30.0"
+version = "2.30.1"
 source = { editable = "src/storage" }
 dependencies = [
     { name = "deprecation" },
     { name = "httpx", extra = ["http2"] },
     { name = "pydantic" },
-    { name = "pyiceberg" },
     { name = "yarl" },
+]
+
+[package.optional-dependencies]
+iceberg = [
+    { name = "pyiceberg" },
 ]
 
 [package.dev-dependencies]
@@ -3487,9 +3491,10 @@ requires-dist = [
     { name = "deprecation", specifier = ">=2.1.0" },
     { name = "httpx", extras = ["http2"], specifier = ">=0.26,<0.29" },
     { name = "pydantic", specifier = ">=2.11.7" },
-    { name = "pyiceberg", specifier = ">=0.10.0" },
+    { name = "pyiceberg", marker = "extra == 'iceberg'", specifier = ">=0.10.0" },
     { name = "yarl", specifier = ">=1.20.1" },
 ]
+provides-extras = ["iceberg"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -3548,7 +3553,7 @@ wheels = [
 
 [[package]]
 name = "supabase"
-version = "2.30.0"
+version = "2.30.1"
 source = { editable = "src/supabase" }
 dependencies = [
     { name = "httpx" },
@@ -3617,7 +3622,7 @@ tests = [
 
 [[package]]
 name = "supabase-auth"
-version = "2.30.0"
+version = "2.30.1"
 source = { editable = "src/auth" }
 dependencies = [
     { name = "httpx", extra = ["http2"] },
@@ -3704,7 +3709,7 @@ tests = [
 
 [[package]]
 name = "supabase-functions"
-version = "2.30.0"
+version = "2.30.1"
 source = { editable = "src/functions" }
 dependencies = [
     { name = "httpx", extra = ["http2"] },


### PR DESCRIPTION
Fixes #1508.

## Summary
- Move pyiceberg out of storage3 default dependencies and into the storage3[iceberg] extra.
- Lazy-load the PyIceberg RestCatalog in sync and async analytics catalog helpers.
- Add regression coverage for importing analytics without pyiceberg and for the install hint when catalog support is used without the extra.

## Tests
- UV_DEFAULT_INDEX=https://pypi.org/simple uv lock --check
- UV_DEFAULT_INDEX=https://pypi.org/simple uv run --locked ruff check src/storage3/_iceberg.py src/storage3/_sync/analytics.py src/storage3/_async/analytics.py tests/test_iceberg.py
- UV_DEFAULT_INDEX=https://pypi.org/simple PYTHONPATH=src uv run --locked pytest tests/test_client.py tests/test_iceberg.py