### PR TITLE
fix(functions): copy headers in invoke() to avoid leaking them across calls

### DIFF
--- a/src/functions/src/supabase_functions/_async/functions_client.py
+++ b/src/functions/src/supabase_functions/_async/functions_client.py
@@ -136,7 +136,9 @@ class AsyncFunctionsClient:
         """
         if not is_valid_str_arg(function_name):
             raise ValueError("function_name must a valid string value.")
-        headers = self.headers
+        # Copy the client headers so per-call headers and the body Content-Type
+        # don't leak back into self.headers and bleed into later invoke() calls.
+        headers = {**self.headers}
         params = QueryParams()
         body = None
         response_type = "text/plain"

--- a/src/functions/src/supabase_functions/_sync/functions_client.py
+++ b/src/functions/src/supabase_functions/_sync/functions_client.py
@@ -136,7 +136,9 @@ class SyncFunctionsClient:
         """
         if not is_valid_str_arg(function_name):
             raise ValueError("function_name must a valid string value.")
-        headers = self.headers
+        # Copy the client headers so per-call headers and the body Content-Type
+        # don't leak back into self.headers and bleed into later invoke() calls.
+        headers = {**self.headers}
         params = QueryParams()
         body = None
         response_type = "text/plain"

--- a/src/functions/tests/_async/test_function_client.py
+++ b/src/functions/tests/_async/test_function_client.py
@@ -96,6 +96,31 @@ async def test_invoke_success_binary(client: AsyncFunctionsClient) -> None:
         mock_request.assert_called_once()
 
 
+async def test_invoke_does_not_leak_headers_between_calls(
+    client: AsyncFunctionsClient,
+) -> None:
+    # invoke() must not mutate the client's persistent headers: a per-call
+    # header and the body Content-Type must not bleed into later calls.
+    before = dict(client.headers)
+
+    mock_response = Mock(spec=Response)
+    mock_response.json.return_value = {}
+    mock_response.content = b""
+    mock_response.raise_for_status = Mock()
+    mock_response.headers = {}
+
+    with patch.object(
+        client._client, "request", new_callable=AsyncMock
+    ) as mock_request:
+        mock_request.return_value = mock_response
+
+        await client.invoke("fn1", {"body": {"a": 1}, "headers": {"X-Once": "1"}})
+
+    assert dict(client.headers) == before
+    assert "X-Once" not in client.headers
+    assert "Content-Type" not in client.headers
+
+
 async def test_invoke_with_region(client: AsyncFunctionsClient) -> None:
     mock_response = Mock(spec=Response)
     mock_response.json.return_value = {"message": "success"}

--- a/src/functions/tests/_sync/test_function_client.py
+++ b/src/functions/tests/_sync/test_function_client.py
@@ -92,6 +92,29 @@ def test_invoke_success_binary(client: SyncFunctionsClient) -> None:
         mock_request.assert_called_once()
 
 
+def test_invoke_does_not_leak_headers_between_calls(
+    client: SyncFunctionsClient,
+) -> None:
+    # invoke() must not mutate the client's persistent headers: a per-call
+    # header and the body Content-Type must not bleed into later calls.
+    before = dict(client.headers)
+
+    mock_response = Mock(spec=Response)
+    mock_response.json.return_value = {}
+    mock_response.content = b""
+    mock_response.raise_for_status = Mock()
+    mock_response.headers = {}
+
+    with patch.object(client._client, "request", new_callable=Mock) as mock_request:
+        mock_request.return_value = mock_response
+
+        client.invoke("fn1", {"body": {"a": 1}, "headers": {"X-Once": "1"}})
+
+    assert dict(client.headers) == before
+    assert "X-Once" not in client.headers
+    assert "Content-Type" not in client.headers
+
+
 def test_invoke_with_region(client: SyncFunctionsClient) -> None:
     mock_response = Mock(spec=Response)
     mock_response.json.return_value = {"message": "success"}


### PR DESCRIPTION
No linked issue — found by reading the functions client.

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

`AsyncFunctionsClient.invoke()` (and its sync twin) aliases the client's persistent header dict instead of copying it:

```python
headers = self.headers
...
headers.update(invoke_options.get("headers", {}))   # mutates self.headers
...
headers["Content-Type"] = "application/json"         # mutates self.headers
```

So every call's one-off `headers` option, its `x-region`, and the body `Content-Type` are written back onto `self.headers` and leak into all later `invoke()` calls:

```python
await client.invoke("fn1", {"body": {...}, "headers": {"X-Once": "1"}})
await client.invoke("fn2")   # still sends X-Once: 1 and a stale Content-Type
```

## What is the new behavior?

`invoke()` copies the client headers (`headers = {**self.headers}`) before mutating them, so per-call headers stay per-call and `self.headers` is never modified. This matches functions-js, which builds a fresh header object per request, and completes the header-mutation fix from #1249 (which corrected the constructor but left this `invoke()` path aliasing `self.headers`).

## Additional context

Fixed in both `_async` and `_sync` clients. Added `test_invoke_does_not_leak_headers_between_calls` to the async and sync test suites — it fails on the current code (`self.headers` gains `Content-Type` and the per-call header) and passes with the fix. Full functions test suite passes; `ruff` check + format are clean.
