### PR TITLE
ci: pin supabase/sdk validate-capabilities workflow to v1.0.0

### DIFF
--- a/.github/workflows/validate-capabilities.yml
+++ b/.github/workflows/validate-capabilities.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   validate:
-    uses: supabase/sdk/.github/workflows/validate-sdk-compliance-python.yml@main
+    uses: supabase/sdk/.github/workflows/validate-sdk-compliance-python.yml@93b52588ffda761e61b22cebfc3e5e29aa3cb3f4 # v1.0.0
     with:
       griffe-packages: >-
         supabase supabase_auth postgrest storage3 realtime supabase_functions


### PR DESCRIPTION
## Summary
- supabase/sdk cut its first tagged release, v1.0.0 (github.com/supabase/sdk/releases/tag/v1.0.0).
- Pins `validate-capabilities.yml`'s `uses:` ref to that release's commit SHA with a `# v1.0.0` comment, instead of a floating `@main` ref. (This repo doesn't have a sync-compliance.yml, so that's the only file to update.)
- Dependabot's `github-actions` ecosystem (already configured in `.github/dependabot.yml`) recognizes the version comment and will open PRs here as supabase/sdk cuts new releases, so this stays current automatically.

## Test plan
- [ ] Merge this PR
- [ ] Confirm `Validate SDK Compliance` workflow still runs successfully against the pinned ref
- [ ] Confirm Dependabot picks up a future supabase/sdk release and opens a bump PR