### PR TITLE
fix(storage): surface real error when error body lacks message

### DIFF
--- a/src/storage/src/storage3/_async/file_api.py
+++ b/src/storage/src/storage3/_async/file_api.py
@@ -84,7 +84,7 @@ class AsyncBucketActionsMixin:
                     resp["message"], resp["error"], resp["statusCode"]
                 ) from exc
             except KeyError as err:
-                message = f"Unable to parse error message: {resp.text}"
+                message = f"Unable to parse error message: {exc.response.text}"
                 raise StorageApiError(message, "InternalError", 400) from err
 
         # close the resource before returning the response

--- a/src/storage/src/storage3/_sync/file_api.py
+++ b/src/storage/src/storage3/_sync/file_api.py
@@ -84,7 +84,7 @@ class SyncBucketActionsMixin:
                     resp["message"], resp["error"], resp["statusCode"]
                 ) from exc
             except KeyError as err:
-                message = f"Unable to parse error message: {resp.text}"
+                message = f"Unable to parse error message: {exc.response.text}"
                 raise StorageApiError(message, "InternalError", 400) from err
 
         # close the resource before returning the response

--- a/src/storage/tests/_async/test_file_api.py
+++ b/src/storage/tests/_async/test_file_api.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+from httpx import Headers
+from storage3._async.file_api import AsyncBucketProxy
+from storage3.exceptions import StorageApiError
+from yarl import URL
+
+
+async def test_request_raises_real_error_when_body_missing_message_field() -> None:
+    """A non-2xx body without message/error/statusCode must surface as StorageApiError."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, json={"code": "TooLarge"}, request=request)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        proxy = AsyncBucketProxy(
+            id="bucket",
+            _base_url=URL("http://localhost:54321/storage/v1"),
+            _headers=Headers(),
+            _client=client,
+        )
+        with pytest.raises(StorageApiError) as exc_info:
+            await proxy._request("GET", ["object", "open", "bucket", "file.txt"])
+
+    assert exc_info.value.code == "InternalError"
+    assert exc_info.value.status == 400
+    assert "TooLarge" in exc_info.value.message

--- a/src/storage/tests/_sync/test_file_api.py
+++ b/src/storage/tests/_sync/test_file_api.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+from httpx import Headers
+from storage3._sync.file_api import SyncBucketProxy
+from storage3.exceptions import StorageApiError
+from yarl import URL
+
+
+def test_request_raises_real_error_when_body_missing_message_field() -> None:
+    """A non-2xx body without message/error/statusCode must surface as StorageApiError."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, json={"code": "TooLarge"}, request=request)
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        proxy = SyncBucketProxy(
+            id="bucket",
+            _base_url=URL("http://localhost:54321/storage/v1"),
+            _headers=Headers(),
+            _client=client,
+        )
+        with pytest.raises(StorageApiError) as exc_info:
+            proxy._request("GET", ["object", "open", "bucket", "file.txt"])
+
+    assert exc_info.value.code == "InternalError"
+    assert exc_info.value.status == 400
+    assert "TooLarge" in exc_info.value.message


### PR DESCRIPTION
## Description
In `storage3`, when the Storage API returns a non-2xx response whose JSON body is missing any of `message`, `error` or `statusCode`, the error-recovery path accessed `resp.text` where `resp` is the already-decoded `dict` — raising `AttributeError: 'dict' object has no attribute 'text'` and completely masking the real error.

## Motivation
Closes #1563. The real status and body were being discarded exactly when they matter most (the error path). The fix reports the raw response text in a proper `StorageApiError` instead.

## Changes
- `src/storage3/_sync/file_api.py` and `src/storage3/_async/file_api.py`: use `exc.response.text` on the recovery path.
- Added regression tests (`tests/_sync/test_file_api.py`, `tests/_async/test_file_api.py`) covering both sync and async `_request`.

## Testing
- New tests pass for `_sync` and `_async`.
- Adjacent storage unit tests (bucket, exceptions, utils) pass: 28 passed.
- `ruff check` and `ruff format --check` clean on changed files.

Cc: cc @olirice @silentworks for review.