### PR TITLE
fix(postgrest): make query builders immutable (#1208)

### DIFF
--- a/src/postgrest/src/postgrest/_async/request_builder.py
+++ b/src/postgrest/src/postgrest/_async/request_builder.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 from typing import Any, Generic, Literal, Optional, TypeVar, Union, overload
 
 from httpx import AsyncClient, BasicAuth, Headers, QueryParams, Response
@@ -16,6 +17,7 @@ from ..base_request_builder import (
     CountMethod,
     RequestConfig,
     SingleAPIResponse,
+    _clone_request,
     pre_delete,
     pre_insert,
     pre_select,
@@ -60,20 +62,27 @@ class AsyncQueryRequestBuilder:
     def __init__(self, request: ReqConfig):
         self.request = request
 
+    def _clone(self: Self) -> Self:
+        new = copy.copy(self)
+        new.request = _clone_request(self.request)
+        return new
+
     def select(self: QueryBuilderT, *columns: str) -> QueryBuilderT:
+        new = self._clone()
         _, params, _, _ = pre_select(*columns, count=None)
-        self.request.params = self.request.params.add("select", params["select"])
-        if prefer_headers := self.request.headers.get_list("Prefer", split_commas=True):
+        new.request.params = new.request.params.add("select", params["select"])
+        if prefer_headers := new.request.headers.get_list("Prefer", split_commas=True):
             prefer_headers = [h for h in prefer_headers if not h.startswith("return=")]
             prefer_headers.append("return=representation")
-            self.request.headers["Prefer"] = ",".join(prefer_headers)
+            new.request.headers["Prefer"] = ",".join(prefer_headers)
         else:
-            self.request.headers["Prefer"] = "return=representation"
-        return self
+            new.request.headers["Prefer"] = "return=representation"
+        return new
 
     def retry(self, enabled: bool) -> Self:
-        self.request.retry_enabled = enabled
-        return self
+        new = self._clone()
+        new.request.retry_enabled = enabled
+        return new
 
     async def execute(self) -> APIResponse:
         """Execute the query.
@@ -102,9 +111,15 @@ class AsyncSingleRequestBuilder:
     def __init__(self, request: ReqConfig):
         self.request = request
 
+    def _clone(self: Self) -> Self:
+        new = copy.copy(self)
+        new.request = _clone_request(self.request)
+        return new
+
     def retry(self, enabled: bool) -> Self:
-        self.request.retry_enabled = enabled
-        return self
+        new = self._clone()
+        new.request.retry_enabled = enabled
+        return new
 
     async def execute(self) -> SingleAPIResponse:
         """Execute the query.
@@ -135,9 +150,15 @@ class AsyncExplainRequestBuilder:
     def __init__(self, request: ReqConfig):
         self.request = request
 
+    def _clone(self: Self) -> Self:
+        new = copy.copy(self)
+        new.request = _clone_request(self.request)
+        return new
+
     def retry(self, enabled: bool) -> Self:
-        self.request.retry_enabled = enabled
-        return self
+        new = self._clone()
+        new.request.retry_enabled = enabled
+        return new
 
     async def execute(self) -> str:
         r = await send_with_retry(self.request)
@@ -155,9 +176,15 @@ class AsyncMaybeSingleRequestBuilder:
     def __init__(self, request: ReqConfig):
         self.request = request
 
+    def _clone(self: Self) -> Self:
+        new = copy.copy(self)
+        new.request = _clone_request(self.request)
+        return new
+
     def retry(self, enabled: bool) -> Self:
-        self.request.retry_enabled = enabled
-        return self
+        new = self._clone()
+        new.request.retry_enabled = enabled
+        return new
 
     async def execute(self) -> Optional[SingleAPIResponse]:
         r = await send_with_retry(self.request)
@@ -211,12 +238,13 @@ class AsyncSelectRequestBuilder(
         .. caution::
             The API will raise an error if the query returned more than one row.
         """
-        self.request.headers["Accept"] = "application/vnd.pgrst.object+json"
-        return AsyncSingleRequestBuilder(self.request)
+        new_req = _clone_request(self.request)
+        new_req.headers["Accept"] = "application/vnd.pgrst.object+json"
+        return AsyncSingleRequestBuilder(new_req)
 
     def maybe_single(self) -> AsyncMaybeSingleRequestBuilder:
         """Retrieves at most one row from the result. Result must be at most one row (e.g. using `eq` on a UNIQUE column), otherwise this will result in an error."""
-        return AsyncMaybeSingleRequestBuilder(self.request)
+        return AsyncMaybeSingleRequestBuilder(_clone_request(self.request))
 
     def text_search(
         self, column: str, query: str, options: dict[str, Any] = {}
@@ -230,16 +258,18 @@ class AsyncSelectRequestBuilder(
         elif type_ == "web_search":
             type_part = "w"
         config_part = f"({options.get('config')})" if options.get("config") else ""
-        self.request.params = self.request.params.add(
+        new_req = _clone_request(self.request)
+        new_req.params = new_req.params.add(
             column, f"{type_part}fts{config_part}.{query}"
         )
 
-        return AsyncQueryRequestBuilder(self.request)
+        return AsyncQueryRequestBuilder(new_req)
 
     def csv(self) -> AsyncSingleRequestBuilder:
         """Specify that the query must retrieve data as a single CSV string."""
-        self.request.headers["Accept"] = "text/csv"
-        return AsyncSingleRequestBuilder(self.request)
+        new_req = _clone_request(self.request)
+        new_req.headers["Accept"] = "text/csv"
+        return AsyncSingleRequestBuilder(new_req)
 
     @overload
     def explain(
@@ -279,13 +309,14 @@ class AsyncSelectRequestBuilder(
             if key not in ["self", "format"] and value
         ]
         options_str = "|".join(options)
-        self.request.headers["Accept"] = (
+        new_req = _clone_request(self.request)
+        new_req.headers["Accept"] = (
             f"application/vnd.pgrst.plan+{format}; options={options_str}"
         )
         if format == "text":
-            return AsyncExplainRequestBuilder(self.request)
+            return AsyncExplainRequestBuilder(new_req)
         else:
-            return AsyncSingleRequestBuilder(self.request)
+            return AsyncSingleRequestBuilder(new_req)
 
 
 class AsyncRequestBuilder:  #

--- a/src/postgrest/src/postgrest/_sync/request_builder.py
+++ b/src/postgrest/src/postgrest/_sync/request_builder.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import time
 from typing import Any, Generic, Literal, Optional, TypeVar, Union, overload
 
@@ -16,6 +17,7 @@ from ..base_request_builder import (
     CountMethod,
     RequestConfig,
     SingleAPIResponse,
+    _clone_request,
     pre_delete,
     pre_insert,
     pre_select,
@@ -60,20 +62,27 @@ class SyncQueryRequestBuilder:
     def __init__(self, request: ReqConfig):
         self.request = request
 
+    def _clone(self: Self) -> Self:
+        new = copy.copy(self)
+        new.request = _clone_request(self.request)
+        return new
+
     def select(self: QueryBuilderT, *columns: str) -> QueryBuilderT:
+        new = self._clone()
         _, params, _, _ = pre_select(*columns, count=None)
-        self.request.params = self.request.params.add("select", params["select"])
-        if prefer_headers := self.request.headers.get_list("Prefer", split_commas=True):
+        new.request.params = new.request.params.add("select", params["select"])
+        if prefer_headers := new.request.headers.get_list("Prefer", split_commas=True):
             prefer_headers = [h for h in prefer_headers if not h.startswith("return=")]
             prefer_headers.append("return=representation")
-            self.request.headers["Prefer"] = ",".join(prefer_headers)
+            new.request.headers["Prefer"] = ",".join(prefer_headers)
         else:
-            self.request.headers["Prefer"] = "return=representation"
-        return self
+            new.request.headers["Prefer"] = "return=representation"
+        return new
 
     def retry(self, enabled: bool) -> Self:
-        self.request.retry_enabled = enabled
-        return self
+        new = self._clone()
+        new.request.retry_enabled = enabled
+        return new
 
     def execute(self) -> APIResponse:
         """Execute the query.
@@ -102,9 +111,15 @@ class SyncSingleRequestBuilder:
     def __init__(self, request: ReqConfig):
         self.request = request
 
+    def _clone(self: Self) -> Self:
+        new = copy.copy(self)
+        new.request = _clone_request(self.request)
+        return new
+
     def retry(self, enabled: bool) -> Self:
-        self.request.retry_enabled = enabled
-        return self
+        new = self._clone()
+        new.request.retry_enabled = enabled
+        return new
 
     def execute(self) -> SingleAPIResponse:
         """Execute the query.
@@ -135,9 +150,15 @@ class SyncExplainRequestBuilder:
     def __init__(self, request: ReqConfig):
         self.request = request
 
+    def _clone(self: Self) -> Self:
+        new = copy.copy(self)
+        new.request = _clone_request(self.request)
+        return new
+
     def retry(self, enabled: bool) -> Self:
-        self.request.retry_enabled = enabled
-        return self
+        new = self._clone()
+        new.request.retry_enabled = enabled
+        return new
 
     def execute(self) -> str:
         r = send_with_retry(self.request)
@@ -155,9 +176,15 @@ class SyncMaybeSingleRequestBuilder:
     def __init__(self, request: ReqConfig):
         self.request = request
 
+    def _clone(self: Self) -> Self:
+        new = copy.copy(self)
+        new.request = _clone_request(self.request)
+        return new
+
     def retry(self, enabled: bool) -> Self:
-        self.request.retry_enabled = enabled
-        return self
+        new = self._clone()
+        new.request.retry_enabled = enabled
+        return new
 
     def execute(self) -> Optional[SingleAPIResponse]:
         r = send_with_retry(self.request)
@@ -211,12 +238,13 @@ class SyncSelectRequestBuilder(
         .. caution::
             The API will raise an error if the query returned more than one row.
         """
-        self.request.headers["Accept"] = "application/vnd.pgrst.object+json"
-        return SyncSingleRequestBuilder(self.request)
+        new_req = _clone_request(self.request)
+        new_req.headers["Accept"] = "application/vnd.pgrst.object+json"
+        return SyncSingleRequestBuilder(new_req)
 
     def maybe_single(self) -> SyncMaybeSingleRequestBuilder:
         """Retrieves at most one row from the result. Result must be at most one row (e.g. using `eq` on a UNIQUE column), otherwise this will result in an error."""
-        return SyncMaybeSingleRequestBuilder(self.request)
+        return SyncMaybeSingleRequestBuilder(_clone_request(self.request))
 
     def text_search(
         self, column: str, query: str, options: dict[str, Any] = {}
@@ -230,16 +258,18 @@ class SyncSelectRequestBuilder(
         elif type_ == "web_search":
             type_part = "w"
         config_part = f"({options.get('config')})" if options.get("config") else ""
-        self.request.params = self.request.params.add(
+        new_req = _clone_request(self.request)
+        new_req.params = new_req.params.add(
             column, f"{type_part}fts{config_part}.{query}"
         )
 
-        return SyncQueryRequestBuilder(self.request)
+        return SyncQueryRequestBuilder(new_req)
 
     def csv(self) -> SyncSingleRequestBuilder:
         """Specify that the query must retrieve data as a single CSV string."""
-        self.request.headers["Accept"] = "text/csv"
-        return SyncSingleRequestBuilder(self.request)
+        new_req = _clone_request(self.request)
+        new_req.headers["Accept"] = "text/csv"
+        return SyncSingleRequestBuilder(new_req)
 
     @overload
     def explain(
@@ -279,13 +309,14 @@ class SyncSelectRequestBuilder(
             if key not in ["self", "format"] and value
         ]
         options_str = "|".join(options)
-        self.request.headers["Accept"] = (
+        new_req = _clone_request(self.request)
+        new_req.headers["Accept"] = (
             f"application/vnd.pgrst.plan+{format}; options={options_str}"
         )
         if format == "text":
-            return SyncExplainRequestBuilder(self.request)
+            return SyncExplainRequestBuilder(new_req)
         else:
-            return SyncSingleRequestBuilder(self.request)
+            return SyncSingleRequestBuilder(new_req)
 
 
 class SyncRequestBuilder:  #

--- a/src/postgrest/src/postgrest/base_request_builder.py
+++ b/src/postgrest/src/postgrest/base_request_builder.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import json
 import sys
 from json import JSONDecodeError
@@ -102,6 +103,20 @@ class RequestConfig(Generic[C]):
         if not (self.http_method == "GET" or self.http_method == "HTTP"):
             return False
         return response.status_code == 503 or response.status_code == 520
+
+
+def _clone_request(request: RequestConfig[C]) -> RequestConfig[C]:
+    """Produce a fresh RequestConfig with copies of the mutable pieces (Headers, QueryParams)."""
+    return RequestConfig(
+        session=request.session,
+        path=request.path,
+        http_method=request.http_method,
+        headers=Headers(request.headers),
+        params=QueryParams(request.params),
+        auth=request.auth,
+        json=request.json,
+        retry_enabled=request.retry_enabled,
+    )
 
 
 def _unique_columns(json: List[Dict[str, JSON]]):
@@ -282,11 +297,22 @@ class BaseFilterRequestBuilder(Generic[C]):
         self.request: RequestConfig[C] = request
         self.negate_next = False
 
+    def _clone(self: Self) -> Self:
+        """Return a new builder with an independent RequestConfig.
+
+        Chained filter/select methods call this so that they return a fresh
+        instance instead of mutating the current builder — see issue #1208.
+        """
+        new = copy.copy(self)
+        new.request = _clone_request(self.request)
+        return new
+
     @property
     def not_(self: Self) -> Self:
         """Whether the filter applied next should be negated."""
-        self.negate_next = True
-        return self
+        new = self._clone()
+        new.negate_next = True
+        return new
 
     def filter(self: Self, column: str, operator: str, criteria: str) -> Self:
         """Apply filters on a query.
@@ -296,12 +322,13 @@ class BaseFilterRequestBuilder(Generic[C]):
             operator: The operator to use while filtering
             criteria: The value to filter by
         """
+        new = self._clone()
         if self.negate_next is True:
-            self.negate_next = False
             operator = f"{Filters.NOT}.{operator}"
+        new.negate_next = False
         key, val = sanitize_param(column), f"{operator}.{criteria}"
-        self.request.params = self.request.params.add(key, val)
-        return self
+        new.request.params = new.request.params.add(key, val)
+        return new
 
     def eq(self: Self, column: str, value: Any) -> Self:
         """An 'equal to' filter.
@@ -433,9 +460,10 @@ class BaseFilterRequestBuilder(Generic[C]):
             filters: The filters to use, following PostgREST syntax
             reference_table: Set this to filter on referenced tables instead of the parent table
         """
+        new = self._clone()
         key = f"{sanitize_param(reference_table)}.or" if reference_table else "or"
-        self.request.params = self.request.params.add(key, f"({filters})")
-        return self
+        new.request.params = new.request.params.add(key, f"({filters})")
+        return new
 
     def fts(self: Self, column: str, query: Any) -> Self:
         return self.filter(column, Filters.FTS, query)
@@ -532,15 +560,14 @@ class BaseFilterRequestBuilder(Generic[C]):
         return self.ov(column, values)
 
     def match(self: Self, query: Dict[str, Any]) -> Self:
-        updated_query = self
-
         if not query:
             raise ValueError(
                 "query dictionary should contain at least one key-value pair"
             )
 
+        updated_query = self
         for key, value in query.items():
-            updated_query = self.eq(key, value)
+            updated_query = updated_query.eq(key, value)
 
         return updated_query
 
@@ -552,7 +579,8 @@ class BaseFilterRequestBuilder(Generic[C]):
         Args:
             value: The maximum number of rows that can be affected
         """
-        prefer_header = self.request.headers.get("Prefer", "")
+        new = self._clone()
+        prefer_header = new.request.headers.get("Prefer", "")
         if prefer_header:
             if "handling=strict" not in prefer_header:
                 prefer_header += ",handling=strict"
@@ -561,8 +589,8 @@ class BaseFilterRequestBuilder(Generic[C]):
 
         prefer_header += f",max-affected={value}"
 
-        self.request.headers["Prefer"] = prefer_header
-        return self
+        new.request.headers["Prefer"] = prefer_header
+        return new
 
 
 class BaseSelectRequestBuilder(BaseFilterRequestBuilder[C]):
@@ -584,10 +612,11 @@ class BaseSelectRequestBuilder(BaseFilterRequestBuilder[C]):
         .. versionchanged:: 0.10.3
            Allow ordering results for foreign tables with the foreign_table parameter.
         """
+        new = self._clone()
         key = f"{foreign_table}.order" if foreign_table else "order"
-        existing_order = self.request.params.get(key)
+        existing_order = new.request.params.get(key)
 
-        self.request.params = self.request.params.set(
+        new.request.params = new.request.params.set(
             key,
             f"{existing_order + ',' if existing_order else ''}"
             + f"{column}.{'desc' if desc else 'asc'}"
@@ -597,7 +626,7 @@ class BaseSelectRequestBuilder(BaseFilterRequestBuilder[C]):
                 else ""
             ),
         )
-        return self
+        return new
 
     def limit(self: Self, size: int, *, foreign_table: Optional[str] = None) -> Self:
         """Limit the number of rows returned by a query.
@@ -608,34 +637,37 @@ class BaseSelectRequestBuilder(BaseFilterRequestBuilder[C]):
         .. versionchanged:: 0.10.3
            Allow limiting results returned for foreign tables with the foreign_table parameter.
         """
-        self.request.params = self.request.params.add(
+        new = self._clone()
+        new.request.params = new.request.params.add(
             f"{foreign_table}.limit" if foreign_table else "limit",
             size,
         )
-        return self
+        return new
 
     def offset(self: Self, size: int) -> Self:
         """Set the starting row index returned by a query.
         Args:
             size: The number of the row to start at
         """
-        self.request.params = self.request.params.add(
+        new = self._clone()
+        new.request.params = new.request.params.add(
             "offset",
             size,
         )
-        return self
+        return new
 
     def range(
         self: Self, start: int, end: int, foreign_table: Optional[str] = None
     ) -> Self:
-        self.request.params = self.request.params.add(
+        new = self._clone()
+        new.request.params = new.request.params.add(
             f"{foreign_table}.offset" if foreign_table else "offset", start
         )
-        self.request.params = self.request.params.add(
+        new.request.params = new.request.params.add(
             f"{foreign_table}.limit" if foreign_table else "limit",
             end - start + 1,
         )
-        return self
+        return new
 
 
 class BaseRPCRequestBuilder(BaseSelectRequestBuilder):
@@ -650,14 +682,15 @@ class BaseRPCRequestBuilder(BaseSelectRequestBuilder):
         Returns:
             :class:`BaseSelectRequestBuilder`
         """
+        new = self._clone()
         method, params, headers, json = pre_select(*columns, count=None)
-        self.request.params = self.request.params.add("select", params.get("select"))
-        if self.request.headers.get("Prefer"):
-            self.request.headers["Prefer"] += ",return=representation"
+        new.request.params = new.request.params.add("select", params.get("select"))
+        if new.request.headers.get("Prefer"):
+            new.request.headers["Prefer"] += ",return=representation"
         else:
-            self.request.headers["Prefer"] = "return=representation"
+            new.request.headers["Prefer"] = "return=representation"
 
-        return self
+        return new
 
     def single(self) -> Self:
         """Specify that the query will only return a single row in response.
@@ -665,15 +698,18 @@ class BaseRPCRequestBuilder(BaseSelectRequestBuilder):
         .. caution::
             The API will raise an error if the query returned more than one row.
         """
-        self.request.headers["Accept"] = "application/vnd.pgrst.object+json"
-        return self
+        new = self._clone()
+        new.request.headers["Accept"] = "application/vnd.pgrst.object+json"
+        return new
 
     def maybe_single(self) -> Self:
         """Retrieves at most one row from the result. Result must be at most one row (e.g. using `eq` on a UNIQUE column), otherwise this will result in an error."""
-        self.request.headers["Accept"] = "application/vnd.pgrst.object+json"
-        return self
+        new = self._clone()
+        new.request.headers["Accept"] = "application/vnd.pgrst.object+json"
+        return new
 
     def csv(self) -> Self:
         """Specify that the query must retrieve data as a single CSV string."""
-        self.request.headers["Accept"] = "text/csv"
-        return self
+        new = self._clone()
+        new.request.headers["Accept"] = "text/csv"
+        return new

--- a/src/postgrest/tests/_async/test_filter_request_builder.py
+++ b/src/postgrest/tests/_async/test_filter_request_builder.py
@@ -5,7 +5,7 @@ from httpx import AsyncClient, Headers, QueryParams
 from yarl import URL
 
 from postgrest import AsyncFilterRequestBuilder
-from postgrest._async.request_builder import RequestConfig
+from postgrest._async.request_builder import AsyncSelectRequestBuilder, RequestConfig
 
 
 @pytest.fixture
@@ -15,6 +15,15 @@ async def filter_request_builder() -> AsyncIterable[AsyncFilterRequestBuilder]:
             client, URL("/example_table"), "GET", Headers(), QueryParams(), None, {}
         )
         yield AsyncFilterRequestBuilder(request)
+
+
+@pytest.fixture
+async def select_request_builder() -> AsyncIterable[AsyncSelectRequestBuilder]:
+    async with AsyncClient() as client:
+        request = RequestConfig(
+            client, URL("/example_table"), "GET", Headers(), QueryParams(), None, {}
+        )
+        yield AsyncSelectRequestBuilder(request)
 
 
 def test_constructor(filter_request_builder: AsyncFilterRequestBuilder):
@@ -64,6 +73,87 @@ def test_multivalued_param(filter_request_builder):
 def test_match(filter_request_builder):
     builder = filter_request_builder.match({"id": "1", "done": "false"})
     assert str(builder.request.params) == "id=eq.1&done=eq.false"
+
+
+def test_builder_immutability(filter_request_builder):
+    # Regression test for https://github.com/supabase/supabase-py/issues/1208
+    # Reusing a shared base builder must not leak filters between executions.
+    base = filter_request_builder.eq("account_id", "abc")
+    q1 = base.in_("id", ["1", "2", "3"])
+    q2 = base.in_("id", ["4", "5", "6"])
+
+    assert base is not q1
+    assert base is not q2
+    assert q1 is not q2
+
+    # base is untouched — only the account_id filter
+    assert str(base.request.params) == "account_id=eq.abc"
+    # each branch has account_id + its own id filter, no cross-contamination
+    assert (
+        str(q1.request.params) == "account_id=eq.abc&id=in.%281%2C2%2C3%29"
+    )
+    assert (
+        str(q2.request.params) == "account_id=eq.abc&id=in.%284%2C5%2C6%29"
+    )
+
+    # not_ must not mutate the base
+    not_builder = base.not_
+    assert not_builder is not base
+    assert base.negate_next is False
+    assert not_builder.negate_next is True
+
+
+@pytest.mark.parametrize(
+    "chain_call",
+    [
+        lambda b: b.limit(5),
+        lambda b: b.offset(10),
+        lambda b: b.order("name"),
+        lambda b: b.range(0, 9),
+        lambda b: b.select("id"),
+        lambda b: b.eq("x", "y"),
+        lambda b: b.in_("x", ["1", "2"]),
+        lambda b: b.filter("x", "eq", "y"),
+        lambda b: b.or_("x.eq.1"),
+        lambda b: b.max_affected(3),
+        lambda b: b.match({"x": "1"}),
+        lambda b: b.not_,
+        lambda b: b.single(),
+        lambda b: b.maybe_single(),
+        lambda b: b.csv(),
+    ],
+)
+def test_select_builder_base_is_untouched(select_request_builder, chain_call):
+    # Every chain method on AsyncSelectRequestBuilder must return a new instance
+    # without mutating the base — issue #1208.
+    base_params = str(select_request_builder.request.params)
+    base_headers = dict(select_request_builder.request.headers)
+
+    returned = chain_call(select_request_builder)
+
+    assert returned is not select_request_builder
+    assert str(select_request_builder.request.params) == base_params
+    assert dict(select_request_builder.request.headers) == base_headers
+
+
+def test_pagination_immutability(select_request_builder):
+    # Regression test for the pagination scenario in issue #1208 (DDoerner comment):
+    # repeated .range() on a shared base previously appended offset=&limit= duplicates.
+    base = select_request_builder.eq("account_id", "abc")
+    urls = [str(base.range(off, off + 249).request.params) for off in (0, 250, 500)]
+
+    # base itself never accumulated offset/limit
+    assert "offset" not in str(base.request.params)
+    assert "limit" not in str(base.request.params)
+
+    # each derived query has exactly one offset and one limit
+    for url in urls:
+        assert url.count("offset=") == 1
+        assert url.count("limit=") == 1
+
+    assert "offset=0" in urls[0]
+    assert "offset=250" in urls[1]
+    assert "offset=500" in urls[2]
 
 
 def test_equals(filter_request_builder):
@@ -294,7 +384,10 @@ def test_max_affected_with_existing_handling_strict(filter_request_builder):
     )
 
 
-def test_max_affected_returns_self(filter_request_builder):
+def test_max_affected_returns_new_instance(filter_request_builder):
+    # Builders are immutable (issue #1208): each chain call must return a new instance.
     builder = filter_request_builder.max_affected(1)
 
-    assert builder is filter_request_builder
+    assert builder is not filter_request_builder
+    assert "prefer" in builder.request.headers
+    assert "prefer" not in filter_request_builder.request.headers

--- a/src/postgrest/tests/_sync/test_filter_request_builder.py
+++ b/src/postgrest/tests/_sync/test_filter_request_builder.py
@@ -5,7 +5,7 @@ from httpx import Client, Headers, QueryParams
 from yarl import URL
 
 from postgrest import SyncFilterRequestBuilder
-from postgrest._sync.request_builder import RequestConfig
+from postgrest._sync.request_builder import RequestConfig, SyncSelectRequestBuilder
 
 
 @pytest.fixture
@@ -15,6 +15,15 @@ def filter_request_builder() -> Iterable[SyncFilterRequestBuilder]:
             client, URL("/example_table"), "GET", Headers(), QueryParams(), None, {}
         )
         yield SyncFilterRequestBuilder(request)
+
+
+@pytest.fixture
+def select_request_builder() -> Iterable[SyncSelectRequestBuilder]:
+    with Client() as client:
+        request = RequestConfig(
+            client, URL("/example_table"), "GET", Headers(), QueryParams(), None, {}
+        )
+        yield SyncSelectRequestBuilder(request)
 
 
 def test_constructor(filter_request_builder: SyncFilterRequestBuilder):
@@ -64,6 +73,87 @@ def test_multivalued_param(filter_request_builder):
 def test_match(filter_request_builder):
     builder = filter_request_builder.match({"id": "1", "done": "false"})
     assert str(builder.request.params) == "id=eq.1&done=eq.false"
+
+
+def test_builder_immutability(filter_request_builder):
+    # Regression test for https://github.com/supabase/supabase-py/issues/1208
+    # Reusing a shared base builder must not leak filters between executions.
+    base = filter_request_builder.eq("account_id", "abc")
+    q1 = base.in_("id", ["1", "2", "3"])
+    q2 = base.in_("id", ["4", "5", "6"])
+
+    assert base is not q1
+    assert base is not q2
+    assert q1 is not q2
+
+    # base is untouched — only the account_id filter
+    assert str(base.request.params) == "account_id=eq.abc"
+    # each branch has account_id + its own id filter, no cross-contamination
+    assert (
+        str(q1.request.params) == "account_id=eq.abc&id=in.%281%2C2%2C3%29"
+    )
+    assert (
+        str(q2.request.params) == "account_id=eq.abc&id=in.%284%2C5%2C6%29"
+    )
+
+    # not_ must not mutate the base
+    not_builder = base.not_
+    assert not_builder is not base
+    assert base.negate_next is False
+    assert not_builder.negate_next is True
+
+
+@pytest.mark.parametrize(
+    "chain_call",
+    [
+        lambda b: b.limit(5),
+        lambda b: b.offset(10),
+        lambda b: b.order("name"),
+        lambda b: b.range(0, 9),
+        lambda b: b.select("id"),
+        lambda b: b.eq("x", "y"),
+        lambda b: b.in_("x", ["1", "2"]),
+        lambda b: b.filter("x", "eq", "y"),
+        lambda b: b.or_("x.eq.1"),
+        lambda b: b.max_affected(3),
+        lambda b: b.match({"x": "1"}),
+        lambda b: b.not_,
+        lambda b: b.single(),
+        lambda b: b.maybe_single(),
+        lambda b: b.csv(),
+    ],
+)
+def test_select_builder_base_is_untouched(select_request_builder, chain_call):
+    # Every chain method on AsyncSelectRequestBuilder must return a new instance
+    # without mutating the base — issue #1208.
+    base_params = str(select_request_builder.request.params)
+    base_headers = dict(select_request_builder.request.headers)
+
+    returned = chain_call(select_request_builder)
+
+    assert returned is not select_request_builder
+    assert str(select_request_builder.request.params) == base_params
+    assert dict(select_request_builder.request.headers) == base_headers
+
+
+def test_pagination_immutability(select_request_builder):
+    # Regression test for the pagination scenario in issue #1208 (DDoerner comment):
+    # repeated .range() on a shared base previously appended offset=&limit= duplicates.
+    base = select_request_builder.eq("account_id", "abc")
+    urls = [str(base.range(off, off + 249).request.params) for off in (0, 250, 500)]
+
+    # base itself never accumulated offset/limit
+    assert "offset" not in str(base.request.params)
+    assert "limit" not in str(base.request.params)
+
+    # each derived query has exactly one offset and one limit
+    for url in urls:
+        assert url.count("offset=") == 1
+        assert url.count("limit=") == 1
+
+    assert "offset=0" in urls[0]
+    assert "offset=250" in urls[1]
+    assert "offset=500" in urls[2]
 
 
 def test_equals(filter_request_builder):
@@ -294,7 +384,10 @@ def test_max_affected_with_existing_handling_strict(filter_request_builder):
     )
 
 
-def test_max_affected_returns_self(filter_request_builder):
+def test_max_affected_returns_new_instance(filter_request_builder):
+    # Builders are immutable (issue #1208): each chain call must return a new instance.
     builder = filter_request_builder.max_affected(1)
 
-    assert builder is filter_request_builder
+    assert builder is not filter_request_builder
+    assert "prefer" in builder.request.headers
+    assert "prefer" not in filter_request_builder.request.headers


### PR DESCRIPTION
## Summary

Fix #1208 by making every postgrest query builder chain method return a new instance instead of mutating shared `RequestConfig` state.

**Before (bug):**
```python
query = sb.table("items").select("*").eq("account_id", "abc")
query.in_("id", ["1","2","3"]).execute()   # runs with 1,2,3   ✅
query.in_("id", ["4","5","6"]).execute()   # runs with 1..6    ❌
```

Same class of bug affects pagination via reused `.range()`/`.limit()`/`.offset()` — the request URL ends up with `?offset=0&offset=250&…&limit=251&limit=251…` (see the DDoerner comment on the issue).

## Approach

- Add a module-level `_clone_request(request)` helper that returns a fresh `RequestConfig` with copies of the mutable pieces (`Headers`, `QueryParams`).
- Add `_clone(self)` on `BaseFilterRequestBuilder` (inherited by `BaseSelectRequestBuilder` → `BaseRPCRequestBuilder`) and on the four standalone `Async*RequestBuilder` classes.
- Rewrite every mutating method to `new = self._clone(); …mutate new…; return new`.
- For methods that return a *different* builder type (`AsyncSelectRequestBuilder.{single,maybe_single,csv,text_search,explain}`), clone the request first and hand it to the new builder — never mutate `self.request`.

Also fixes a latent bug in `BaseFilterRequestBuilder.match()` where the loop used `self.eq(...)` instead of chaining through the accumulator.

## Coverage vs. prior PRs

**#1385 (open):** introduced the `_clone()` idea but only for `not_`, `filter`, `or_`, `match` — leaves ~20 mutating methods still broken (`order/limit/offset/range/max_affected/select/single/csv/explain/text_search/retry`, plus every RPC builder method). This PR extends the pattern to all of them.

**#1521 (closed):** used a class decorator (`_make_immutable`) that monkey-patched every public method. This PR uses explicit per-method `_clone()` calls instead — reviewable, doesn't break IDE navigation, preserves `Self`-typing for mypy.

## Breaking change callout

@silentworks noted on 2026-03-30 that this fix is scheduled for v3 because it's a breaking change. Users relying on `builder is builder.eq(...)` identity, or on mutating a builder in place and re-executing, will see behavior change. Suggest labeling for v3 (or gating behind an opt-in flag if you'd prefer to ship it in v2).

I asked in [this comment on #1208](https://github.com/supabase/supabase-py/issues/1208#issuecomment-4865118262) whether you'd prefer this against `main` or a `v3` branch — happy to retarget if needed.

## Test plan

- [x] `test_builder_immutability` — reproduces the exact `eq → in_` scenario from the issue.
- [x] `test_pagination_immutability` — reproduces the DDoerner `.range()` pagination scenario.
- [x] `test_select_builder_base_is_untouched` — parameterized over 15 chain methods (`limit`, `offset`, `order`, `range`, `select`, `eq`, `in_`, `filter`, `or_`, `max_affected`, `match`, `not_`, `single`, `maybe_single`, `csv`) asserting the base builder's params and headers are unchanged after each call.
- [x] `test_max_affected_returns_new_instance` — renamed from `test_max_affected_returns_self`, updated assertion to reflect the new immutable contract.
- [x] All 196 existing unit tests still pass (`uv run --package postgrest pytest src/postgrest/tests/_async src/postgrest/tests/_sync --ignore=…integration.py --ignore=…test_client.py`).
- [x] `make postgrest.mypy` clean.
- [x] `uv run ruff check src/postgrest` clean.

Closes #1208