### PR TITLE
fix(postgrest): align rpc maybe_single with select

### DIFF
--- a/src/postgrest/src/postgrest/_async/request_builder.py
+++ b/src/postgrest/src/postgrest/_async/request_builder.py
@@ -197,6 +197,10 @@ class AsyncRPCFilterRequestBuilder(BaseRPCRequestBuilder, AsyncSingleRequestBuil
         BaseFilterRequestBuilder.__init__(self, request)
         AsyncSingleRequestBuilder.__init__(self, request)
 
+    def maybe_single(self) -> AsyncMaybeSingleRequestBuilder:
+        """Retrieves at most one row from the result. Result must be at most one row (e.g. using `eq` on a UNIQUE column), otherwise this will result in an error."""
+        return AsyncMaybeSingleRequestBuilder(self.request)
+
 
 class AsyncSelectRequestBuilder(
     AsyncQueryRequestBuilder, BaseSelectRequestBuilder[AsyncClient]

--- a/src/postgrest/src/postgrest/_sync/request_builder.py
+++ b/src/postgrest/src/postgrest/_sync/request_builder.py
@@ -197,6 +197,10 @@ class SyncRPCFilterRequestBuilder(BaseRPCRequestBuilder, SyncSingleRequestBuilde
         BaseFilterRequestBuilder.__init__(self, request)
         SyncSingleRequestBuilder.__init__(self, request)
 
+    def maybe_single(self) -> SyncMaybeSingleRequestBuilder:
+        """Retrieves at most one row from the result. Result must be at most one row (e.g. using `eq` on a UNIQUE column), otherwise this will result in an error."""
+        return SyncMaybeSingleRequestBuilder(self.request)
+
 
 class SyncSelectRequestBuilder(
     SyncQueryRequestBuilder, BaseSelectRequestBuilder[Client]

--- a/src/postgrest/src/postgrest/base_request_builder.py
+++ b/src/postgrest/src/postgrest/base_request_builder.py
@@ -668,11 +668,6 @@ class BaseRPCRequestBuilder(BaseSelectRequestBuilder):
         self.request.headers["Accept"] = "application/vnd.pgrst.object+json"
         return self
 
-    def maybe_single(self) -> Self:
-        """Retrieves at most one row from the result. Result must be at most one row (e.g. using `eq` on a UNIQUE column), otherwise this will result in an error."""
-        self.request.headers["Accept"] = "application/vnd.pgrst.object+json"
-        return self
-
     def csv(self) -> Self:
         """Specify that the query must retrieve data as a single CSV string."""
         self.request.headers["Accept"] = "text/csv"

--- a/src/postgrest/tests/_async/test_filter_request_builder_integration.py
+++ b/src/postgrest/tests/_async/test_filter_request_builder_integration.py
@@ -500,6 +500,32 @@ async def test_rpc_with_single():
     assert res.data == {"nicename": "Albania", "country_name": "ALBANIA", "iso": "AL"}
 
 
+async def test_rpc_with_maybe_single():
+    res = (
+        await rest_client()
+        .rpc("list_stored_countries", {})
+        .select("nicename, country_name, iso")
+        .eq("nicename", "Albania")
+        .maybe_single()
+        .execute()
+    )
+
+    assert res.data == {"nicename": "Albania", "country_name": "ALBANIA", "iso": "AL"}
+
+
+async def test_rpc_with_maybe_single_no_match():
+    res = (
+        await rest_client()
+        .rpc("list_stored_countries", {})
+        .select("nicename, country_name, iso")
+        .eq("nicename", "Wonderland")
+        .maybe_single()
+        .execute()
+    )
+
+    assert res is None
+
+
 async def test_rpc_with_limit():
     res = (
         await rest_client()

--- a/src/postgrest/tests/_async/test_filter_request_builder_integration.py
+++ b/src/postgrest/tests/_async/test_filter_request_builder_integration.py
@@ -1,4 +1,7 @@
+import pytest
+
 from postgrest import CountMethod
+from postgrest.exceptions import APIError
 
 from .client import rest_client, rest_client_httpx
 
@@ -74,6 +77,23 @@ async def test_no_match_maybe_single():
     )
 
     assert res is None
+
+
+async def test_maybe_single_multiple_rows():
+    with pytest.raises(APIError) as exc_info:
+        await (
+            rest_client()
+            .from_("countries")
+            .select("country_name, iso")
+            .lte("numcode", 8)
+            .gte("numcode", 4)
+            .maybe_single()
+            .execute()
+        )
+
+    assert exc_info.value.code == "406"
+    assert exc_info.value.message == "Cannot coerce the result to a single JSON object"
+    assert exc_info.value.details == "The result contains more than one row."
 
 
 async def test_equals():
@@ -524,6 +544,21 @@ async def test_rpc_with_maybe_single_no_match():
     )
 
     assert res is None
+
+
+async def test_rpc_with_maybe_single_multiple_rows():
+    with pytest.raises(APIError) as exc_info:
+        await (
+            rest_client()
+            .rpc("list_stored_countries", {})
+            .select("nicename, country_name, iso")
+            .maybe_single()
+            .execute()
+        )
+
+    assert exc_info.value.code == "406"
+    assert exc_info.value.message == "Cannot coerce the result to a single JSON object"
+    assert exc_info.value.details == "The result contains more than one row."
 
 
 async def test_rpc_with_limit():

--- a/src/postgrest/tests/_sync/test_filter_request_builder_integration.py
+++ b/src/postgrest/tests/_sync/test_filter_request_builder_integration.py
@@ -1,4 +1,7 @@
+import pytest
+
 from postgrest import CountMethod
+from postgrest.exceptions import APIError
 
 from .client import rest_client, rest_client_httpx
 
@@ -74,6 +77,23 @@ def test_no_match_maybe_single():
     )
 
     assert res is None
+
+
+def test_maybe_single_multiple_rows():
+    with pytest.raises(APIError) as exc_info:
+        (
+            rest_client()
+            .from_("countries")
+            .select("country_name, iso")
+            .lte("numcode", 8)
+            .gte("numcode", 4)
+            .maybe_single()
+            .execute()
+        )
+
+    assert exc_info.value.code == "406"
+    assert exc_info.value.message == "Cannot coerce the result to a single JSON object"
+    assert exc_info.value.details == "The result contains more than one row."
 
 
 def test_equals():
@@ -517,6 +537,21 @@ def test_rpc_with_maybe_single_no_match():
     )
 
     assert res is None
+
+
+def test_rpc_with_maybe_single_multiple_rows():
+    with pytest.raises(APIError) as exc_info:
+        (
+            rest_client()
+            .rpc("list_stored_countries", {})
+            .select("nicename, country_name, iso")
+            .maybe_single()
+            .execute()
+        )
+
+    assert exc_info.value.code == "406"
+    assert exc_info.value.message == "Cannot coerce the result to a single JSON object"
+    assert exc_info.value.details == "The result contains more than one row."
 
 
 def test_rpc_with_limit():

--- a/src/postgrest/tests/_sync/test_filter_request_builder_integration.py
+++ b/src/postgrest/tests/_sync/test_filter_request_builder_integration.py
@@ -493,6 +493,32 @@ def test_rpc_with_single():
     assert res.data == {"nicename": "Albania", "country_name": "ALBANIA", "iso": "AL"}
 
 
+def test_rpc_with_maybe_single():
+    res = (
+        rest_client()
+        .rpc("list_stored_countries", {})
+        .select("nicename, country_name, iso")
+        .eq("nicename", "Albania")
+        .maybe_single()
+        .execute()
+    )
+
+    assert res.data == {"nicename": "Albania", "country_name": "ALBANIA", "iso": "AL"}
+
+
+def test_rpc_with_maybe_single_no_match():
+    res = (
+        rest_client()
+        .rpc("list_stored_countries", {})
+        .select("nicename, country_name, iso")
+        .eq("nicename", "Wonderland")
+        .maybe_single()
+        .execute()
+    )
+
+    assert res is None
+
+
 def test_rpc_with_limit():
     res = (
         rest_client()


### PR DESCRIPTION
## Summary
- Make `rpc().maybe_single()` use the same `MaybeSingleRequestBuilder` path as `select().maybe_single()`, instead of setting `Accept: application/vnd.pgrst.object+json`
- Zero-row RPC results now return `None` instead of raising an `APIError`, matching select behavior (follows #1424)
- Add sync/async integration tests for match and no-match RPC `maybe_single` cases

Fixes the remaining gap from #1107 / #1207 where select was fixed but RPC still used the old Accept-header approach.

## Test plan
- [ ] `test_rpc_with_maybe_single` passes (sync + async)
- [ ] `test_rpc_with_maybe_single_no_match` returns `None` (sync + async)
- [ ] Existing `test_rpc_with_single` and select `maybe_single` tests still pass

Made with [Cursor](https://cursor.com)