### PR TITLE
fix(storage): raise StorageApiError when a bucket error body is unrecognized

### DIFF
--- a/src/storage/src/storage3/_async/bucket.py
+++ b/src/storage/src/storage3/_async/bucket.py
@@ -42,10 +42,14 @@ class AsyncStorageBucketAPI:
             )
             response.raise_for_status()
         except HTTPStatusError as exc:
-            resp = exc.response.json()
-            raise StorageApiError(
-                resp["message"], resp["error"], resp["statusCode"]
-            ) from exc
+            try:
+                resp = exc.response.json()
+                raise StorageApiError(
+                    resp["message"], resp["error"], resp["statusCode"]
+                ) from exc
+            except (KeyError, ValueError) as err:
+                message = f"Unable to parse error message: {exc.response.text}"
+                raise StorageApiError(message, "InternalError", 400) from err
 
         return response
 

--- a/src/storage/src/storage3/_sync/bucket.py
+++ b/src/storage/src/storage3/_sync/bucket.py
@@ -42,10 +42,14 @@ class SyncStorageBucketAPI:
             )
             response.raise_for_status()
         except HTTPStatusError as exc:
-            resp = exc.response.json()
-            raise StorageApiError(
-                resp["message"], resp["error"], resp["statusCode"]
-            ) from exc
+            try:
+                resp = exc.response.json()
+                raise StorageApiError(
+                    resp["message"], resp["error"], resp["statusCode"]
+                ) from exc
+            except (KeyError, ValueError) as err:
+                message = f"Unable to parse error message: {exc.response.text}"
+                raise StorageApiError(message, "InternalError", 400) from err
 
         return response
 

--- a/src/storage/tests/_async/test_bucket.py
+++ b/src/storage/tests/_async/test_bucket.py
@@ -1,3 +1,4 @@
+from json import JSONDecodeError
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -196,6 +197,43 @@ async def test_request_error_handling(storage_api, mock_client) -> None:
         await storage_api._request("GET", ["test"])
 
     assert exc_info.value.message == "Test error message"
+
+
+async def test_request_error_handling_unrecognized_body(
+    storage_api, mock_client
+) -> None:
+    error_response = Mock(spec=Response)
+    error_response.json.return_value = {"code": "TooLarge"}
+    error_response.text = '{"code": "TooLarge"}'
+
+    exc = HTTPStatusError("HTTP Error", request=Mock(), response=error_response)
+    mock_client.request.side_effect = exc
+
+    with pytest.raises(StorageApiError) as exc_info:
+        await storage_api._request("GET", ["test"])
+
+    assert (
+        exc_info.value.message == 'Unable to parse error message: {"code": "TooLarge"}'
+    )
+    assert exc_info.value.code == "InternalError"
+
+
+async def test_request_error_handling_non_json_body(storage_api, mock_client) -> None:
+    error_response = Mock(spec=Response)
+    error_response.json.side_effect = JSONDecodeError("Expecting value", "", 0)
+    error_response.text = "<html>504 Gateway Time-out</html>"
+
+    exc = HTTPStatusError("HTTP Error", request=Mock(), response=error_response)
+    mock_client.request.side_effect = exc
+
+    with pytest.raises(StorageApiError) as exc_info:
+        await storage_api._request("GET", ["test"])
+
+    assert (
+        exc_info.value.message
+        == "Unable to parse error message: <html>504 Gateway Time-out</html>"
+    )
+    assert exc_info.value.code == "InternalError"
 
 
 @pytest.mark.parametrize(

--- a/src/storage/tests/_sync/test_bucket.py
+++ b/src/storage/tests/_sync/test_bucket.py
@@ -1,3 +1,4 @@
+from json import JSONDecodeError
 from unittest.mock import Mock
 
 import pytest
@@ -196,6 +197,41 @@ def test_request_error_handling(storage_api, mock_client) -> None:
         storage_api._request("GET", ["test"])
 
     assert exc_info.value.message == "Test error message"
+
+
+def test_request_error_handling_unrecognized_body(storage_api, mock_client) -> None:
+    error_response = Mock(spec=Response)
+    error_response.json.return_value = {"code": "TooLarge"}
+    error_response.text = '{"code": "TooLarge"}'
+
+    exc = HTTPStatusError("HTTP Error", request=Mock(), response=error_response)
+    mock_client.request.side_effect = exc
+
+    with pytest.raises(StorageApiError) as exc_info:
+        storage_api._request("GET", ["test"])
+
+    assert (
+        exc_info.value.message == 'Unable to parse error message: {"code": "TooLarge"}'
+    )
+    assert exc_info.value.code == "InternalError"
+
+
+def test_request_error_handling_non_json_body(storage_api, mock_client) -> None:
+    error_response = Mock(spec=Response)
+    error_response.json.side_effect = JSONDecodeError("Expecting value", "", 0)
+    error_response.text = "<html>504 Gateway Time-out</html>"
+
+    exc = HTTPStatusError("HTTP Error", request=Mock(), response=error_response)
+    mock_client.request.side_effect = exc
+
+    with pytest.raises(StorageApiError) as exc_info:
+        storage_api._request("GET", ["test"])
+
+    assert (
+        exc_info.value.message
+        == "Unable to parse error message: <html>504 Gateway Time-out</html>"
+    )
+    assert exc_info.value.code == "InternalError"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What

`StorageBucketAPI._request` indexed the parsed error body directly:

```python
except HTTPStatusError as exc:
    resp = exc.response.json()
    raise StorageApiError(resp["message"], resp["error"], resp["statusCode"]) from exc
```

So a storage error whose JSON body is missing any of `message` / `error` / `statusCode` came back as a bare `KeyError`, and a body that isn't JSON at all (an HTML page from a proxy or gateway) came back as a `JSONDecodeError`. Either way the caller lost the real status and body and got an opaque exception instead of `StorageApiError` — on the one path where the message matters most. This affects every bucket operation: `list_buckets`, `get_bucket`, `create_bucket`, `update_bucket`, `empty_bucket`, `delete_bucket`.

## Fix

Wrap the lookup and fall back to `StorageApiError` carrying the raw response text, mirroring the shape `file_api._request` already uses and the `ValidationError` fallback `request.py` uses for vector buckets.

## Tests

Two new cases per flavour (async + sync), asserting `StorageApiError` rather than the leaked exception:
- error body missing the expected keys
- error body that isn't JSON

Reverting only the source change makes all four fail with the raw `KeyError` / `JSONDecodeError`; with the fix the bucket suite is 28 passed.

## Note

#1563 reports this same class of bug in `file_api._request` (its recovery path reaches for `resp.text` on a dict), and there are already PRs open for that file. This PR is the bucket API only, which is a separate `_request` with no recovery path at all — so the two don't overlap.

`_sync` is generated, so the change was made in `_async` and regenerated with `make build-sync`; only the bucket files are included here.
