### PR TITLE
fix(postgrest): normalize boolean values in is_() to lowercase literals

### DIFF
--- a/src/postgrest/src/postgrest/base_request_builder.py
+++ b/src/postgrest/src/postgrest/base_request_builder.py
@@ -366,6 +366,10 @@ class BaseFilterRequestBuilder(Generic[C]):
         """
         if value is None:
             value = "null"
+        elif value is True:
+            value = "true"
+        elif value is False:
+            value = "false"
         return self.filter(column, Filters.IS, value)
 
     def like(self: Self, column: str, pattern: str) -> Self:

--- a/src/postgrest/tests/_async/test_filter_request_builder.py
+++ b/src/postgrest/tests/_async/test_filter_request_builder.py
@@ -282,6 +282,26 @@ def test_is_(filter_request_builder):
     assert str(builder.request.params) == "x=is.a"
 
 
+def test_is_true(filter_request_builder):
+    # PostgREST's `is` operator is case-sensitive and only accepts lowercase
+    # trilean literals, so a Python ``True`` must become ``is.true``.
+    builder = filter_request_builder.is_("x", True)
+
+    assert str(builder.request.params) == "x=is.true"
+
+
+def test_is_false(filter_request_builder):
+    builder = filter_request_builder.is_("x", False)
+
+    assert str(builder.request.params) == "x=is.false"
+
+
+def test_is_none(filter_request_builder):
+    builder = filter_request_builder.is_("x", None)
+
+    assert str(builder.request.params) == "x=is.null"
+
+
 def test_in_(filter_request_builder):
     builder = filter_request_builder.in_("x", ["a", "b"])
 

--- a/src/postgrest/tests/_sync/test_filter_request_builder.py
+++ b/src/postgrest/tests/_sync/test_filter_request_builder.py
@@ -282,6 +282,26 @@ def test_is_(filter_request_builder):
     assert str(builder.request.params) == "x=is.a"
 
 
+def test_is_true(filter_request_builder):
+    # PostgREST's `is` operator is case-sensitive and only accepts lowercase
+    # trilean literals, so a Python ``True`` must become ``is.true``.
+    builder = filter_request_builder.is_("x", True)
+
+    assert str(builder.request.params) == "x=is.true"
+
+
+def test_is_false(filter_request_builder):
+    builder = filter_request_builder.is_("x", False)
+
+    assert str(builder.request.params) == "x=is.false"
+
+
+def test_is_none(filter_request_builder):
+    builder = filter_request_builder.is_("x", None)
+
+    assert str(builder.request.params) == "x=is.null"
+
+
 def test_in_(filter_request_builder):
     builder = filter_request_builder.in_("x", ["a", "b"])
 


### PR DESCRIPTION
No linked issue — found by reading the postgrest filter builder.

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

`is_()` normalizes Python `None` to the PostgREST literal `null`, but does nothing for Python booleans. A boolean therefore falls through to `filter()`, which formats it into the query string as `is.True` / `is.False`:

```python
client.table("t").select("*").is_("active", True)
# -> ?active=is.True
```

PostgREST's `is` operator is case-sensitive and only accepts the lowercase trilean literals `null`, `true`, `false`, `unknown` (see postgrest/postgrest#2077). `is.True` is rejected by the server, so `.is_(col, True)` / `.is_(col, False)` — the natural way to filter a boolean column against `IS TRUE` / `IS FALSE` — produce a failing request.

## What is the new behavior?

`is_()` converts `True`/`False` to `"true"`/`"false"`, using `is True` / `is False` identity checks so only real booleans are touched — strings such as `"unknown"` / `"not_null"` and any other value pass through unchanged. This matches supabase-js, whose `.is('col', true)` emits `is.true`.

```python
client.table("t").select("*").is_("active", True)   # -> ?active=is.true
client.table("t").select("*").is_("active", False)  # -> ?active=is.false
client.table("t").select("*").is_("active", None)   # -> ?active=is.null   (unchanged)
```

## Additional context

The fix lives in the shared `base_request_builder.py`, so it covers both the sync and async clients. Added `test_is_true` / `test_is_false` / `test_is_none` to the postgrest filter-builder tests (`_async` and `_sync`). The full postgrest unit suite passes and `ruff` check + format are clean.
