### PR TITLE
feat(postgrest): support single()/maybe_single() after insert/upsert select

### DIFF
--- a/src/postgrest/src/postgrest/_async/request_builder.py
+++ b/src/postgrest/src/postgrest/_async/request_builder.py
@@ -75,6 +75,19 @@ class AsyncQueryRequestBuilder:
         self.request.retry_enabled = enabled
         return self
 
+    def single(self) -> AsyncSingleRequestBuilder:
+        """Specify that the query will only return a single row in response.
+
+        .. caution::
+            The API will raise an error if the query returned more than one row.
+        """
+        self.request.headers["Accept"] = "application/vnd.pgrst.object+json"
+        return AsyncSingleRequestBuilder(self.request)
+
+    def maybe_single(self) -> AsyncMaybeSingleRequestBuilder:
+        """Retrieves at most one row from the result. Result must be at most one row (e.g. using `eq` on a UNIQUE column), otherwise this will result in an error."""
+        return AsyncMaybeSingleRequestBuilder(self.request)
+
     async def execute(self) -> APIResponse:
         """Execute the query.
 
@@ -204,19 +217,6 @@ class AsyncSelectRequestBuilder(
     def __init__(self, request: ReqConfig) -> None:
         BaseSelectRequestBuilder.__init__(self, request)
         AsyncQueryRequestBuilder.__init__(self, request)
-
-    def single(self) -> AsyncSingleRequestBuilder:
-        """Specify that the query will only return a single row in response.
-
-        .. caution::
-            The API will raise an error if the query returned more than one row.
-        """
-        self.request.headers["Accept"] = "application/vnd.pgrst.object+json"
-        return AsyncSingleRequestBuilder(self.request)
-
-    def maybe_single(self) -> AsyncMaybeSingleRequestBuilder:
-        """Retrieves at most one row from the result. Result must be at most one row (e.g. using `eq` on a UNIQUE column), otherwise this will result in an error."""
-        return AsyncMaybeSingleRequestBuilder(self.request)
 
     def text_search(
         self, column: str, query: str, options: dict[str, Any] = {}

--- a/src/postgrest/src/postgrest/_sync/request_builder.py
+++ b/src/postgrest/src/postgrest/_sync/request_builder.py
@@ -75,6 +75,19 @@ class SyncQueryRequestBuilder:
         self.request.retry_enabled = enabled
         return self
 
+    def single(self) -> SyncSingleRequestBuilder:
+        """Specify that the query will only return a single row in response.
+
+        .. caution::
+            The API will raise an error if the query returned more than one row.
+        """
+        self.request.headers["Accept"] = "application/vnd.pgrst.object+json"
+        return SyncSingleRequestBuilder(self.request)
+
+    def maybe_single(self) -> SyncMaybeSingleRequestBuilder:
+        """Retrieves at most one row from the result. Result must be at most one row (e.g. using `eq` on a UNIQUE column), otherwise this will result in an error."""
+        return SyncMaybeSingleRequestBuilder(self.request)
+
     def execute(self) -> APIResponse:
         """Execute the query.
 
@@ -204,19 +217,6 @@ class SyncSelectRequestBuilder(
     def __init__(self, request: ReqConfig) -> None:
         BaseSelectRequestBuilder.__init__(self, request)
         SyncQueryRequestBuilder.__init__(self, request)
-
-    def single(self) -> SyncSingleRequestBuilder:
-        """Specify that the query will only return a single row in response.
-
-        .. caution::
-            The API will raise an error if the query returned more than one row.
-        """
-        self.request.headers["Accept"] = "application/vnd.pgrst.object+json"
-        return SyncSingleRequestBuilder(self.request)
-
-    def maybe_single(self) -> SyncMaybeSingleRequestBuilder:
-        """Retrieves at most one row from the result. Result must be at most one row (e.g. using `eq` on a UNIQUE column), otherwise this will result in an error."""
-        return SyncMaybeSingleRequestBuilder(self.request)
 
     def text_search(
         self, column: str, query: str, options: dict[str, Any] = {}

--- a/src/postgrest/tests/_async/test_query_request_builder.py
+++ b/src/postgrest/tests/_async/test_query_request_builder.py
@@ -5,7 +5,11 @@ from httpx import AsyncClient, Headers, QueryParams
 from yarl import URL
 
 from postgrest import AsyncQueryRequestBuilder
-from postgrest._async.request_builder import RequestConfig
+from postgrest._async.request_builder import (
+    AsyncMaybeSingleRequestBuilder,
+    AsyncSingleRequestBuilder,
+    RequestConfig,
+)
 
 
 @pytest.fixture
@@ -25,3 +29,19 @@ def test_constructor(query_request_builder: AsyncQueryRequestBuilder):
     assert len(builder.request.params) == 0
     assert builder.request.http_method == "GET"
     assert builder.request.json is None
+
+
+def test_select_single(query_request_builder: AsyncQueryRequestBuilder):
+    # insert()/upsert() return an AsyncQueryRequestBuilder, so single() must be
+    # reachable after select() to match the JS client's
+    # insert(...).select().single() chain. See GH-1553.
+    builder = query_request_builder.select("*").single()
+
+    assert isinstance(builder, AsyncSingleRequestBuilder)
+    assert builder.request.headers["Accept"] == "application/vnd.pgrst.object+json"
+
+
+def test_select_maybe_single(query_request_builder: AsyncQueryRequestBuilder):
+    builder = query_request_builder.select("*").maybe_single()
+
+    assert isinstance(builder, AsyncMaybeSingleRequestBuilder)

--- a/src/postgrest/tests/_sync/test_query_request_builder.py
+++ b/src/postgrest/tests/_sync/test_query_request_builder.py
@@ -5,7 +5,11 @@ from httpx import Client, Headers, QueryParams
 from yarl import URL
 
 from postgrest import SyncQueryRequestBuilder
-from postgrest._sync.request_builder import RequestConfig
+from postgrest._sync.request_builder import (
+    RequestConfig,
+    SyncMaybeSingleRequestBuilder,
+    SyncSingleRequestBuilder,
+)
 
 
 @pytest.fixture
@@ -25,3 +29,19 @@ def test_constructor(query_request_builder: SyncQueryRequestBuilder):
     assert len(builder.request.params) == 0
     assert builder.request.http_method == "GET"
     assert builder.request.json is None
+
+
+def test_select_single(query_request_builder: SyncQueryRequestBuilder):
+    # insert()/upsert() return a SyncQueryRequestBuilder, so single() must be
+    # reachable after select() to match the JS client's
+    # insert(...).select().single() chain. See GH-1553.
+    builder = query_request_builder.select("*").single()
+
+    assert isinstance(builder, SyncSingleRequestBuilder)
+    assert builder.request.headers["Accept"] == "application/vnd.pgrst.object+json"
+
+
+def test_select_maybe_single(query_request_builder: SyncQueryRequestBuilder):
+    builder = query_request_builder.select("*").maybe_single()
+
+    assert isinstance(builder, SyncMaybeSingleRequestBuilder)


### PR DESCRIPTION
## What

Closes #1553.

The JS client supports `client.from("t").insert(...).select().single()`, but the Python client didn't: `insert()` and `upsert()` return a `*QueryRequestBuilder`, whose `select()` returns `self`, and `single()` / `maybe_single()` only lived on `*SelectRequestBuilder`. So after an insert/upsert there was no way to get a single-row response.

## Change

Move `single()` and `maybe_single()` up from `*SelectRequestBuilder` to the base `*QueryRequestBuilder`. They're now reachable from every builder `select()` can return, so all of these work and mirror the JS client:

```py
client.from_("t").insert(row).select().single().execute()
client.from_("t").upsert(row).select().maybe_single().execute()
```

`*SelectRequestBuilder` still exposes them via inheritance, so existing `select().single()` usage is unchanged. The methods only set headers and return the existing single/maybe-single builders, so there's no behavioural change to what `single()` itself does.

Async is the source of truth; the sync builder and both test files are the unasync-generated mirror.

## Testing

Added `test_select_single` / `test_select_maybe_single` to the query-request-builder tests (async + sync), asserting `select().single()` returns the single-request builder with the `application/vnd.pgrst.object+json` Accept header and `select().maybe_single()` returns the maybe-single builder. Full postgrest unit suite passes:

```
90 passed
```
