### PR TITLE
refactor(postgrest): replace Any with explicit types in array filters

### DIFF
--- a/src/postgrest/src/postgrest/base_request_builder.py
+++ b/src/postgrest/src/postgrest/base_request_builder.py
@@ -39,7 +39,15 @@ except ImportError:
     from pydantic import validator as field_validator  # type: ignore
 
 from .base_client import BasePostgrestClient
-from .types import JSON, CountMethod, Filters, JSONAdapter, RequestMethod, ReturnMethod
+from .types import (
+    JSON,
+    CountMethod,
+    Filters,
+    FilterValue,
+    JSONAdapter,
+    RequestMethod,
+    ReturnMethod,
+)
 from .utils import sanitize_param
 
 
@@ -449,21 +457,20 @@ class BaseFilterRequestBuilder(Generic[C]):
     def wfts(self: Self, column: str, query: Any) -> Self:
         return self.filter(column, Filters.WFTS, query)
 
-    def in_(self: Self, column: str, values: Iterable[Any]) -> Self:
-        values = map(sanitize_param, values)
-        values = ",".join(values)
-        return self.filter(column, Filters.IN, f"({values})")
+    def in_(self: Self, column: str, values: Iterable[FilterValue]) -> Self:
+        stringified_values = ",".join(map(sanitize_param, values))
+        return self.filter(column, Filters.IN, f"({stringified_values})")
 
-    def cs(self: Self, column: str, values: Iterable[Any]) -> Self:
+    def cs(self: Self, column: str, values: Iterable[FilterValue]) -> Self:
         values = ",".join(str(v) for v in values)
         return self.filter(column, Filters.CS, f"{{{values}}}")
 
-    def cd(self: Self, column: str, values: Iterable[Any]) -> Self:
+    def cd(self: Self, column: str, values: Iterable[FilterValue]) -> Self:
         values = ",".join(str(v) for v in values)
         return self.filter(column, Filters.CD, f"{{{values}}}")
 
     def contains(
-        self: Self, column: str, value: Union[Iterable[Any], str, Dict[Any, Any]]
+        self: Self, column: str, value: Union[Iterable[FilterValue], str, Dict[str, JSON]]
     ) -> Self:
         if isinstance(value, str):
             # range types can be inclusive '[', ']' or exclusive '(', ')' so just
@@ -477,7 +484,7 @@ class BaseFilterRequestBuilder(Generic[C]):
         return self.filter(column, Filters.CS, json.dumps(value))
 
     def contained_by(
-        self: Self, column: str, value: Union[Iterable[Any], str, Dict[Any, Any]]
+        self: Self, column: str, value: Union[Iterable[FilterValue], str, Dict[str, JSON]]
     ) -> Self:
         if isinstance(value, str):
             # range
@@ -487,7 +494,9 @@ class BaseFilterRequestBuilder(Generic[C]):
             return self.filter(column, Filters.CD, f"{{{stringified_values}}}")
         return self.filter(column, Filters.CD, json.dumps(value))
 
-    def ov(self: Self, column: str, value: Iterable[Any]) -> Self:
+    def ov(
+        self: Self, column: str, value: Union[Iterable[FilterValue], str, Dict[str, JSON]]
+    ) -> Self:
         if isinstance(value, str):
             # range types can be inclusive '[', ']' or exclusive '(', ')' so just
             # keep it simple and accept a string
@@ -528,7 +537,7 @@ class BaseFilterRequestBuilder(Generic[C]):
     def range_adjacent(self: Self, column: str, range: Tuple[int, int]) -> Self:
         return self.adj(column, range)
 
-    def overlaps(self: Self, column: str, values: Iterable[Any]) -> Self:
+    def overlaps(self: Self, column: str, values: Iterable[FilterValue]) -> Self:
         return self.ov(column, values)
 
     def match(self: Self, query: Dict[str, Any]) -> Self:

--- a/src/postgrest/src/postgrest/types.py
+++ b/src/postgrest/src/postgrest/types.py
@@ -20,6 +20,11 @@ JSON = TypeAliasType(
 )
 JSONAdapter: TypeAdapter = TypeAdapter(JSON)
 
+# A scalar value accepted by PostgREST filter operators. Used instead of ``Any``
+# so the accepted types are explicit; values are still coerced to ``str`` when
+# serialized into the query string.
+FilterValue = Union[str, int, float, bool]
+
 
 class CountMethod(StrEnum):
     exact = "exact"


### PR DESCRIPTION
Follow-up to #1530.

In the review there, @o-santi noted the proper fix is to remove `Any` from the filter arguments and be stricter about the types users provide. This does that for the array/collection filters.

## Change
- Add a `FilterValue = Union[str, int, float, bool]` alias in `types.py`.
- Type `in_`, `cs`, `cd`, `contains`, `contained_by`, `ov`, and `overlaps` with `Iterable[FilterValue]` instead of `Iterable[Any]`, and type the JSON-object branch of `contains`/`contained_by`/`ov` as `Dict[str, JSON]`.
- Runtime `str` coercion (from #1530) is kept, so integer arrays still work — this just makes the *accepted* types explicit at the type level.

## Checks
- `mypy` clean on the changed files.
- Existing sync + async filter tests pass (84).

## Scope
I kept this to the array/collection filters that #1530 touched. Happy to extend the same treatment to the scalar operators (`eq`, `neq`, `gt`, …, which still take `value: Any`) in this PR or a separate one — whichever you prefer. And of course feel free to adjust the target types or close this if you'd rather own the wider cleanup.