### PR TITLE
Fix JSON type alias for datetime and UUID in TypedDicts

### DIFF
--- a/src/postgrest/src/postgrest/types.py
+++ b/src/postgrest/src/postgrest/types.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import sys
 from collections.abc import Mapping, Sequence
+from datetime import date, datetime, time
 from typing import Union
+from uuid import UUID
 
 from httpx import AsyncClient, BasicAuth, Client, Headers, QueryParams
 from pydantic import TypeAdapter
@@ -16,7 +18,8 @@ else:
 
 # https://docs.pydantic.dev/2.11/concepts/types/#named-recursive-types
 JSON = TypeAliasType(
-    "JSON", "Union[None, bool, str, int, float, Sequence[JSON], Mapping[str, JSON]]"
+    "JSON",
+    "Union[None, bool, str, int, float, datetime, date, time, UUID, Sequence[JSON], Mapping[str, JSON]]",
 )
 JSONAdapter: TypeAdapter = TypeAdapter(JSON)
 


### PR DESCRIPTION
## Problem
The `JSON` type alias in `postgrest/types.py` did not include `datetime`, 
`date`, `time`, or `UUID`. The Supabase CLI generates TypedDicts that 
use these types, causing type errors when passing them to `.insert()`, 
`.upsert()`, or `.update()`.

## Fix
Added `datetime`, `date`, `time`, and `UUID` to the `JSON` type alias. 
These types are already serializable by httpx/pydantic — this was purely 
a type annotation gap.

## Testing
All 43 existing sync unit tests pass.

Fixes #1443