### PR TITLE
feat(postgrest): add structured execution results

### DIFF
--- a/src/postgrest/docs/api/responses.rst
+++ b/src/postgrest/docs/api/responses.rst
@@ -5,3 +5,9 @@ Once a query is run, the library parses the server's response into an APIRespons
 
 .. autoclass:: postgrest.APIResponse
     :members:
+
+For callers that prefer to handle failures without exceptions, ``execute_result``
+returns a structured result for both successful and unsuccessful HTTP responses.
+
+.. autoclass:: postgrest.ExecuteResult
+    :members:

--- a/src/postgrest/src/postgrest/__init__.py
+++ b/src/postgrest/src/postgrest/__init__.py
@@ -22,7 +22,7 @@ from ._sync.request_builder import (
     SyncSelectRequestBuilder,
     SyncSingleRequestBuilder,
 )
-from .base_request_builder import APIResponse
+from .base_request_builder import APIResponse, ExecuteResult
 from .constants import DEFAULT_POSTGREST_CLIENT_HEADERS
 from .exceptions import APIError
 from .types import (
@@ -51,6 +51,7 @@ __all__ = [
     "SyncSelectRequestBuilder",
     "SyncSingleRequestBuilder",
     "APIResponse",
+    "ExecuteResult",
     "DEFAULT_POSTGREST_CLIENT_HEADERS",
     "APIError",
     "CountMethod",

--- a/src/postgrest/src/postgrest/_async/request_builder.py
+++ b/src/postgrest/src/postgrest/_async/request_builder.py
@@ -14,6 +14,7 @@ from ..base_request_builder import (
     BaseRPCRequestBuilder,
     BaseSelectRequestBuilder,
     CountMethod,
+    ExecuteResult,
     RequestConfig,
     SingleAPIResponse,
     pre_delete,
@@ -54,6 +55,25 @@ async def send_with_retry(req: ReqConfig) -> Response:
         await asyncio.sleep(get_retry_delay(resp, attempt_count))
         attempt_count += 1
     return resp
+
+
+def _error_result(response: Response) -> ExecuteResult:
+    try:
+        json_obj = model_validate_json(APIErrorFromJSON, response.content)
+        error = dict(json_obj)
+    except ValidationError:
+        try:
+            error = response.json()
+            if not isinstance(error, dict):
+                raise ValueError
+        except ValueError:
+            error = generate_default_error_message(response)
+    return ExecuteResult(
+        type="error",
+        data=None,
+        error=error,
+        status=response.status_code,
+    )
 
 
 class AsyncQueryRequestBuilder:
@@ -97,6 +117,19 @@ class AsyncQueryRequestBuilder:
         except ValidationError as e:
             raise APIError(generate_default_error_message(r))
 
+    async def execute_result(self) -> ExecuteResult:
+        """Execute the query and return a result without raising ``APIError``."""
+        r = await send_with_retry(self.request)
+        if r.is_success:
+            response = APIResponse.from_http_request_response(r)
+            return ExecuteResult(
+                type="success",
+                data=response.data,
+                status=r.status_code,
+                count=response.count,
+            )
+        return _error_result(r)
+
 
 class AsyncSingleRequestBuilder:
     def __init__(self, request: ReqConfig):
@@ -130,6 +163,19 @@ class AsyncSingleRequestBuilder:
         except ValidationError as e:
             raise APIError(generate_default_error_message(r))
 
+    async def execute_result(self) -> ExecuteResult:
+        """Execute the query and return a result without raising ``APIError``."""
+        r = await send_with_retry(self.request)
+        if 200 <= r.status_code <= 299:
+            response = SingleAPIResponse.from_http_request_response(r)
+            return ExecuteResult(
+                type="success",
+                data=response.data,
+                status=r.status_code,
+                count=response.count,
+            )
+        return _error_result(r)
+
 
 class AsyncExplainRequestBuilder:
     def __init__(self, request: ReqConfig):
@@ -149,6 +195,13 @@ class AsyncExplainRequestBuilder:
                 raise APIError(dict(json_obj))
         except ValidationError as e:
             raise APIError(generate_default_error_message(r))
+
+    async def execute_result(self) -> ExecuteResult:
+        """Execute the explain query and return a result without raising ``APIError``."""
+        r = await send_with_retry(self.request)
+        if r.is_success:
+            return ExecuteResult(type="success", data=r.text, status=r.status_code)
+        return _error_result(r)
 
 
 class AsyncMaybeSingleRequestBuilder:
@@ -182,6 +235,39 @@ class AsyncMaybeSingleRequestBuilder:
                 raise APIError(dict(json_obj))
         except ValidationError as e:
             raise APIError(generate_default_error_message(r))
+
+    async def execute_result(self) -> ExecuteResult:
+        """Execute the query and return a result without raising ``APIError``."""
+        r = await send_with_retry(self.request)
+        if not r.is_success:
+            return _error_result(r)
+
+        parsed = APIResponse.from_http_request_response(r)
+        if len(parsed.data) == 0:
+            return ExecuteResult(
+                type="success",
+                data=None,
+                status=r.status_code,
+                count=parsed.count,
+            )
+        if len(parsed.data) == 1:
+            return ExecuteResult(
+                type="success",
+                data=parsed.data[0],
+                status=r.status_code,
+                count=parsed.count,
+            )
+        return ExecuteResult(
+            type="error",
+            data=None,
+            error={
+                "message": "Cannot coerce the result to a single JSON object",
+                "code": "406",
+                "hint": "Please check traceback of the code",
+                "details": "The result contains more than one row.",
+            },
+            status=r.status_code,
+        )
 
 
 class AsyncFilterRequestBuilder(

--- a/src/postgrest/src/postgrest/_sync/request_builder.py
+++ b/src/postgrest/src/postgrest/_sync/request_builder.py
@@ -14,6 +14,7 @@ from ..base_request_builder import (
     BaseRPCRequestBuilder,
     BaseSelectRequestBuilder,
     CountMethod,
+    ExecuteResult,
     RequestConfig,
     SingleAPIResponse,
     pre_delete,
@@ -54,6 +55,25 @@ def send_with_retry(req: ReqConfig) -> Response:
         time.sleep(get_retry_delay(resp, attempt_count))
         attempt_count += 1
     return resp
+
+
+def _error_result(response: Response) -> ExecuteResult:
+    try:
+        json_obj = model_validate_json(APIErrorFromJSON, response.content)
+        error = dict(json_obj)
+    except ValidationError:
+        try:
+            error = response.json()
+            if not isinstance(error, dict):
+                raise ValueError
+        except ValueError:
+            error = generate_default_error_message(response)
+    return ExecuteResult(
+        type="error",
+        data=None,
+        error=error,
+        status=response.status_code,
+    )
 
 
 class SyncQueryRequestBuilder:
@@ -97,6 +117,19 @@ class SyncQueryRequestBuilder:
         except ValidationError as e:
             raise APIError(generate_default_error_message(r))
 
+    def execute_result(self) -> ExecuteResult:
+        """Execute the query and return a result without raising ``APIError``."""
+        r = send_with_retry(self.request)
+        if r.is_success:
+            response = APIResponse.from_http_request_response(r)
+            return ExecuteResult(
+                type="success",
+                data=response.data,
+                status=r.status_code,
+                count=response.count,
+            )
+        return _error_result(r)
+
 
 class SyncSingleRequestBuilder:
     def __init__(self, request: ReqConfig):
@@ -130,6 +163,19 @@ class SyncSingleRequestBuilder:
         except ValidationError as e:
             raise APIError(generate_default_error_message(r))
 
+    def execute_result(self) -> ExecuteResult:
+        """Execute the query and return a result without raising ``APIError``."""
+        r = send_with_retry(self.request)
+        if 200 <= r.status_code <= 299:
+            response = SingleAPIResponse.from_http_request_response(r)
+            return ExecuteResult(
+                type="success",
+                data=response.data,
+                status=r.status_code,
+                count=response.count,
+            )
+        return _error_result(r)
+
 
 class SyncExplainRequestBuilder:
     def __init__(self, request: ReqConfig):
@@ -149,6 +195,13 @@ class SyncExplainRequestBuilder:
                 raise APIError(dict(json_obj))
         except ValidationError as e:
             raise APIError(generate_default_error_message(r))
+
+    def execute_result(self) -> ExecuteResult:
+        """Execute the explain query and return a result without raising ``APIError``."""
+        r = send_with_retry(self.request)
+        if r.is_success:
+            return ExecuteResult(type="success", data=r.text, status=r.status_code)
+        return _error_result(r)
 
 
 class SyncMaybeSingleRequestBuilder:
@@ -182,6 +235,39 @@ class SyncMaybeSingleRequestBuilder:
                 raise APIError(dict(json_obj))
         except ValidationError as e:
             raise APIError(generate_default_error_message(r))
+
+    def execute_result(self) -> ExecuteResult:
+        """Execute the query and return a result without raising ``APIError``."""
+        r = send_with_retry(self.request)
+        if not r.is_success:
+            return _error_result(r)
+
+        parsed = APIResponse.from_http_request_response(r)
+        if len(parsed.data) == 0:
+            return ExecuteResult(
+                type="success",
+                data=None,
+                status=r.status_code,
+                count=parsed.count,
+            )
+        if len(parsed.data) == 1:
+            return ExecuteResult(
+                type="success",
+                data=parsed.data[0],
+                status=r.status_code,
+                count=parsed.count,
+            )
+        return ExecuteResult(
+            type="error",
+            data=None,
+            error={
+                "message": "Cannot coerce the result to a single JSON object",
+                "code": "406",
+                "hint": "Please check traceback of the code",
+                "details": "The result contains more than one row.",
+            },
+            status=r.status_code,
+        )
 
 
 class SyncFilterRequestBuilder(

--- a/src/postgrest/src/postgrest/base_request_builder.py
+++ b/src/postgrest/src/postgrest/base_request_builder.py
@@ -261,6 +261,21 @@ class APIResponse(BaseModel):
         return APIResponse.model_construct(data=data, count=count)
 
 
+class ExecuteResult(BaseModel):
+    """A non-throwing result returned by ``execute_result``."""
+
+    type: Literal["success", "error"]
+    """Whether the request succeeded or failed."""
+    data: Optional[Any] = None
+    """The data returned by a successful request."""
+    error: Optional[Dict[str, Any]] = None
+    """The error details returned by a failed request."""
+    status: int
+    """The HTTP status code returned by the server."""
+    count: Optional[int] = None
+    """The number of rows returned, when requested."""
+
+
 class SingleAPIResponse(APIResponse):
     data: JSON  # type: ignore
     """The data returned by the query."""

--- a/src/postgrest/tests/_async/test_client.py
+++ b/src/postgrest/tests/_async/test_client.py
@@ -15,6 +15,7 @@ from httpx import (
 
 from postgrest import AsyncPostgrestClient
 from postgrest.exceptions import APIError
+from postgrest.types import ReturnMethod
 
 
 @pytest.fixture
@@ -176,3 +177,108 @@ async def test_response_client_invalid_response_but_valid_json(
         assert isinstance(exc_response.get("message"), str)
         assert exc_response.get("message") == "JSON could not be generated"
         assert "code" in exc_response and int(exc_response["code"]) == 502
+
+
+@pytest.mark.asyncio
+async def test_execute_result_returns_success_response(
+    postgrest_client: AsyncPostgrestClient,
+):
+    with patch(
+        "httpx._client.AsyncClient.request",
+        return_value=Response(
+            status_code=201,
+            text='[{"id": 1}]',
+            request=Request(method="GET", url="http://example.com"),
+        ),
+    ):
+        result = await postgrest_client.from_("test").select("id").execute_result()
+
+    assert result.type == "success"
+    assert result.data == [{"id": 1}]
+    assert result.error is None
+    assert result.status == 201
+
+
+@pytest.mark.asyncio
+async def test_execute_result_returns_error_response(
+    postgrest_client: AsyncPostgrestClient,
+):
+    with patch(
+        "httpx._client.AsyncClient.request",
+        return_value=Response(
+            status_code=400,
+            text='{"message": "Bad request", "code": "PGRST000"}',
+            request=Request(method="GET", url="http://example.com"),
+        ),
+    ):
+        result = await postgrest_client.from_("test").select("id").execute_result()
+
+    assert result.type == "error"
+    assert result.data is None
+    assert result.error is not None
+    assert result.error["message"] == "Bad request"
+    assert result.error["code"] == "PGRST000"
+    assert result.status == 400
+
+
+@pytest.mark.asyncio
+async def test_execute_result_returns_empty_success_response(
+    postgrest_client: AsyncPostgrestClient,
+):
+    with patch(
+        "httpx._client.AsyncClient.request",
+        return_value=Response(
+            status_code=204,
+            request=Request(method="POST", url="http://example.com"),
+        ),
+    ):
+        result = await postgrest_client.from_("test").insert(
+            {"id": 1}, returning=ReturnMethod.minimal
+        ).execute_result()
+
+    assert result.type == "success"
+    assert result.data == []
+    assert result.error is None
+    assert result.status == 204
+
+
+@pytest.mark.asyncio
+async def test_execute_result_returns_single_response(
+    postgrest_client: AsyncPostgrestClient,
+):
+    with patch(
+        "httpx._client.AsyncClient.request",
+        return_value=Response(
+            status_code=200,
+            text='{"id": 1}',
+            request=Request(method="GET", url="http://example.com"),
+        ),
+    ):
+        result = await (
+            postgrest_client.from_("test").select("id").single().execute_result()
+        )
+
+    assert result.type == "success"
+    assert result.data == {"id": 1}
+    assert result.status == 200
+
+
+@pytest.mark.asyncio
+async def test_execute_result_returns_none_for_empty_maybe_single(
+    postgrest_client: AsyncPostgrestClient,
+):
+    with patch(
+        "httpx._client.AsyncClient.request",
+        return_value=Response(
+            status_code=200,
+            text="[]",
+            request=Request(method="GET", url="http://example.com"),
+        ),
+    ):
+        result = await (
+            postgrest_client.from_("test").select("id").maybe_single().execute_result()
+        )
+
+    assert result.type == "success"
+    assert result.data is None
+    assert result.status == 200

--- a/src/postgrest/tests/_sync/test_client.py
+++ b/src/postgrest/tests/_sync/test_client.py
@@ -15,6 +15,7 @@ from httpx import (
 
 from postgrest import SyncPostgrestClient
 from postgrest.exceptions import APIError
+from postgrest.types import ReturnMethod
 
 
 @pytest.fixture
@@ -174,3 +175,103 @@ def test_response_client_invalid_response_but_valid_json(
         assert isinstance(exc_response.get("message"), str)
         assert exc_response.get("message") == "JSON could not be generated"
         assert "code" in exc_response and int(exc_response["code"]) == 502
+
+
+def test_execute_result_returns_success_response(
+    postgrest_client: SyncPostgrestClient,
+):
+    with patch(
+        "httpx._client.Client.request",
+        return_value=Response(
+            status_code=201,
+            text='[{"id": 1}]',
+            request=Request(method="GET", url="http://example.com"),
+        ),
+    ):
+        result = postgrest_client.from_("test").select("id").execute_result()
+
+    assert result.type == "success"
+    assert result.data == [{"id": 1}]
+    assert result.error is None
+    assert result.status == 201
+
+
+def test_execute_result_returns_error_response(
+    postgrest_client: SyncPostgrestClient,
+):
+    with patch(
+        "httpx._client.Client.request",
+        return_value=Response(
+            status_code=400,
+            text='{"message": "Bad request", "code": "PGRST000"}',
+            request=Request(method="GET", url="http://example.com"),
+        ),
+    ):
+        result = postgrest_client.from_("test").select("id").execute_result()
+
+    assert result.type == "error"
+    assert result.data is None
+    assert result.error is not None
+    assert result.error["message"] == "Bad request"
+    assert result.error["code"] == "PGRST000"
+    assert result.status == 400
+
+
+def test_execute_result_returns_empty_success_response(
+    postgrest_client: SyncPostgrestClient,
+):
+    with patch(
+        "httpx._client.Client.request",
+        return_value=Response(
+            status_code=204,
+            request=Request(method="POST", url="http://example.com"),
+        ),
+    ):
+        result = postgrest_client.from_("test").insert(
+            {"id": 1}, returning=ReturnMethod.minimal
+        ).execute_result()
+
+    assert result.type == "success"
+    assert result.data == []
+    assert result.error is None
+    assert result.status == 204
+
+
+def test_execute_result_returns_single_response(
+    postgrest_client: SyncPostgrestClient,
+):
+    with patch(
+        "httpx._client.Client.request",
+        return_value=Response(
+            status_code=200,
+            text='{"id": 1}',
+            request=Request(method="GET", url="http://example.com"),
+        ),
+    ):
+        result = (
+            postgrest_client.from_("test").select("id").single().execute_result()
+        )
+
+    assert result.type == "success"
+    assert result.data == {"id": 1}
+    assert result.status == 200
+
+
+def test_execute_result_returns_none_for_empty_maybe_single(
+    postgrest_client: SyncPostgrestClient,
+):
+    with patch(
+        "httpx._client.Client.request",
+        return_value=Response(
+            status_code=200,
+            text="[]",
+            request=Request(method="GET", url="http://example.com"),
+        ),
+    ):
+        result = (
+            postgrest_client.from_("test").select("id").maybe_single().execute_result()
+        )
+
+    assert result.type == "success"
+    assert result.data is None
+    assert result.status == 200

--- a/src/supabase/src/supabase/__init__.py
+++ b/src/supabase/src/supabase/__init__.py
@@ -1,5 +1,6 @@
 from postgrest import APIError as PostgrestAPIError
 from postgrest import APIResponse as PostgrestAPIResponse
+from postgrest import ExecuteResult as PostgrestExecuteResult
 from realtime import AuthorizationError, NotConnectedError
 from storage3.utils import StorageException
 from supabase_auth.errors import (
@@ -58,6 +59,7 @@ __all__ = (
     "ClientOptions",
     "PostgrestAPIError",
     "PostgrestAPIResponse",
+    "PostgrestExecuteResult",
     "StorageException",
     "__version__",
     "AuthApiError",

--- a/src/supabase/src/supabase/client.py
+++ b/src/supabase/src/supabase/client.py
@@ -1,5 +1,6 @@
 from postgrest import APIError as PostgrestAPIError
 from postgrest import APIResponse as PostgrestAPIResponse
+from postgrest import ExecuteResult as PostgrestExecuteResult
 from realtime import AuthorizationError, NotConnectedError
 from storage3.utils import StorageException
 from supabase_auth.errors import (
@@ -53,6 +54,7 @@ __all__ = [
     "SupabaseStorageClient",
     "PostgrestAPIError",
     "PostgrestAPIResponse",
+    "PostgrestExecuteResult",
     "StorageException",
     "__version__",
     "AuthApiError",


### PR DESCRIPTION
## Summary

Adds an opt-in, non-throwing execution API that returns structured results similar to the Supabase JavaScript client.

Relates to #1548

## What changed

Added `execute_result()` to PostgREST request builders.

Successful responses return:

```python
ExecuteResult(
    type="success",
    data=...,
    error=None,
    status=200,
    count=...,
)
```

Failed responses return:

```python
ExecuteResult(
    type="error",
    data=None,
    error={...},
    status=400,
)
```

- successful requests still return `APIResponse`
- failed requests still raise `APIError`

The new API supports normal queries, `single()`, `maybe_single()`, and synchronous and asynchronous clients.

## Additional changes

- Added the `ExecuteResult` response model.
- Exported it from the `postgrest` package.
- Re-exported it through `supabase`.
- Added response documentation.
- Added sync and async tests covering successful responses, errors, HTTP status codes, empty responses, `single()`, and `maybe_single()`.

## Validation

- Ruff: passed
- Mypy: passed
- Public export validation: passed
- Focused sync/async tests: 14 passed

The complete integration suite was not completed locally. The focused tests and static checks pass, and the remaining validation can be completed by CI.