### PR TITLE
fix(storage3): use exc.response.text instead of resp.text in async er…

### DIFF
--- a/src/storage/src/storage3/_async/file_api.py
+++ b/src/storage/src/storage3/_async/file_api.py
@@ -84,7 +84,7 @@ class AsyncBucketActionsMixin:
                     resp["message"], resp["error"], resp["statusCode"]
                 ) from exc
             except KeyError as err:
-                message = f"Unable to parse error message: {resp.text}"
+                message = f"Unable to parse error message: {exc.response.text}"
                 raise StorageApiError(message, "InternalError", 400) from err
 
         # close the resource before returning the response


### PR DESCRIPTION
Fixes #1563

## What kind of change does this PR introduce?
Bug fix

## What is the current behavior?
In `_async/file_api.py`, the `except KeyError` recovery block calls 
`resp.text` where `resp` is the already-decoded JSON dict. Dicts have 
no `.text` attribute, so this always raises an `AttributeError` that 
masks the real storage error and discards the actual status and body.

## What is the new behavior?
Changed `resp.text` to `exc.response.text` to correctly read the raw 
response body from the httpx exception object, so the caller gets a 
proper `StorageApiError` with the full error