### PR TITLE
   perf(postgrest): speed up JSON parsing by 22x using json.loads

### DIFF
--- a/src/postgrest/src/postgrest/base_request_builder.py
+++ b/src/postgrest/src/postgrest/base_request_builder.py
@@ -23,7 +23,7 @@ from typing import (
 
 from httpx import AsyncClient, BasicAuth, Client, Headers, QueryParams
 from httpx import Response as RequestResponse
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel
 from yarl import URL
 
 if sys.version_info >= (3, 11):
@@ -39,9 +39,8 @@ except ImportError:
     from pydantic import validator as field_validator  # type: ignore
 
 from .base_client import BasePostgrestClient
-from .types import JSON, CountMethod, Filters, JSONAdapter, RequestMethod, ReturnMethod
 from .utils import sanitize_param
-
+from .types import JSON, CountMethod, Filters, RequestMethod, ReturnMethod
 
 class QueryArgs(NamedTuple):
     # groups the method, json, headers and params for a query in a single object
@@ -255,8 +254,10 @@ class APIResponse(BaseModel):
     def from_http_request_response(request_response: RequestResponse) -> APIResponse:
         count = APIResponse._get_count_from_http_request_response(request_response)
         try:
-            data = JSONAdapter.validate_json(request_response.content)
-        except ValidationError:
+            # json.loads is ~22x faster than Pydantic validation.
+            # Valid JSON inherently satisfies the JSON type union, so runtime validatio is redundant.
+            data = json.loads(request_response.content)
+        except JSONDecodeError:
             data = request_response.text if len(request_response.text) > 0 else []
         return APIResponse.model_construct(data=data, count=count)
 


### PR DESCRIPTION
   ## Summary
   Resolves #1486 by replacing the slow `JSONAdapter.validate_json` call in `base_request_builder.py` with the standard library `json.loads`.

   ## Context
   The current `JSONAdapter` (a Pydantic `TypeAdapter` over the `JSON` type alias) performs redundant runtime validation. Because standard JSON parsing already guarantees the output matches the `Union[None, bool, str, int, float, Sequence[JSON], Mapping[str, JSON]]` schema, we can safely skip the Pydantic validation pass entirely.

   This matches the exact, proven pattern already used successfully by `SingleAPIResponse.from_http_request_response` in the exact same file.

   ## Benchmarks
   As reported in #1486 and verified by community members:
   - **Before (JSONAdapter):** ~43ms
   - **After (json.loads):** ~1.9ms
   This represents a **~22x speedup** for large payloads, requires zero new dependencies, and maintains exact backward compatibility.

   ## Changes
   1. Removed `ValidationError` from Pydantic imports as it is no longer used.
   2. Removed unused `JSONAdapter` import.
   3. Switched `APIResponse.from_http_request_response` to use `json.loads` + `JSONDecodeError` fallback.