### PR TITLE
feat(postgrest): return a select builder from insert, upsert, update and delete

### DIFF
--- a/src/postgrest/src/postgrest/_async/request_builder.py
+++ b/src/postgrest/src/postgrest/_async/request_builder.py
@@ -332,7 +332,7 @@ class AsyncRequestBuilder:  #
         returning: ReturnMethod = ReturnMethod.representation,
         upsert: bool = False,
         default_to_null: bool = True,
-    ) -> AsyncQueryRequestBuilder:
+    ) -> AsyncSelectRequestBuilder:
         """Run an INSERT query.
 
         Args:
@@ -344,7 +344,7 @@ class AsyncRequestBuilder:  #
                 Otherwise, use the default value for the column.
                 Only applies for bulk inserts.
         Returns:
-            :class:`AsyncQueryRequestBuilder`
+            :class:`AsyncSelectRequestBuilder`
         """
         method, params, headers, json = pre_insert(
             json,
@@ -363,7 +363,7 @@ class AsyncRequestBuilder:  #
             headers=headers,
             json=json,
         )
-        return AsyncQueryRequestBuilder(request)
+        return AsyncSelectRequestBuilder(request)
 
     def upsert(
         self,
@@ -374,7 +374,7 @@ class AsyncRequestBuilder:  #
         ignore_duplicates: bool = False,
         on_conflict: str = "",
         default_to_null: bool = True,
-    ) -> AsyncQueryRequestBuilder:
+    ) -> AsyncSelectRequestBuilder:
         """Run an upsert (INSERT ... ON CONFLICT DO UPDATE) query.
 
         Args:
@@ -388,7 +388,7 @@ class AsyncRequestBuilder:  #
                 not when merging with existing rows under `ignoreDuplicates: false`.
                 This also only applies when doing bulk upserts.
         Returns:
-            :class:`AsyncQueryRequestBuilder`
+            :class:`AsyncSelectRequestBuilder`
         """
         method, params, headers, json = pre_upsert(
             json,
@@ -408,7 +408,7 @@ class AsyncRequestBuilder:  #
             headers=headers,
             json=json,
         )
-        return AsyncQueryRequestBuilder(request)
+        return AsyncSelectRequestBuilder(request)
 
     def update(
         self,
@@ -416,7 +416,7 @@ class AsyncRequestBuilder:  #
         *,
         count: Optional[CountMethod] = None,
         returning: ReturnMethod = ReturnMethod.representation,
-    ) -> AsyncFilterRequestBuilder:
+    ) -> AsyncSelectRequestBuilder:
         """Run an UPDATE query.
 
         Args:
@@ -424,7 +424,7 @@ class AsyncRequestBuilder:  #
             count: The method to use to get the count of rows returned.
             returning: Either 'minimal' or 'representation'
         Returns:
-            :class:`AsyncFilterRequestBuilder`
+            :class:`AsyncSelectRequestBuilder`
         """
         method, params, headers, json = pre_update(
             json,
@@ -441,21 +441,21 @@ class AsyncRequestBuilder:  #
             headers=headers,
             json=json,
         )
-        return AsyncFilterRequestBuilder(request)
+        return AsyncSelectRequestBuilder(request)
 
     def delete(
         self,
         *,
         count: Optional[CountMethod] = None,
         returning: ReturnMethod = ReturnMethod.representation,
-    ) -> AsyncFilterRequestBuilder:
+    ) -> AsyncSelectRequestBuilder:
         """Run a DELETE query.
 
         Args:
             count: The method to use to get the count of rows returned.
             returning: Either 'minimal' or 'representation'
         Returns:
-            :class:`AsyncFilterRequestBuilder`
+            :class:`AsyncSelectRequestBuilder`
         """
         method, params, headers, json = pre_delete(
             count=count,
@@ -471,4 +471,4 @@ class AsyncRequestBuilder:  #
             headers=headers,
             json=json,
         )
-        return AsyncFilterRequestBuilder(request)
+        return AsyncSelectRequestBuilder(request)

--- a/src/postgrest/src/postgrest/_sync/request_builder.py
+++ b/src/postgrest/src/postgrest/_sync/request_builder.py
@@ -332,7 +332,7 @@ class SyncRequestBuilder:  #
         returning: ReturnMethod = ReturnMethod.representation,
         upsert: bool = False,
         default_to_null: bool = True,
-    ) -> SyncQueryRequestBuilder:
+    ) -> SyncSelectRequestBuilder:
         """Run an INSERT query.
 
         Args:
@@ -344,7 +344,7 @@ class SyncRequestBuilder:  #
                 Otherwise, use the default value for the column.
                 Only applies for bulk inserts.
         Returns:
-            :class:`SyncQueryRequestBuilder`
+            :class:`SyncSelectRequestBuilder`
         """
         method, params, headers, json = pre_insert(
             json,
@@ -363,7 +363,7 @@ class SyncRequestBuilder:  #
             headers=headers,
             json=json,
         )
-        return SyncQueryRequestBuilder(request)
+        return SyncSelectRequestBuilder(request)
 
     def upsert(
         self,
@@ -374,7 +374,7 @@ class SyncRequestBuilder:  #
         ignore_duplicates: bool = False,
         on_conflict: str = "",
         default_to_null: bool = True,
-    ) -> SyncQueryRequestBuilder:
+    ) -> SyncSelectRequestBuilder:
         """Run an upsert (INSERT ... ON CONFLICT DO UPDATE) query.
 
         Args:
@@ -388,7 +388,7 @@ class SyncRequestBuilder:  #
                 not when merging with existing rows under `ignoreDuplicates: false`.
                 This also only applies when doing bulk upserts.
         Returns:
-            :class:`SyncQueryRequestBuilder`
+            :class:`SyncSelectRequestBuilder`
         """
         method, params, headers, json = pre_upsert(
             json,
@@ -408,7 +408,7 @@ class SyncRequestBuilder:  #
             headers=headers,
             json=json,
         )
-        return SyncQueryRequestBuilder(request)
+        return SyncSelectRequestBuilder(request)
 
     def update(
         self,
@@ -416,7 +416,7 @@ class SyncRequestBuilder:  #
         *,
         count: Optional[CountMethod] = None,
         returning: ReturnMethod = ReturnMethod.representation,
-    ) -> SyncFilterRequestBuilder:
+    ) -> SyncSelectRequestBuilder:
         """Run an UPDATE query.
 
         Args:
@@ -424,7 +424,7 @@ class SyncRequestBuilder:  #
             count: The method to use to get the count of rows returned.
             returning: Either 'minimal' or 'representation'
         Returns:
-            :class:`SyncFilterRequestBuilder`
+            :class:`SyncSelectRequestBuilder`
         """
         method, params, headers, json = pre_update(
             json,
@@ -441,21 +441,21 @@ class SyncRequestBuilder:  #
             headers=headers,
             json=json,
         )
-        return SyncFilterRequestBuilder(request)
+        return SyncSelectRequestBuilder(request)
 
     def delete(
         self,
         *,
         count: Optional[CountMethod] = None,
         returning: ReturnMethod = ReturnMethod.representation,
-    ) -> SyncFilterRequestBuilder:
+    ) -> SyncSelectRequestBuilder:
         """Run a DELETE query.
 
         Args:
             count: The method to use to get the count of rows returned.
             returning: Either 'minimal' or 'representation'
         Returns:
-            :class:`SyncFilterRequestBuilder`
+            :class:`SyncSelectRequestBuilder`
         """
         method, params, headers, json = pre_delete(
             count=count,
@@ -471,4 +471,4 @@ class SyncRequestBuilder:  #
             headers=headers,
             json=json,
         )
-        return SyncFilterRequestBuilder(request)
+        return SyncSelectRequestBuilder(request)

--- a/src/postgrest/tests/_async/test_request_builder.py
+++ b/src/postgrest/tests/_async/test_request_builder.py
@@ -4,7 +4,11 @@ import pytest
 from httpx import AsyncClient, Headers, QueryParams, Request, Response
 from yarl import URL
 
-from postgrest import AsyncRequestBuilder, AsyncSingleRequestBuilder
+from postgrest import (
+    AsyncMaybeSingleRequestBuilder,
+    AsyncRequestBuilder,
+    AsyncSingleRequestBuilder,
+)
 from postgrest._async.request_builder import RequestConfig
 from postgrest.base_request_builder import APIResponse, SingleAPIResponse
 from postgrest.types import JSON, CountMethod, ReturnMethod
@@ -140,6 +144,34 @@ class TestInsert:
             "return=representation",
         ]
 
+    def test_insert_with_select_single(self, request_builder: AsyncRequestBuilder):
+        builder = request_builder.insert({"key1": "val1"}).select("id").single()
+
+        assert isinstance(builder, AsyncSingleRequestBuilder)
+        assert builder.request.params["select"] == "id"
+        assert builder.request.headers["accept"] == "application/vnd.pgrst.object+json"
+        assert builder.request.headers.get_list("prefer", True) == [
+            "return=representation"
+        ]
+        assert builder.request.http_method == "POST"
+
+    def test_insert_with_select_maybe_single(
+        self, request_builder: AsyncRequestBuilder
+    ):
+        builder = request_builder.insert({"key1": "val1"}).select("id").maybe_single()
+
+        assert isinstance(builder, AsyncMaybeSingleRequestBuilder)
+        assert builder.request.params["select"] == "id"
+        assert builder.request.http_method == "POST"
+
+    def test_upsert_with_select_single(self, request_builder: AsyncRequestBuilder):
+        builder = request_builder.upsert({"key1": "val1"}).select("id").single()
+
+        assert isinstance(builder, AsyncSingleRequestBuilder)
+        assert builder.request.params["select"] == "id"
+        assert builder.request.headers["accept"] == "application/vnd.pgrst.object+json"
+        assert builder.request.http_method == "POST"
+
     def test_bulk_upsert_with_default(self, request_builder: AsyncRequestBuilder):
         builder = request_builder.upsert(
             [{"key1": "val1", "key2": "val2"}, {"key3": "val3"}], default_to_null=False
@@ -194,6 +226,21 @@ class TestUpdate:
         assert builder.request.params["id"] == "eq.1"
         assert builder.request.params["select"] == "id"
 
+    def test_update_with_select_single(self, request_builder: AsyncRequestBuilder):
+        builder = request_builder.update({"key1": "val1"}).eq("id", 1).select().single()
+
+        assert isinstance(builder, AsyncSingleRequestBuilder)
+        assert builder.request.params["id"] == "eq.1"
+        assert builder.request.headers["accept"] == "application/vnd.pgrst.object+json"
+        assert builder.request.http_method == "PATCH"
+
+    def test_update_with_order_and_limit(self, request_builder: AsyncRequestBuilder):
+        builder = request_builder.update({"key1": "val1"}).order("id").limit(1)
+
+        assert builder.request.params["order"] == "id.asc"
+        assert builder.request.params["limit"] == "1"
+        assert builder.request.http_method == "PATCH"
+
 
 class TestDelete:
     def test_delete(self, request_builder: AsyncRequestBuilder):
@@ -229,6 +276,14 @@ class TestDelete:
 
         assert builder.request.params["id"] == "eq.1"
         assert builder.request.params["select"] == "id"
+
+    def test_delete_with_select_single(self, request_builder: AsyncRequestBuilder):
+        builder = request_builder.delete().eq("id", 1).select("id").single()
+
+        assert isinstance(builder, AsyncSingleRequestBuilder)
+        assert builder.request.params["id"] == "eq.1"
+        assert builder.request.headers["accept"] == "application/vnd.pgrst.object+json"
+        assert builder.request.http_method == "DELETE"
 
 
 class TestTextSearch:

--- a/src/postgrest/tests/_sync/test_request_builder.py
+++ b/src/postgrest/tests/_sync/test_request_builder.py
@@ -4,7 +4,11 @@ import pytest
 from httpx import Client, Headers, QueryParams, Request, Response
 from yarl import URL
 
-from postgrest import SyncRequestBuilder, SyncSingleRequestBuilder
+from postgrest import (
+    SyncMaybeSingleRequestBuilder,
+    SyncRequestBuilder,
+    SyncSingleRequestBuilder,
+)
 from postgrest._async.request_builder import RequestConfig
 from postgrest.base_request_builder import APIResponse, SingleAPIResponse
 from postgrest.types import JSON, CountMethod, ReturnMethod
@@ -140,6 +144,32 @@ class TestInsert:
             "return=representation",
         ]
 
+    def test_insert_with_select_single(self, request_builder: SyncRequestBuilder):
+        builder = request_builder.insert({"key1": "val1"}).select("id").single()
+
+        assert isinstance(builder, SyncSingleRequestBuilder)
+        assert builder.request.params["select"] == "id"
+        assert builder.request.headers["accept"] == "application/vnd.pgrst.object+json"
+        assert builder.request.headers.get_list("prefer", True) == [
+            "return=representation"
+        ]
+        assert builder.request.http_method == "POST"
+
+    def test_insert_with_select_maybe_single(self, request_builder: SyncRequestBuilder):
+        builder = request_builder.insert({"key1": "val1"}).select("id").maybe_single()
+
+        assert isinstance(builder, SyncMaybeSingleRequestBuilder)
+        assert builder.request.params["select"] == "id"
+        assert builder.request.http_method == "POST"
+
+    def test_upsert_with_select_single(self, request_builder: SyncRequestBuilder):
+        builder = request_builder.upsert({"key1": "val1"}).select("id").single()
+
+        assert isinstance(builder, SyncSingleRequestBuilder)
+        assert builder.request.params["select"] == "id"
+        assert builder.request.headers["accept"] == "application/vnd.pgrst.object+json"
+        assert builder.request.http_method == "POST"
+
     def test_bulk_upsert_with_default(self, request_builder: SyncRequestBuilder):
         builder = request_builder.upsert(
             [{"key1": "val1", "key2": "val2"}, {"key3": "val3"}], default_to_null=False
@@ -194,6 +224,21 @@ class TestUpdate:
         assert builder.request.params["id"] == "eq.1"
         assert builder.request.params["select"] == "id"
 
+    def test_update_with_select_single(self, request_builder: SyncRequestBuilder):
+        builder = request_builder.update({"key1": "val1"}).eq("id", 1).select().single()
+
+        assert isinstance(builder, SyncSingleRequestBuilder)
+        assert builder.request.params["id"] == "eq.1"
+        assert builder.request.headers["accept"] == "application/vnd.pgrst.object+json"
+        assert builder.request.http_method == "PATCH"
+
+    def test_update_with_order_and_limit(self, request_builder: SyncRequestBuilder):
+        builder = request_builder.update({"key1": "val1"}).order("id").limit(1)
+
+        assert builder.request.params["order"] == "id.asc"
+        assert builder.request.params["limit"] == "1"
+        assert builder.request.http_method == "PATCH"
+
 
 class TestDelete:
     def test_delete(self, request_builder: SyncRequestBuilder):
@@ -229,6 +274,14 @@ class TestDelete:
 
         assert builder.request.params["id"] == "eq.1"
         assert builder.request.params["select"] == "id"
+
+    def test_delete_with_select_single(self, request_builder: SyncRequestBuilder):
+        builder = request_builder.delete().eq("id", 1).select("id").single()
+
+        assert isinstance(builder, SyncSingleRequestBuilder)
+        assert builder.request.params["id"] == "eq.1"
+        assert builder.request.headers["accept"] == "application/vnd.pgrst.object+json"
+        assert builder.request.http_method == "DELETE"
 
 
 class TestTextSearch:


### PR DESCRIPTION
Closes #1553.

### Problem

`insert()` and `upsert()` return a query builder, `update()` and `delete()` return a filter builder. Neither type exposes `single()`, `maybe_single()`, `csv()`, `explain()`, `order()`, `limit()` or `range()`, so a chain that reads naturally in the JS client has no equivalent in Python:

```py
client.from_("users").insert({"name": "n"}).select().single().execute()
#                                            ^^^^^^ returns self, so .single() does not exist
```

`select()` is defined on the query builder and returns `self`, which means the chain ends on a builder that never had `single()` to begin with. In supabase-js all four of these methods return a `PostgrestFilterBuilder`, and the transform methods hang off it — this is the parity gap the issue describes.

### Fix

Return `SelectRequestBuilder` from `insert()`, `upsert()`, `update()` and `delete()`.

`SelectRequestBuilder` already derives from the query builder and from the filter builder, so this only widens the surface. Every method that worked before still works, on the same object, with the same request state — filters after `update()` and `delete()` are unaffected, and nothing is removed or renamed. Callers who only use `.execute()` see no difference.

`single()` on a write is what PostgREST already supports: `Prefer: return=representation` is set by `select()`, and `single()` adds `Accept: application/vnd.pgrst.object+json`. The added tests assert exactly that, together with the HTTP method staying `POST` / `PATCH` / `DELETE`.

### Note on the sync package

`src/postgrest/src/postgrest/_sync/request_builder.py` is edited by hand here rather than regenerated with `make build-sync`. On `main`, the generated output differs from the committed `_sync` in ways unrelated to this change — most visibly `send_with_retry` comes out with `asyncio.sleep` where the committed file has `time.sleep`, plus import ordering. Regenerating would have pulled that into this PR, so the same twelve lines were applied to `_async` and `_sync` instead. Happy to raise that separately if it is news to you.

### Verification

- `make postgrest.pytest` — 306 passed (8 new tests, spread across `_async` and `_sync`).
- `make postgrest.mypy` — no issues in 30 source files.
- `uv run ruff check` and `uv run ruff format --check` — clean.