### PR TITLE
docs: fix code of conduct link in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ We highly appreciate feedback and contributions from the community! If you'd lik
 
 ## Code of conduct
 
-In the interest of fostering an open and welcoming environment, please review and follow our [code of conduct](./CODE_OF_CONDUCT.md).
+In the interest of fostering an open and welcoming environment, please review and follow our [code of conduct](https://github.com/supabase/.github/blob/main/CODE_OF_CONDUCT.md).
 
 ## Code and copy reviews
 


### PR DESCRIPTION
CONTRIBUTING.md links to `./CODE_OF_CONDUCT.md`, which doesn't exist in this repo, so the link 404s.

The code of conduct lives in the org-wide health files repo: https://github.com/supabase/.github/blob/main/CODE_OF_CONDUCT.md (GitHub already applies it to this repo's community profile). This updates the link to point there instead of adding a duplicate file.

Documentation-only change, same shape as #1493.

cc @olirice @silentworks
