### PR TITLE
Clarify when get_user() returns None

### DIFF
--- a/src/auth/src/supabase_auth/_sync/gotrue_client.py
+++ b/src/auth/src/supabase_auth/_sync/gotrue_client.py
@@ -679,6 +679,9 @@ class SyncGoTrueClient(SyncGoTrueBaseAPI):
 
         Takes in an optional access token `jwt`. If no `jwt` is provided,
         `get_user()` will attempt to get the `jwt` from the current session.
+        
+        Returns `None` if no `jwt` is provided and there is no active
+        session to retrieve one from.
         """
         if not jwt:
             session = self.get_session()


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update.

## What is the current behavior?

`get_user()` is typed `Optional[UserResponse]`, but the docstring only explains the `jwt` parameter - it doesn't say when the method returns `None`. Callers have to read the implementation to find out.

## What is the new behavior?

Adds a sentence to the docstring clarifying that `get_user()` returns `None` only when no `jwt` is provided and there is no active session to retrieve one from.

No behavior changes - docstring only, no tests affected.