### PR TITLE
fix(utils): remove stray debug print in AsyncHttpIO

### DIFF
--- a/src/utils/src/supabase_utils/http/io.py
+++ b/src/utils/src/supabase_utils/http/io.py
@@ -102,7 +102,6 @@ class AsyncHttpIO:
                 if request.delay:
                     await asyncio.sleep(request.delay)
                 response = await self.session.send(request)
-                print(response)
                 http_request = iterator.send(response)
         except StopIteration:
             return return_value_iterator.return_value


### PR DESCRIPTION
Removes a leftover debug print in AsyncHttpIO.communicate. Every async request on the v3 branch currently prints its full response to stdout. Noticed while reading the v3 work discussed in #1251.