### PR TITLE
fix(postgrest): coerce non-string values in array filters

### DIFF
--- a/src/postgrest/src/postgrest/base_request_builder.py
+++ b/src/postgrest/src/postgrest/base_request_builder.py
@@ -455,11 +455,11 @@ class BaseFilterRequestBuilder(Generic[C]):
         return self.filter(column, Filters.IN, f"({values})")
 
     def cs(self: Self, column: str, values: Iterable[Any]) -> Self:
-        values = ",".join(values)
+        values = ",".join(str(v) for v in values)
         return self.filter(column, Filters.CS, f"{{{values}}}")
 
     def cd(self: Self, column: str, values: Iterable[Any]) -> Self:
-        values = ",".join(values)
+        values = ",".join(str(v) for v in values)
         return self.filter(column, Filters.CD, f"{{{values}}}")
 
     def contains(
@@ -471,7 +471,7 @@ class BaseFilterRequestBuilder(Generic[C]):
             return self.filter(column, Filters.CS, value)
         if not isinstance(value, dict) and isinstance(value, Iterable):
             # Expected to be some type of iterable
-            stringified_values = ",".join(value)
+            stringified_values = ",".join(str(v) for v in value)
             return self.filter(column, Filters.CS, f"{{{stringified_values}}}")
 
         return self.filter(column, Filters.CS, json.dumps(value))
@@ -483,7 +483,7 @@ class BaseFilterRequestBuilder(Generic[C]):
             # range
             return self.filter(column, Filters.CD, value)
         if not isinstance(value, dict) and isinstance(value, Iterable):
-            stringified_values = ",".join(value)
+            stringified_values = ",".join(str(v) for v in value)
             return self.filter(column, Filters.CD, f"{{{stringified_values}}}")
         return self.filter(column, Filters.CD, json.dumps(value))
 
@@ -494,7 +494,7 @@ class BaseFilterRequestBuilder(Generic[C]):
             return self.filter(column, Filters.OV, value)
         if not isinstance(value, dict) and isinstance(value, Iterable):
             # Expected to be some type of iterable
-            stringified_values = ",".join(value)
+            stringified_values = ",".join(str(v) for v in value)
             return self.filter(column, Filters.OV, f"{{{stringified_values}}}")
         return self.filter(column, Filters.OV, json.dumps(value))
 

--- a/src/postgrest/tests/_async/test_filter_request_builder.py
+++ b/src/postgrest/tests/_async/test_filter_request_builder.py
@@ -110,6 +110,43 @@ def test_contains_any_item(filter_request_builder):
     assert str(builder.request.params) == "x=cs.%7Ba%2Cb%7D"
 
 
+def test_contains_non_string_items(filter_request_builder):
+    # Non-string iterables (e.g. integer arrays) must be coerced to str
+    # instead of raising TypeError from ",".join(...).
+    builder = filter_request_builder.contains("x", [1, 2, 3])
+
+    # {1,2,3}
+    assert str(builder.request.params) == "x=cs.%7B1%2C2%2C3%7D"
+
+
+def test_cs_non_string_items(filter_request_builder):
+    builder = filter_request_builder.cs("x", [1, 2, 3])
+
+    # {1,2,3}
+    assert str(builder.request.params) == "x=cs.%7B1%2C2%2C3%7D"
+
+
+def test_cd_non_string_items(filter_request_builder):
+    builder = filter_request_builder.cd("x", [1, 2, 3])
+
+    # {1,2,3}
+    assert str(builder.request.params) == "x=cd.%7B1%2C2%2C3%7D"
+
+
+def test_contained_by_non_string_items(filter_request_builder):
+    builder = filter_request_builder.contained_by("x", [1, 2, 3])
+
+    # {1,2,3}
+    assert str(builder.request.params) == "x=cd.%7B1%2C2%2C3%7D"
+
+
+def test_overlaps_non_string_items(filter_request_builder):
+    builder = filter_request_builder.overlaps("x", [1, 2, 3])
+
+    # {1,2,3}
+    assert str(builder.request.params) == "x=ov.%7B1%2C2%2C3%7D"
+
+
 def test_contains_in_list(filter_request_builder):
     builder = filter_request_builder.contains("x", '[{"a": "b"}]')
 

--- a/src/postgrest/tests/_sync/test_filter_request_builder.py
+++ b/src/postgrest/tests/_sync/test_filter_request_builder.py
@@ -110,6 +110,43 @@ def test_contains_any_item(filter_request_builder):
     assert str(builder.request.params) == "x=cs.%7Ba%2Cb%7D"
 
 
+def test_contains_non_string_items(filter_request_builder):
+    # Non-string iterables (e.g. integer arrays) must be coerced to str
+    # instead of raising TypeError from ",".join(...).
+    builder = filter_request_builder.contains("x", [1, 2, 3])
+
+    # {1,2,3}
+    assert str(builder.request.params) == "x=cs.%7B1%2C2%2C3%7D"
+
+
+def test_cs_non_string_items(filter_request_builder):
+    builder = filter_request_builder.cs("x", [1, 2, 3])
+
+    # {1,2,3}
+    assert str(builder.request.params) == "x=cs.%7B1%2C2%2C3%7D"
+
+
+def test_cd_non_string_items(filter_request_builder):
+    builder = filter_request_builder.cd("x", [1, 2, 3])
+
+    # {1,2,3}
+    assert str(builder.request.params) == "x=cd.%7B1%2C2%2C3%7D"
+
+
+def test_contained_by_non_string_items(filter_request_builder):
+    builder = filter_request_builder.contained_by("x", [1, 2, 3])
+
+    # {1,2,3}
+    assert str(builder.request.params) == "x=cd.%7B1%2C2%2C3%7D"
+
+
+def test_overlaps_non_string_items(filter_request_builder):
+    builder = filter_request_builder.overlaps("x", [1, 2, 3])
+
+    # {1,2,3}
+    assert str(builder.request.params) == "x=ov.%7B1%2C2%2C3%7D"
+
+
 def test_contains_in_list(filter_request_builder):
     builder = filter_request_builder.contains("x", '[{"a": "b"}]')
 


### PR DESCRIPTION
## What

Fixes #1529.

The array/range filter methods `cs`, `cd`, `contains`, `contained_by`, and `ov` (and `overlaps`, which delegates to `ov`) passed values directly to `",".join(...)`, which raises `TypeError` on non-string iterables like integer arrays — even though the signatures accept `Iterable[Any]`. `in_` already avoids this by mapping through `sanitize_param`.

```python
builder.contains("ids", [1, 2, 3])
# TypeError: sequence item 0: expected str instance, int found
```

Integer array columns (`int[]`) are common in Postgres, so this is easy to hit.

## Change

Coerce each element with `str()` before joining in the five affected methods, so `.contains("ids", [1, 2, 3])` builds `{1,2,3}`. This mirrors what `in_` already does and leaves existing string behaviour unchanged (verified against the existing tests, including ones with reserved characters like `overlaps("x", ["is:closed", "severity:high"])`).

The change is in the shared `base_request_builder.py`, so it fixes both sync and async builders.

## Tests

Added `test_{contains,cs,cd,contained_by,overlaps}_non_string_items` to both the async and sync filter-builder test suites. They fail on `main` (`TypeError`) and pass with the fix. Full filter test suite: 84 passed.