### PR TITLE
chore: update sdk-compliance.yaml for renamed capability matrix IDs

### DIFF
--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -53,7 +53,7 @@ features:
     symbols:
       - AsyncGoTrueClient.resend
       - SyncGoTrueClient.resend
-  auth.sign_in.reset_password:
+  auth.sign_in.send_password_reset_email:
     status: implemented
     symbols:
       - AsyncGoTrueClient.reset_password_for_email
@@ -532,7 +532,7 @@ features:
     symbols:
       - AsyncRealtimeChannel.unsubscribe
       - SyncRealtimeChannel.unsubscribe
-  realtime.channel.send:
+  realtime.channel.broadcast:
     status: implemented
     symbols:
       - AsyncRealtimeChannel.send_broadcast
@@ -646,9 +646,12 @@ features:
       - SyncBucketActionsMixin.download
   storage.file_buckets.list_files:
     status: implemented
+    note: "Cursor-based pagination is exposed via the list_v2 variant of list()."
     symbols:
       - AsyncBucketActionsMixin.list
       - SyncBucketActionsMixin.list
+      - AsyncBucketActionsMixin.list_v2
+      - SyncBucketActionsMixin.list_v2
   storage.file_buckets.move:
     status: implemented
     symbols:
@@ -704,11 +707,6 @@ features:
     symbols:
       - AsyncBucketActionsMixin.info
       - SyncBucketActionsMixin.info
-  storage.file_buckets.list_files_paginated:
-    status: implemented
-    symbols:
-      - AsyncBucketActionsMixin.list_v2
-      - SyncBucketActionsMixin.list_v2
   storage.file_buckets.download_with_transform:
     status: implemented
     note: "Pass a transform key in the url_options argument of create_signed_url(); the transform dict is forwarded in the signed URL request."
@@ -845,16 +843,58 @@ features:
       - AsyncStorageAnalyticsClient.delete
       - SyncStorageAnalyticsClient.delete
 
-  storage.analytics.iceberg_namespace:
+  storage.analytics.create_namespace:
     status: implemented
-    note: "catalog() returns a pyiceberg RestCatalog giving full Iceberg REST catalog access including namespace management."
+    note: "catalog() returns a pyiceberg RestCatalog giving full Iceberg REST catalog access, including namespace creation."
+    symbols:
+      - AsyncStorageAnalyticsClient.catalog
+      - SyncStorageAnalyticsClient.catalog
+  storage.analytics.list_namespaces:
+    status: implemented
+    note: "catalog() returns a pyiceberg RestCatalog giving full Iceberg REST catalog access, including namespace listing."
+    symbols:
+      - AsyncStorageAnalyticsClient.catalog
+      - SyncStorageAnalyticsClient.catalog
+  storage.analytics.delete_namespace:
+    status: implemented
+    note: "catalog() returns a pyiceberg RestCatalog giving full Iceberg REST catalog access, including namespace deletion."
     symbols:
       - AsyncStorageAnalyticsClient.catalog
       - SyncStorageAnalyticsClient.catalog
 
-  storage.analytics.iceberg_table:
+  storage.analytics.create_table:
     status: implemented
-    note: "catalog() returns a pyiceberg RestCatalog giving full Iceberg REST catalog access including table management."
+    note: "catalog() returns a pyiceberg RestCatalog giving full Iceberg REST catalog access, including table creation."
+    symbols:
+      - AsyncStorageAnalyticsClient.catalog
+      - SyncStorageAnalyticsClient.catalog
+  storage.analytics.list_tables:
+    status: implemented
+    note: "catalog() returns a pyiceberg RestCatalog giving full Iceberg REST catalog access, including table listing."
+    symbols:
+      - AsyncStorageAnalyticsClient.catalog
+      - SyncStorageAnalyticsClient.catalog
+  storage.analytics.load_table:
+    status: implemented
+    note: "catalog() returns a pyiceberg RestCatalog giving full Iceberg REST catalog access, including table loading."
+    symbols:
+      - AsyncStorageAnalyticsClient.catalog
+      - SyncStorageAnalyticsClient.catalog
+  storage.analytics.update_table:
+    status: implemented
+    note: "catalog() returns a pyiceberg RestCatalog giving full Iceberg REST catalog access, including table updates."
+    symbols:
+      - AsyncStorageAnalyticsClient.catalog
+      - SyncStorageAnalyticsClient.catalog
+  storage.analytics.rename_table:
+    status: implemented
+    note: "catalog() returns a pyiceberg RestCatalog giving full Iceberg REST catalog access, including table renaming."
+    symbols:
+      - AsyncStorageAnalyticsClient.catalog
+      - SyncStorageAnalyticsClient.catalog
+  storage.analytics.delete_table:
+    status: implemented
+    note: "catalog() returns a pyiceberg RestCatalog giving full Iceberg REST catalog access, including table deletion."
     symbols:
       - AsyncStorageAnalyticsClient.catalog
       - SyncStorageAnalyticsClient.catalog


### PR DESCRIPTION
## Summary
[supabase/sdk#74](https://github.com/supabase/sdk/pull/74) renames/splits several feature IDs in the canonical capability matrix. This updates `sdk-compliance.yaml` so the SDK compliance CI check doesn't fail on unknown IDs once that PR merges. No SDK code changes.

- `auth.sign_in.reset_password` → `auth.sign_in.send_password_reset_email`
- `realtime.channel.send` → `realtime.channel.broadcast`
- `storage.file_buckets.list_files_paginated` merged into `list_files` (symbols combined; noted that pagination is exposed via `list_v2`)
- `storage.analytics.iceberg_namespace` split into `create_namespace`/`list_namespaces`/`delete_namespace` (same `catalog()` symbols on each, note text adapted per operation)
- `storage.analytics.iceberg_table` split into `create_table`/`list_tables`/`load_table`/`update_table`/`rename_table`/`delete_table` (same treatment)

Context: [SDK-1439](https://linear.app/supabase/issue/SDK-1439)

## Test plan
- [x] Validated against the updated registry with `npm run validate-compliance` from `supabase/sdk` (branch with #74's changes): `OK — compliance file is valid.`