### PR TITLE
Make postgrest query builders immutable

### DIFF
--- a/src/postgrest/src/postgrest/base_request_builder.py
+++ b/src/postgrest/src/postgrest/base_request_builder.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import copy
 import sys
 from json import JSONDecodeError
 from re import search
@@ -285,8 +286,9 @@ class BaseFilterRequestBuilder(Generic[C]):
     @property
     def not_(self: Self) -> Self:
         """Whether the filter applied next should be negated."""
-        self.negate_next = True
-        return self
+        cloned = copy.copy(self)
+        cloned.negate_next = True
+        return cloned
 
     def filter(self: Self, column: str, operator: str, criteria: str) -> Self:
         """Apply filters on a query.
@@ -540,7 +542,7 @@ class BaseFilterRequestBuilder(Generic[C]):
             )
 
         for key, value in query.items():
-            updated_query = self.eq(key, value)
+            updated_query = updated_query.eq(key, value)
 
         return updated_query
 
@@ -677,3 +679,35 @@ class BaseRPCRequestBuilder(BaseSelectRequestBuilder):
         """Specify that the query must retrieve data as a single CSV string."""
         self.request.headers["Accept"] = "text/csv"
         return self
+
+
+def _make_immutable(cls: Type[Self]) -> Type[Self]:
+    import inspect
+    from functools import wraps
+
+    def wrap_method(method: Any) -> Any:
+        @wraps(method)
+        def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
+            cloned = copy.copy(self)
+            cloned.request = copy.copy(self.request)
+            cloned.request.headers = Headers(self.request.headers)
+            cloned.request.params = QueryParams(self.request.params)
+            result = method(cloned, *args, **kwargs)
+            if result is cloned:
+                return cloned
+            return result
+        return wrapper
+
+    for name, attr in list(cls.__dict__.items()):
+        if (
+            not name.startswith("_")
+            and name != "not_"
+            and (inspect.isfunction(attr) or inspect.ismethod(attr))
+        ):
+            setattr(cls, name, wrap_method(attr))
+    return cls
+
+
+_make_immutable(BaseFilterRequestBuilder)
+_make_immutable(BaseSelectRequestBuilder)
+_make_immutable(BaseRPCRequestBuilder)

--- a/src/postgrest/tests/_async/test_filter_request_builder.py
+++ b/src/postgrest/tests/_async/test_filter_request_builder.py
@@ -66,6 +66,17 @@ def test_match(filter_request_builder):
     assert str(builder.request.params) == "id=eq.1&done=eq.false"
 
 
+def test_builder_immutability(filter_request_builder):
+    base_query = filter_request_builder.eq("account_id", "abc")
+
+    query1 = base_query.eq("id", "1")
+    query2 = base_query.eq("id", "2")
+
+    assert str(base_query.request.params) == "account_id=eq.abc"
+    assert str(query1.request.params) == "account_id=eq.abc&id=eq.1"
+    assert str(query2.request.params) == "account_id=eq.abc&id=eq.2"
+
+
 def test_equals(filter_request_builder):
     builder = filter_request_builder.eq("x", "a")
 
@@ -294,7 +305,9 @@ def test_max_affected_with_existing_handling_strict(filter_request_builder):
     )
 
 
-def test_max_affected_returns_self(filter_request_builder):
+def test_max_affected_returns_new_instance(filter_request_builder):
     builder = filter_request_builder.max_affected(1)
 
-    assert builder is filter_request_builder
+    assert builder is not filter_request_builder
+    assert "prefer" in builder.request.headers
+    assert "prefer" not in filter_request_builder.request.headers

--- a/src/postgrest/tests/_sync/test_filter_request_builder.py
+++ b/src/postgrest/tests/_sync/test_filter_request_builder.py
@@ -66,6 +66,17 @@ def test_match(filter_request_builder):
     assert str(builder.request.params) == "id=eq.1&done=eq.false"
 
 
+def test_builder_immutability(filter_request_builder):
+    base_query = filter_request_builder.eq("account_id", "abc")
+
+    query1 = base_query.eq("id", "1")
+    query2 = base_query.eq("id", "2")
+
+    assert str(base_query.request.params) == "account_id=eq.abc"
+    assert str(query1.request.params) == "account_id=eq.abc&id=eq.1"
+    assert str(query2.request.params) == "account_id=eq.abc&id=eq.2"
+
+
 def test_equals(filter_request_builder):
     builder = filter_request_builder.eq("x", "a")
 
@@ -294,7 +305,9 @@ def test_max_affected_with_existing_handling_strict(filter_request_builder):
     )
 
 
-def test_max_affected_returns_self(filter_request_builder):
+def test_max_affected_returns_new_instance(filter_request_builder):
     builder = filter_request_builder.max_affected(1)
 
-    assert builder is filter_request_builder
+    assert builder is not filter_request_builder
+    assert "prefer" in builder.request.headers
+    assert "prefer" not in filter_request_builder.request.headers


### PR DESCRIPTION
This PR resolves the issue where query builder objects in postgrest are mutable (Issue supabase/supabase-py#1208). By implementing cloned-builder logic for all public filter methods, each chained method now returns a new independent builder instance. This matches postgrest-js behavior and prevents query parameters from incorrectly appending when sharing query builders or running multiple paginated queries.