### PR TITLE
feat(postgrest): add current timestamp sentinel

### DIFF
--- a/src/postgrest/src/postgrest/constants.py
+++ b/src/postgrest/src/postgrest/constants.py
@@ -1,6 +1,14 @@
+from datetime import datetime
+from typing import Final, cast
+
 DEFAULT_POSTGREST_CLIENT_HEADERS = {
     "Accept": "application/json",
     "Content-Type": "application/json",
 }
 
 DEFAULT_POSTGREST_CLIENT_TIMEOUT = 120
+
+# PostgreSQL recognizes this string as the current transaction timestamp. The
+# cast lets generated update types accept it for datetime columns while keeping
+# the value sent to PostgREST unchanged.
+NOW: Final[datetime] = cast(datetime, "now()")

--- a/src/postgrest/tests/test_constants.py
+++ b/src/postgrest/tests/test_constants.py
@@ -1,0 +1,14 @@
+from datetime import datetime
+from typing import TypedDict
+
+from postgrest.constants import NOW
+
+
+class GeneratedUpdate(TypedDict, total=False):
+    updated_at: datetime
+
+
+def test_now_is_compatible_with_generated_datetime_fields() -> None:
+    payload = GeneratedUpdate(updated_at=NOW)
+
+    assert payload == {"updated_at": "now()"}


### PR DESCRIPTION
## Summary

- add `postgrest.constants.NOW` as a typed sentinel for PostgreSQL's current transaction timestamp
- preserve the runtime `"now()"` value sent to PostgREST while exposing a `datetime` type for generated update payloads
- add a regression test using a generated-style `TypedDict` datetime field

## Why

Generated Python update types represent timestamp columns as `datetime`. Until now, setting one of those columns to PostgreSQL's current timestamp required an inline type cast or weakening the generated type. The new sentinel provides an idiomatic, reusable value without changing request serialization.

Closes #1564.

## Validation

- `make postgrest.tests` — 303 passed
- PostgREST mypy checks — passed
- `ruff check .` — passed
- `ruff format --check .` — passed

cc @olirice @silentworks for review
