### PR TITLE
fix(ci): point SDK compliance workflow at the python reusable workflow

### DIFF
--- a/.github/workflows/validate-capabilities.yml
+++ b/.github/workflows/validate-capabilities.yml
@@ -11,9 +11,8 @@ permissions:
 
 jobs:
   validate:
-    uses: supabase/sdk/.github/workflows/validate-sdk-compliance.yml@main
+    uses: supabase/sdk/.github/workflows/validate-sdk-compliance-python.yml@main
     with:
-      language: python
       griffe-packages: >-
         supabase supabase_auth postgrest storage3 realtime supabase_functions
       griffe-search-paths: >-


### PR DESCRIPTION
`validate-capabilities.yml` calls `supabase/sdk/.github/workflows/validate-sdk-compliance.yml@main`, but that workflow does not exist in `supabase/sdk`. The compliance workflows there are per language: `validate-sdk-compliance-python.yml`, `-dart`, `-javascript`, `-swift`.

So the job fails before it runs on every PR:

```
error parsing called workflow ".github/workflows/validate-capabilities.yml"
-> "supabase/sdk/.github/workflows/validate-sdk-compliance.yml@main"
: failed to fetch workflow: workflow was not found.
```

This is happening on all open PRs right now, including dependabot's and internal ones, not just fork PRs.

This points the job at `validate-sdk-compliance-python.yml` and drops the `language` input, which that workflow does not declare (the language is implied by which workflow you call). `griffe-packages` and `griffe-search-paths` are unchanged and match the inputs it expects.

Introduced in #1518.
