### PR TITLE
fix(storage): cache control header and retry safety

### DIFF
--- a/src/storage/src/storage3/_async/file_api.py
+++ b/src/storage/src/storage3/_async/file_api.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import base64
 import json
 import urllib.parse
 from dataclasses import dataclass, field
@@ -157,19 +156,26 @@ class AsyncBucketActionsMixin:
 
         final_url = ["object", "upload", "sign", self.id, *path_parts]
 
-        options: UploadSignedUrlFileOptions = file_options or {}
-        cache_control = options.get("cache-control")
-        # cacheControl is also passed as form data
-        # https://github.com/supabase/storage-js/blob/fa44be8156295ba6320ffeff96bdf91016536a46/src/packages/StorageFileApi.ts#L89
-        _data = {}
-        if cache_control:
-            options["cache-control"] = f"max-age={cache_control}"
-            _data = {"cacheControl": cache_control}
+        options: dict[str, Any] = {
+            **DEFAULT_FILE_OPTIONS,
+            **(file_options or {}),
+        }
+        cache_control = options.pop("cache-control")
+        content_type = options.pop("content-type")
+        metadata = options.pop("metadata", None)
+        file_opts_headers = options.pop("headers", None)
+
+        _data = {"cacheControl": cache_control}
+        if metadata is not None:
+            _data["metadata"] = json.dumps(metadata)
+
         headers = {
             **self._client.headers,
-            **DEFAULT_FILE_OPTIONS,
             **options,
         }
+        if file_opts_headers:
+            headers.update(file_opts_headers)
+
         filename = path_parts[-1]
 
         if (
@@ -178,14 +184,14 @@ class AsyncBucketActionsMixin:
             or isinstance(file, FileIO)
         ):
             # bytes or byte-stream-like object received
-            _file = {"file": (filename, file, headers.pop("content-type"))}
+            _file = {"file": (filename, file, content_type)}
         else:
             # str or pathlib.path received
             _file = {
                 "file": (
                     filename,
                     open(file, "rb"),
-                    headers.pop("content-type"),
+                    content_type,
                 )
             }
         response = await self._request(
@@ -512,41 +518,38 @@ class AsyncBucketActionsMixin:
         file_options
             HTTP headers.
         """
-        if file_options is None:
-            file_options = {}
-        cache_control = file_options.pop("cache-control", None)
-        _data = {}
+        options: dict[str, Any] = {
+            **DEFAULT_FILE_OPTIONS,
+            **(file_options or {}),
+        }
+        cache_control = options.pop("cache-control")
+        content_type = options.pop("content-type")
+        _data = {"cacheControl": cache_control}
 
-        upsert = file_options.pop("upsert", None)
+        upsert = options.pop("upsert", None)
         if upsert:
-            file_options.update({"x-upsert": upsert})
+            options["x-upsert"] = upsert
 
-        metadata = file_options.pop("metadata", None)
-        file_opts_headers = file_options.pop("headers", None)
+        metadata = options.pop("metadata", None)
+        file_opts_headers = options.pop("headers", None)
 
         headers = {
             **self._client.headers,
-            **DEFAULT_FILE_OPTIONS,
-            **file_options,
+            **options,
         }
 
-        if metadata:
+        if metadata is not None:
             metadata_str = json.dumps(metadata)
-            headers["x-metadata"] = base64.b64encode(metadata_str.encode())
-            _data.update({"metadata": metadata_str})
-
-        if file_opts_headers:
-            headers.update({**file_opts_headers})
+            _data["metadata"] = metadata_str
 
         # Only include x-upsert on a POST method
         if method != "POST":
-            del headers["x-upsert"]
+            headers.pop("x-upsert", None)
+
+        if file_opts_headers:
+            headers.update(file_opts_headers)
 
         filename = path[-1]
-
-        if cache_control:
-            headers["cache-control"] = f"max-age={cache_control}"
-            _data.update({"cacheControl": cache_control})
 
         if (
             isinstance(file, BufferedReader)
@@ -554,14 +557,14 @@ class AsyncBucketActionsMixin:
             or isinstance(file, FileIO)
         ):
             # bytes or byte-stream-like object received
-            files = {"file": (filename, file, headers.pop("content-type"))}
+            files = {"file": (filename, file, content_type)}
         else:
             # str or pathlib.path received
             files = {
                 "file": (
                     filename,
                     open(file, "rb"),
-                    headers.pop("content-type"),
+                    content_type,
                 )
             }
 

--- a/src/storage/src/storage3/_sync/file_api.py
+++ b/src/storage/src/storage3/_sync/file_api.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import base64
 import json
 import urllib.parse
 from dataclasses import dataclass, field
@@ -157,19 +156,26 @@ class SyncBucketActionsMixin:
 
         final_url = ["object", "upload", "sign", self.id, *path_parts]
 
-        options: UploadSignedUrlFileOptions = file_options or {}
-        cache_control = options.get("cache-control")
-        # cacheControl is also passed as form data
-        # https://github.com/supabase/storage-js/blob/fa44be8156295ba6320ffeff96bdf91016536a46/src/packages/StorageFileApi.ts#L89
-        _data = {}
-        if cache_control:
-            options["cache-control"] = f"max-age={cache_control}"
-            _data = {"cacheControl": cache_control}
+        options: dict[str, Any] = {
+            **DEFAULT_FILE_OPTIONS,
+            **(file_options or {}),
+        }
+        cache_control = options.pop("cache-control")
+        content_type = options.pop("content-type")
+        metadata = options.pop("metadata", None)
+        file_opts_headers = options.pop("headers", None)
+
+        _data = {"cacheControl": cache_control}
+        if metadata is not None:
+            _data["metadata"] = json.dumps(metadata)
+
         headers = {
             **self._client.headers,
-            **DEFAULT_FILE_OPTIONS,
             **options,
         }
+        if file_opts_headers:
+            headers.update(file_opts_headers)
+
         filename = path_parts[-1]
 
         if (
@@ -178,14 +184,14 @@ class SyncBucketActionsMixin:
             or isinstance(file, FileIO)
         ):
             # bytes or byte-stream-like object received
-            _file = {"file": (filename, file, headers.pop("content-type"))}
+            _file = {"file": (filename, file, content_type)}
         else:
             # str or pathlib.path received
             _file = {
                 "file": (
                     filename,
                     open(file, "rb"),
-                    headers.pop("content-type"),
+                    content_type,
                 )
             }
         response = self._request(
@@ -510,41 +516,38 @@ class SyncBucketActionsMixin:
         file_options
             HTTP headers.
         """
-        if file_options is None:
-            file_options = {}
-        cache_control = file_options.pop("cache-control", None)
-        _data = {}
+        options: dict[str, Any] = {
+            **DEFAULT_FILE_OPTIONS,
+            **(file_options or {}),
+        }
+        cache_control = options.pop("cache-control")
+        content_type = options.pop("content-type")
+        _data = {"cacheControl": cache_control}
 
-        upsert = file_options.pop("upsert", None)
+        upsert = options.pop("upsert", None)
         if upsert:
-            file_options.update({"x-upsert": upsert})
+            options["x-upsert"] = upsert
 
-        metadata = file_options.pop("metadata", None)
-        file_opts_headers = file_options.pop("headers", None)
+        metadata = options.pop("metadata", None)
+        file_opts_headers = options.pop("headers", None)
 
         headers = {
             **self._client.headers,
-            **DEFAULT_FILE_OPTIONS,
-            **file_options,
+            **options,
         }
 
-        if metadata:
+        if metadata is not None:
             metadata_str = json.dumps(metadata)
-            headers["x-metadata"] = base64.b64encode(metadata_str.encode())
-            _data.update({"metadata": metadata_str})
-
-        if file_opts_headers:
-            headers.update({**file_opts_headers})
+            _data["metadata"] = metadata_str
 
         # Only include x-upsert on a POST method
         if method != "POST":
-            del headers["x-upsert"]
+            headers.pop("x-upsert", None)
+
+        if file_opts_headers:
+            headers.update(file_opts_headers)
 
         filename = path[-1]
-
-        if cache_control:
-            headers["cache-control"] = f"max-age={cache_control}"
-            _data.update({"cacheControl": cache_control})
 
         if (
             isinstance(file, BufferedReader)
@@ -552,14 +555,14 @@ class SyncBucketActionsMixin:
             or isinstance(file, FileIO)
         ):
             # bytes or byte-stream-like object received
-            files = {"file": (filename, file, headers.pop("content-type"))}
+            files = {"file": (filename, file, content_type)}
         else:
             # str or pathlib.path received
             files = {
                 "file": (
                     filename,
                     open(file, "rb"),
-                    headers.pop("content-type"),
+                    content_type,
                 )
             }
 

--- a/src/storage/tests/_async/test_client.py
+++ b/src/storage/tests/_async/test_client.py
@@ -282,6 +282,10 @@ async def test_client_upload(
     assert image_info is not None
     assert image_info.get("metadata", {}).get("mimetype") == file.mime_type
 
+    # Default cache-control is "3600" seconds and must be stored as max-age=3600
+    info = await storage_file_client.info(file.bucket_path)
+    assert info.get("cache_control") == "max-age=3600"
+
 
 async def test_client_upload_with_query(
     storage_file_client: AsyncBucketProxy, file: FileForTesting
@@ -336,7 +340,10 @@ async def test_client_update(
     await storage_file_client.update(
         two_files[0].bucket_path,
         two_files[1].local_path,
-        {"content-type": two_files[1].mime_type},
+        {
+            "content-type": two_files[1].mime_type,
+            "cache-control": "7200",
+        },
     )
 
     image = await storage_file_client.download(two_files[0].bucket_path)
@@ -348,6 +355,8 @@ async def test_client_update(
     assert image == two_files[1].file_content
     assert image_info is not None
     assert image_info.get("metadata", {}).get("mimetype") == two_files[1].mime_type
+    info = await storage_file_client.info(two_files[0].bucket_path)
+    assert info.get("cache_control") == "max-age=7200"
 
 
 @pytest.mark.parametrize(
@@ -371,7 +380,13 @@ async def test_client_upload_to_signed_url(
     # Test with content-type
     data = await storage_file_client.create_signed_upload_url(file.bucket_path)
     await storage_file_client.upload_to_signed_url(
-        data["path"], data["token"], file.file_content, {"content-type": file.mime_type}
+        data["path"],
+        data["token"],
+        file.file_content,
+        {
+            "content-type": file.mime_type,
+            "metadata": {"source": "signed-upload"},
+        },
     )
     image = await storage_file_client.download(file.bucket_path)
     files = await storage_file_client.list(file.bucket_folder)
@@ -380,8 +395,10 @@ async def test_client_upload_to_signed_url(
     assert image == file.file_content
     assert image_info is not None
     assert image_info.get("metadata", {}).get("mimetype") == file.mime_type
+    info = await storage_file_client.info(file.bucket_path)
+    assert info.get("metadata") == {"source": "signed-upload"}
 
-    # Test with file_options=None
+    # Test with file_options=None — still applies default cache-control max-age=3600
     data = await storage_file_client.create_signed_upload_url(
         f"no_options_{file.bucket_path}"
     )
@@ -390,16 +407,18 @@ async def test_client_upload_to_signed_url(
     )
     image = await storage_file_client.download(f"no_options_{file.bucket_path}")
     assert image == file.file_content
+    no_options_info = await storage_file_client.info(f"no_options_{file.bucket_path}")
+    assert no_options_info.get("cache_control") == "max-age=3600"
 
-    # Test with cache-control
+    # Test with explicit cache-control
     data = await storage_file_client.create_signed_upload_url(
         f"cached_{file.bucket_path}"
     )
     await storage_file_client.upload_to_signed_url(
-        data["path"], data["token"], file.file_content, {"cache-control": "3600"}
+        data["path"], data["token"], file.file_content, {"cache-control": "86400"}
     )
     cached_info = await storage_file_client.info(f"cached_{file.bucket_path}")
-    assert cached_info.get("cache_control") == "max-age=3600"
+    assert cached_info.get("cache_control") == "max-age=86400"
 
 
 async def test_client_create_signed_url(

--- a/src/storage/tests/_sync/test_client.py
+++ b/src/storage/tests/_sync/test_client.py
@@ -282,6 +282,10 @@ def test_client_upload(
     assert image_info is not None
     assert image_info.get("metadata", {}).get("mimetype") == file.mime_type
 
+    # Default cache-control is "3600" seconds and must be stored as max-age=3600
+    info = storage_file_client.info(file.bucket_path)
+    assert info.get("cache_control") == "max-age=3600"
+
 
 def test_client_upload_with_query(
     storage_file_client: SyncBucketProxy, file: FileForTesting
@@ -336,7 +340,10 @@ def test_client_update(
     storage_file_client.update(
         two_files[0].bucket_path,
         two_files[1].local_path,
-        {"content-type": two_files[1].mime_type},
+        {
+            "content-type": two_files[1].mime_type,
+            "cache-control": "7200",
+        },
     )
 
     image = storage_file_client.download(two_files[0].bucket_path)
@@ -348,6 +355,8 @@ def test_client_update(
     assert image == two_files[1].file_content
     assert image_info is not None
     assert image_info.get("metadata", {}).get("mimetype") == two_files[1].mime_type
+    info = storage_file_client.info(two_files[0].bucket_path)
+    assert info.get("cache_control") == "max-age=7200"
 
 
 @pytest.mark.parametrize(
@@ -371,7 +380,13 @@ def test_client_upload_to_signed_url(
     # Test with content-type
     data = storage_file_client.create_signed_upload_url(file.bucket_path)
     storage_file_client.upload_to_signed_url(
-        data["path"], data["token"], file.file_content, {"content-type": file.mime_type}
+        data["path"],
+        data["token"],
+        file.file_content,
+        {
+            "content-type": file.mime_type,
+            "metadata": {"source": "signed-upload"},
+        },
     )
     image = storage_file_client.download(file.bucket_path)
     files = storage_file_client.list(file.bucket_folder)
@@ -380,8 +395,10 @@ def test_client_upload_to_signed_url(
     assert image == file.file_content
     assert image_info is not None
     assert image_info.get("metadata", {}).get("mimetype") == file.mime_type
+    info = storage_file_client.info(file.bucket_path)
+    assert info.get("metadata") == {"source": "signed-upload"}
 
-    # Test with file_options=None
+    # Test with file_options=None — still applies default cache-control max-age=3600
     data = storage_file_client.create_signed_upload_url(
         f"no_options_{file.bucket_path}"
     )
@@ -390,14 +407,16 @@ def test_client_upload_to_signed_url(
     )
     image = storage_file_client.download(f"no_options_{file.bucket_path}")
     assert image == file.file_content
+    no_options_info = storage_file_client.info(f"no_options_{file.bucket_path}")
+    assert no_options_info.get("cache_control") == "max-age=3600"
 
-    # Test with cache-control
+    # Test with explicit cache-control
     data = storage_file_client.create_signed_upload_url(f"cached_{file.bucket_path}")
     storage_file_client.upload_to_signed_url(
-        data["path"], data["token"], file.file_content, {"cache-control": "3600"}
+        data["path"], data["token"], file.file_content, {"cache-control": "86400"}
     )
     cached_info = storage_file_client.info(f"cached_{file.bucket_path}")
-    assert cached_info.get("cache_control") == "max-age=3600"
+    assert cached_info.get("cache_control") == "max-age=86400"
 
 
 def test_client_create_signed_url(

--- a/src/storage/tests/test_client.py
+++ b/src/storage/tests/test_client.py
@@ -1,10 +1,14 @@
 import re
-from typing import Dict
+from typing import Any, Dict, Mapping
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
-from httpx import AsyncClient, Client, Timeout
+from httpx import AsyncClient, Client, Headers, Timeout
 from storage3 import AsyncStorageClient, SyncStorageClient
+from storage3._async.file_api import AsyncBucketProxy
+from storage3._sync.file_api import SyncBucketProxy
 from storage3.constants import DEFAULT_TIMEOUT
+from yarl import URL
 
 
 @pytest.fixture
@@ -118,3 +122,184 @@ def test_custom_timeout(valid_url, valid_headers) -> None:
         url=valid_url, headers=valid_headers, timeout=custom_timeout
     )
     assert sync_client._client.timeout == Timeout(custom_timeout)
+
+
+def _mock_upload_response() -> Mock:
+    response = Mock()
+    response.json.return_value = {"Key": "bucket/file.txt", "Id": "id"}
+    return response
+
+
+def _async_bucket_proxy() -> AsyncBucketProxy:
+    client = AsyncMock()
+    client.headers = {}
+    return AsyncBucketProxy(
+        "bucket", URL("https://example.com/storage/v1/"), Headers(), client
+    )
+
+
+def _sync_bucket_proxy() -> SyncBucketProxy:
+    client = Mock()
+    client.headers = {}
+    return SyncBucketProxy(
+        "bucket", URL("https://example.com/storage/v1/"), Headers(), client
+    )
+
+
+def _request_kwargs(request: Mock) -> Mapping[str, Any]:
+    call = request.call_args
+    assert call is not None
+    return call.kwargs
+
+
+def _assert_multipart_cache_control(request: Mock, expected: str) -> None:
+    kwargs = _request_kwargs(request)
+    assert "cache-control" not in kwargs["headers"]
+    assert kwargs["data"]["cacheControl"] == expected
+
+
+@pytest.mark.asyncio
+async def test_async_upload_sends_default_cache_control_as_form_data() -> None:
+    proxy = _async_bucket_proxy()
+    with patch.object(proxy, "_request", new_callable=AsyncMock) as request:
+        request.return_value = _mock_upload_response()
+        await proxy.upload("file.txt", b"hello")
+
+    _assert_multipart_cache_control(request, "3600")
+
+
+@pytest.mark.asyncio
+async def test_async_upload_sends_custom_cache_control_as_form_data() -> None:
+    proxy = _async_bucket_proxy()
+    with patch.object(proxy, "_request", new_callable=AsyncMock) as request:
+        request.return_value = _mock_upload_response()
+        await proxy.upload(
+            "file.txt",
+            b"hello",
+            {
+                "cache-control": "86400",
+                "headers": {"x-custom-header": "custom-value"},
+            },
+        )
+
+    _assert_multipart_cache_control(request, "86400")
+    assert _request_kwargs(request)["headers"]["x-custom-header"] == "custom-value"
+
+
+def test_sync_upload_sends_default_cache_control_as_form_data() -> None:
+    proxy = _sync_bucket_proxy()
+    with patch.object(proxy, "_request") as request:
+        request.return_value = _mock_upload_response()
+        proxy.upload("file.txt", b"hello")
+
+    _assert_multipart_cache_control(request, "3600")
+
+
+def test_sync_upload_sends_custom_cache_control_as_form_data() -> None:
+    proxy = _sync_bucket_proxy()
+    with patch.object(proxy, "_request") as request:
+        request.return_value = _mock_upload_response()
+        proxy.upload(
+            "file.txt",
+            b"hello",
+            {
+                "cache-control": "86400",
+                "headers": {"x-custom-header": "custom-value"},
+            },
+        )
+
+    _assert_multipart_cache_control(request, "86400")
+    assert _request_kwargs(request)["headers"]["x-custom-header"] == "custom-value"
+
+
+@pytest.mark.asyncio
+async def test_async_update_sends_cache_control_as_form_data() -> None:
+    proxy = _async_bucket_proxy()
+    with patch.object(proxy, "_request", new_callable=AsyncMock) as request:
+        request.return_value = _mock_upload_response()
+        await proxy.update("file.txt", b"hello", {"cache-control": "7200"})
+
+    _assert_multipart_cache_control(request, "7200")
+    assert "x-upsert" not in _request_kwargs(request)["headers"]
+
+
+def test_sync_update_sends_cache_control_as_form_data() -> None:
+    proxy = _sync_bucket_proxy()
+    with patch.object(proxy, "_request") as request:
+        request.return_value = _mock_upload_response()
+        proxy.update("file.txt", b"hello", {"cache-control": "7200"})
+
+    _assert_multipart_cache_control(request, "7200")
+    assert "x-upsert" not in _request_kwargs(request)["headers"]
+
+
+@pytest.mark.asyncio
+async def test_async_signed_upload_sends_default_cache_control() -> None:
+    proxy = _async_bucket_proxy()
+    with patch.object(proxy, "_request", new_callable=AsyncMock) as request:
+        request.return_value = _mock_upload_response()
+        await proxy.upload_to_signed_url("file.txt", "token", b"hello")
+
+    _assert_multipart_cache_control(request, "3600")
+
+
+def test_sync_signed_upload_sends_default_cache_control() -> None:
+    proxy = _sync_bucket_proxy()
+    with patch.object(proxy, "_request") as request:
+        request.return_value = _mock_upload_response()
+        proxy.upload_to_signed_url("file.txt", "token", b"hello")
+
+    _assert_multipart_cache_control(request, "3600")
+
+
+@pytest.mark.asyncio
+async def test_async_upload_to_signed_url_forwards_all_file_options() -> None:
+    proxy = _async_bucket_proxy()
+    with patch.object(proxy, "_request", new_callable=AsyncMock) as request:
+        request.return_value = _mock_upload_response()
+        await proxy.upload_to_signed_url(
+            "file.txt",
+            "token",
+            b"hello",
+            {
+                "cache-control": "86400",
+                "content-type": "text/custom",
+                "metadata": {"owner": "alice"},
+                "headers": {"x-custom-header": "custom-value"},
+            },
+        )
+
+    kwargs = _request_kwargs(request)
+    _assert_multipart_cache_control(request, "86400")
+    assert kwargs["data"]["metadata"] == '{"owner": "alice"}'
+    assert kwargs["headers"]["x-custom-header"] == "custom-value"
+    assert "metadata" not in kwargs["headers"]
+    assert "headers" not in kwargs["headers"]
+    assert "x-metadata" not in kwargs["headers"]
+    assert kwargs["files"]["file"][2] == "text/custom"
+
+
+def test_sync_upload_to_signed_url_forwards_all_file_options() -> None:
+    proxy = _sync_bucket_proxy()
+    with patch.object(proxy, "_request") as request:
+        request.return_value = _mock_upload_response()
+        proxy.upload_to_signed_url(
+            "file.txt",
+            "token",
+            b"hello",
+            {
+                "cache-control": "86400",
+                "content-type": "text/custom",
+                "metadata": {"owner": "alice"},
+                "headers": {"x-custom-header": "custom-value"},
+            },
+        )
+
+    kwargs = _request_kwargs(request)
+    _assert_multipart_cache_control(request, "86400")
+    assert kwargs["data"]["metadata"] == '{"owner": "alice"}'
+    assert kwargs["headers"]["x-custom-header"] == "custom-value"
+    assert "metadata" not in kwargs["headers"]
+    assert "headers" not in kwargs["headers"]
+    assert "x-metadata" not in kwargs["headers"]
+    assert kwargs["files"]["file"][2] == "text/custom"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

* Default cache-control is sent base 3600 instead of max-age=3600
* Options aren't safe to retry because they are mutated

## What is the new behavior?

* Header is sent correctly and aligned with js implementation and server expectations.
* Options are copied so safer to retry

