### PR TITLE
fix(storage): use exc.response.text instead of resp.text in error handling

### DIFF
--- a/src/storage/src/storage3/_async/file_api.py
+++ b/src/storage/src/storage3/_async/file_api.py
@@ -84,7 +84,7 @@ class AsyncBucketActionsMixin:
                     resp["message"], resp["error"], resp["statusCode"]
                 ) from exc
             except KeyError as err:
-                message = f"Unable to parse error message: {resp.text}"
+                message = f"Unable to parse error message: {exc.response.text}"
                 raise StorageApiError(message, "InternalError", 400) from err
 
         # close the resource before returning the response

--- a/src/storage/src/storage3/_sync/file_api.py
+++ b/src/storage/src/storage3/_sync/file_api.py
@@ -84,7 +84,7 @@ class SyncBucketActionsMixin:
                     resp["message"], resp["error"], resp["statusCode"]
                 ) from exc
             except KeyError as err:
-                message = f"Unable to parse error message: {resp.text}"
+                message = f"Unable to parse error message: {exc.response.text}"
                 raise StorageApiError(message, "InternalError", 400) from err
 
         # close the resource before returning the response


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix

## What is the current behavior?
When an HTTP error occurs in the storage API and the response body cannot be parsed into the expected JSON keys (`message`, `error`, `statusCode`), a `KeyError` is caught. However, the fallback error message attempts to access `resp.text`. Because `resp` is the result of `exc.response.json()` (a Python dictionary), dictionaries do not have a `.text` attribute. This triggers an `AttributeError` that completely hides the original API/storage error from the user.

Fixes #1563

## What is the new behavior?
This PR updates the error handler to correctly reference `exc.response.text` (the raw `httpx` response object) instead of `resp.text`. This ensures that when JSON parsing fails, the raw text of the HTTP error is properly surfaced to the developer.

I applied this fix to both `AsyncBucketActionsMixin` and `SyncBucketActionsMixin`.

## Additional context
None