### PR TITLE
fix(storage): close the upload file handle when the request fails

### DIFF
--- a/src/storage/src/storage3/_async/file_api.py
+++ b/src/storage/src/storage3/_async/file_api.py
@@ -65,33 +65,38 @@ class AsyncBucketActionsMixin:
         **kwargs: Any,
     ) -> Response:
         try:
-            url_path = self._base_url.joinpath(*path).with_query(query_params)
-            headers = headers or dict()
-            headers.update(self._headers)
-            response = await self._client.request(
-                method,
-                str(url_path),
-                headers=headers,
-                json=json,
-                files=files,
-                **kwargs,
-            )
-            response.raise_for_status()
-        except HTTPStatusError as exc:
             try:
-                resp = exc.response.json()
-                raise StorageApiError(
-                    resp["message"], resp["error"], resp["statusCode"]
-                ) from exc
-            except KeyError as err:
-                message = f"Unable to parse error message: {resp.text}"
-                raise StorageApiError(message, "InternalError", 400) from err
+                url_path = self._base_url.joinpath(*path).with_query(query_params)
+                headers = headers or dict()
+                headers.update(self._headers)
+                response = await self._client.request(
+                    method,
+                    str(url_path),
+                    headers=headers,
+                    json=json,
+                    files=files,
+                    **kwargs,
+                )
+                response.raise_for_status()
+            except HTTPStatusError as exc:
+                try:
+                    resp = exc.response.json()
+                    raise StorageApiError(
+                        resp["message"], resp["error"], resp["statusCode"]
+                    ) from exc
+                except KeyError as err:
+                    message = f"Unable to parse error message: {resp.text}"
+                    raise StorageApiError(message, "InternalError", 400) from err
 
-        # close the resource before returning the response
-        if files and "file" in files and isinstance(files["file"][1], BufferedReader):
-            files["file"][1].close()
-
-        return response
+            return response
+        finally:
+            # close the resource on the error path too, not just on success
+            if (
+                files
+                and "file" in files
+                and isinstance(files["file"][1], BufferedReader)
+            ):
+                files["file"][1].close()
 
     async def create_signed_upload_url(
         self,

--- a/src/storage/src/storage3/_sync/file_api.py
+++ b/src/storage/src/storage3/_sync/file_api.py
@@ -65,33 +65,38 @@ class SyncBucketActionsMixin:
         **kwargs: Any,
     ) -> Response:
         try:
-            url_path = self._base_url.joinpath(*path).with_query(query_params)
-            headers = headers or dict()
-            headers.update(self._headers)
-            response = self._client.request(
-                method,
-                str(url_path),
-                headers=headers,
-                json=json,
-                files=files,
-                **kwargs,
-            )
-            response.raise_for_status()
-        except HTTPStatusError as exc:
             try:
-                resp = exc.response.json()
-                raise StorageApiError(
-                    resp["message"], resp["error"], resp["statusCode"]
-                ) from exc
-            except KeyError as err:
-                message = f"Unable to parse error message: {resp.text}"
-                raise StorageApiError(message, "InternalError", 400) from err
+                url_path = self._base_url.joinpath(*path).with_query(query_params)
+                headers = headers or dict()
+                headers.update(self._headers)
+                response = self._client.request(
+                    method,
+                    str(url_path),
+                    headers=headers,
+                    json=json,
+                    files=files,
+                    **kwargs,
+                )
+                response.raise_for_status()
+            except HTTPStatusError as exc:
+                try:
+                    resp = exc.response.json()
+                    raise StorageApiError(
+                        resp["message"], resp["error"], resp["statusCode"]
+                    ) from exc
+                except KeyError as err:
+                    message = f"Unable to parse error message: {resp.text}"
+                    raise StorageApiError(message, "InternalError", 400) from err
 
-        # close the resource before returning the response
-        if files and "file" in files and isinstance(files["file"][1], BufferedReader):
-            files["file"][1].close()
-
-        return response
+            return response
+        finally:
+            # close the resource on the error path too, not just on success
+            if (
+                files
+                and "file" in files
+                and isinstance(files["file"][1], BufferedReader)
+            ):
+                files["file"][1].close()
 
     def create_signed_upload_url(
         self,

--- a/src/storage/tests/_async/test_client.py
+++ b/src/storage/tests/_async/test_client.py
@@ -8,10 +8,12 @@ from uuid import uuid4
 
 import pytest
 from httpx import AsyncClient as HttpxClient
+from httpx import Headers
 from httpx import HTTPStatusError, Response
 from storage3 import AsyncStorageClient
 from storage3.exceptions import StorageApiError
 from storage3.utils import StorageException
+from yarl import URL
 
 from .. import AsyncBucketProxy
 from ..utils import AsyncFinalizerFactory
@@ -827,3 +829,33 @@ async def test_client_list_v2_paginated(
         assert all(f.name.startswith(file.bucket_path) for f in result.objects)
         pages += 1
     assert pages == 4
+
+
+async def test_upload_closes_file_handle_on_error(tmp_path: Path) -> None:
+    """A failed upload must not leak the handle storage3 opened itself."""
+    source = tmp_path / "leak.txt"
+    source.write_bytes(b"payload")
+
+    error_response = Mock(spec=Response)
+    error_response.json.return_value = {
+        "message": "Duplicate",
+        "error": "Duplicate",
+        "statusCode": 409,
+    }
+
+    captured: dict = {}
+
+    async def fail(*args: object, **kwargs: object) -> Response:
+        captured["files"] = kwargs.get("files")
+        raise HTTPStatusError("409", request=Mock(), response=error_response)
+
+    client = AsyncMock()
+    client.headers = Headers()
+    client.request = fail
+
+    proxy = AsyncBucketProxy("bucket", URL("http://localhost"), Headers(), client)
+
+    with pytest.raises(StorageApiError):
+        await proxy.upload("leak.txt", str(source))
+
+    assert captured["files"]["file"][1].closed

--- a/src/storage/tests/_sync/test_client.py
+++ b/src/storage/tests/_sync/test_client.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Generator
+from collections.abc import Generator, Generator
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from unittest.mock import Mock, patch
@@ -8,10 +8,12 @@ from uuid import uuid4
 
 import pytest
 from httpx import Client as HttpxClient
+from httpx import Headers
 from httpx import HTTPStatusError, Response
 from storage3 import SyncStorageClient
 from storage3.exceptions import StorageApiError
 from storage3.utils import StorageException
+from yarl import URL
 
 from .. import SyncBucketProxy
 from ..utils import SyncFinalizerFactory
@@ -825,3 +827,33 @@ def test_client_list_v2_paginated(
         assert all(f.name.startswith(file.bucket_path) for f in result.objects)
         pages += 1
     assert pages == 4
+
+
+def test_upload_closes_file_handle_on_error(tmp_path: Path) -> None:
+    """A failed upload must not leak the handle storage3 opened itself."""
+    source = tmp_path / "leak.txt"
+    source.write_bytes(b"payload")
+
+    error_response = Mock(spec=Response)
+    error_response.json.return_value = {
+        "message": "Duplicate",
+        "error": "Duplicate",
+        "statusCode": 409,
+    }
+
+    captured: dict = {}
+
+    def fail(*args: object, **kwargs: object) -> Response:
+        captured["files"] = kwargs.get("files")
+        raise HTTPStatusError("409", request=Mock(), response=error_response)
+
+    client = Mock()
+    client.headers = Headers()
+    client.request = fail
+
+    proxy = SyncBucketProxy("bucket", URL("http://localhost"), Headers(), client)
+
+    with pytest.raises(StorageApiError):
+        proxy.upload("leak.txt", str(source))
+
+    assert captured["files"]["file"][1].closed


### PR DESCRIPTION
## What

When a caller passes a path instead of an already-open file, storage3 opens the handle itself:

```python
files = {"file": (filename, open(file, "rb"), content_type)}
```

`_request` then closed it *after* the `except HTTPStatusError` block, so the close only ran when the request succeeded. Any non-2xx raised `StorageApiError` straight past it and the handle stayed open — and since it only ever existed inside `_request`'s local `files` dict, the caller has no way to close it either.

It leaks whenever the exception is retained: logging with `exc_info`, collecting failures in a batch-upload loop, `raise ... from`, an error reporter. The traceback keeps the frame holding the reader alive. Python also emits `ResourceWarning: unclosed file` on that path.

Counting open fds against a mock transport returning 409 (the most common upload failure), with the error retained each time:

```
baseline: 0
after failed upload #1: 1
after failed upload #2: 2
...
after failed upload #5: 5
after successful upload: 0     <- success path was always fine
```

Both `upload()` / `update()` (via `_upload_or_update`) and `upload_to_signed_url()` are affected.

## Fix

Move the close into a `finally` so it runs on both paths. The condition is unchanged — still only `BufferedReader`, i.e. only handles storage3 opened itself, so a caller-supplied stream is still left alone to close as they see fit.

## Tests

`test_upload_closes_file_handle_on_error` (async + sync): mock the transport into an error, then assert the handle storage3 opened is closed. Reverting only the source change fails it on `.closed is False`.

## Note

The diff on `file_api.py` looks larger than it is — wrapping the body in `try` reindents it. The only behavioural change is where the close happens.

`_sync` is generated, so the change was made in `_async` and regenerated with `make build-sync`; unrelated regenerated files are excluded.

This does not touch the `resp.text` line a few lines above (#1563), which has PRs open already — different defect, different code path.
