### PR TITLE
fix(functions): keep edge function failures as FunctionsHttpError

### DIFF
--- a/src/functions/src/supabase_functions/_async/functions_client.py
+++ b/src/functions/src/supabase_functions/_async/functions_client.py
@@ -9,6 +9,7 @@ from yarl import URL
 from ..errors import FunctionsHttpError, FunctionsRelayError
 from ..utils import (
     FunctionRegion,
+    get_error_message,
     is_http_url,
     is_valid_str_arg,
 )
@@ -103,7 +104,7 @@ class AsyncFunctionsClient:
                 status_code = response.status_code
 
             raise FunctionsHttpError(
-                response.json().get("error")
+                get_error_message(response)
                 or f"An error occurred while requesting your edge function at {exc.request.url!r}.",
                 status_code,
             ) from exc
@@ -168,7 +169,7 @@ class AsyncFunctionsClient:
         is_relay_error = response.headers.get("x-relay-header")
 
         if is_relay_error and is_relay_error == "true":
-            raise FunctionsRelayError(response.json().get("error"))
+            raise FunctionsRelayError(get_error_message(response))
 
         if response_type == "json":
             data = response.json()

--- a/src/functions/src/supabase_functions/_sync/functions_client.py
+++ b/src/functions/src/supabase_functions/_sync/functions_client.py
@@ -9,6 +9,7 @@ from yarl import URL
 from ..errors import FunctionsHttpError, FunctionsRelayError
 from ..utils import (
     FunctionRegion,
+    get_error_message,
     is_http_url,
     is_valid_str_arg,
 )
@@ -103,7 +104,7 @@ class SyncFunctionsClient:
                 status_code = response.status_code
 
             raise FunctionsHttpError(
-                response.json().get("error")
+                get_error_message(response)
                 or f"An error occurred while requesting your edge function at {exc.request.url!r}.",
                 status_code,
             ) from exc
@@ -168,7 +169,7 @@ class SyncFunctionsClient:
         is_relay_error = response.headers.get("x-relay-header")
 
         if is_relay_error and is_relay_error == "true":
-            raise FunctionsRelayError(response.json().get("error"))
+            raise FunctionsRelayError(get_error_message(response))
 
         if response_type == "json":
             data = response.json()

--- a/src/functions/src/supabase_functions/utils.py
+++ b/src/functions/src/supabase_functions/utils.py
@@ -1,7 +1,9 @@
 import sys
+from typing import Optional
 from urllib.parse import urlparse
 
 from httpx import AsyncClient as AsyncClient  # noqa: F401
+from httpx import Response
 
 if sys.version_info >= (3, 11):
     from enum import StrEnum
@@ -11,6 +13,25 @@ else:
 
 DEFAULT_FUNCTION_CLIENT_TIMEOUT = 5
 BASE64URL_REGEX = r"^([a-z0-9_-]{4})*($|[a-z0-9_-]{3}$|[a-z0-9_-]{2}$)$"
+
+
+def get_error_message(response: Response) -> Optional[str]:
+    """Return the ``error`` field of a JSON error body, or None if it is absent.
+
+    A failing edge function does not always answer with a JSON object: a
+    gateway can return HTML or plain text, and a body can be a valid JSON
+    array or string. Calling ``.json()["error"]`` on those raises instead of
+    reporting the failure, so callers lose the error they were trying to read.
+    """
+    try:
+        data = response.json()
+    except ValueError:
+        return None
+
+    if isinstance(data, dict):
+        return data.get("error")
+
+    return None
 
 
 class FunctionRegion(StrEnum):

--- a/src/functions/tests/_async/test_function_client.py
+++ b/src/functions/tests/_async/test_function_client.py
@@ -1,9 +1,10 @@
 import re
+from json import JSONDecodeError
 from typing import Dict
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
-from httpx import AsyncClient, HTTPError, Response, Timeout
+from httpx import AsyncClient, HTTPError, HTTPStatusError, Request, Response, Timeout
 
 # Import the class to test
 from supabase_functions import AsyncFunctionsClient
@@ -149,6 +150,52 @@ async def test_invoke_with_http_error(client: AsyncFunctionsClient) -> None:
         mock_request.return_value = mock_response
 
         with pytest.raises(FunctionsHttpError, match="Custom error message"):
+            await client.invoke("test-function")
+
+
+async def test_invoke_with_non_json_error_body(client: AsyncFunctionsClient) -> None:
+    """A gateway failure returns HTML, not JSON — that must still be a FunctionsHttpError."""
+    mock_response = Mock(spec=Response)
+    mock_response.json.side_effect = JSONDecodeError("Expecting value", "", 0)
+    mock_response.raise_for_status.side_effect = HTTPStatusError(
+        "HTTP Error",
+        request=Request(
+            "POST", "https://example.supabase.co/functions/v1/test-function"
+        ),
+        response=mock_response,
+    )
+    mock_response.headers = {}
+    mock_response.status_code = 504
+
+    with patch.object(
+        client._client, "request", new_callable=AsyncMock
+    ) as mock_request:
+        mock_request.return_value = mock_response
+
+        with pytest.raises(FunctionsHttpError, match="An error occurred"):
+            await client.invoke("test-function")
+
+
+async def test_invoke_with_non_object_error_body(client: AsyncFunctionsClient) -> None:
+    """A JSON body that is not an object has no `error` key to read."""
+    mock_response = Mock(spec=Response)
+    mock_response.json.return_value = ["boom"]
+    mock_response.raise_for_status.side_effect = HTTPStatusError(
+        "HTTP Error",
+        request=Request(
+            "POST", "https://example.supabase.co/functions/v1/test-function"
+        ),
+        response=mock_response,
+    )
+    mock_response.headers = {}
+    mock_response.status_code = 500
+
+    with patch.object(
+        client._client, "request", new_callable=AsyncMock
+    ) as mock_request:
+        mock_request.return_value = mock_response
+
+        with pytest.raises(FunctionsHttpError, match="An error occurred"):
             await client.invoke("test-function")
 
 

--- a/src/functions/tests/_sync/test_function_client.py
+++ b/src/functions/tests/_sync/test_function_client.py
@@ -1,9 +1,10 @@
 import re
+from json import JSONDecodeError
 from typing import Dict
 from unittest.mock import Mock, patch
 
 import pytest
-from httpx import Client, HTTPError, Response, Timeout
+from httpx import Client, HTTPError, HTTPStatusError, Request, Response, Timeout
 
 # Import the class to test
 from supabase_functions import SyncFunctionsClient
@@ -139,6 +140,48 @@ def test_invoke_with_http_error(client: SyncFunctionsClient) -> None:
         mock_request.return_value = mock_response
 
         with pytest.raises(FunctionsHttpError, match="Custom error message"):
+            client.invoke("test-function")
+
+
+def test_invoke_with_non_json_error_body(client: SyncFunctionsClient) -> None:
+    """A gateway failure returns HTML, not JSON — that must still be a FunctionsHttpError."""
+    mock_response = Mock(spec=Response)
+    mock_response.json.side_effect = JSONDecodeError("Expecting value", "", 0)
+    mock_response.raise_for_status.side_effect = HTTPStatusError(
+        "HTTP Error",
+        request=Request(
+            "POST", "https://example.supabase.co/functions/v1/test-function"
+        ),
+        response=mock_response,
+    )
+    mock_response.headers = {}
+    mock_response.status_code = 504
+
+    with patch.object(client._client, "request", new_callable=Mock) as mock_request:
+        mock_request.return_value = mock_response
+
+        with pytest.raises(FunctionsHttpError, match="An error occurred"):
+            client.invoke("test-function")
+
+
+def test_invoke_with_non_object_error_body(client: SyncFunctionsClient) -> None:
+    """A JSON body that is not an object has no `error` key to read."""
+    mock_response = Mock(spec=Response)
+    mock_response.json.return_value = ["boom"]
+    mock_response.raise_for_status.side_effect = HTTPStatusError(
+        "HTTP Error",
+        request=Request(
+            "POST", "https://example.supabase.co/functions/v1/test-function"
+        ),
+        response=mock_response,
+    )
+    mock_response.headers = {}
+    mock_response.status_code = 500
+
+    with patch.object(client._client, "request", new_callable=Mock) as mock_request:
+        mock_request.return_value = mock_response
+
+        with pytest.raises(FunctionsHttpError, match="An error occurred"):
             client.invoke("test-function")
 
 


### PR DESCRIPTION
## What

`_request` reads the failure body inside its `except HTTPError` handler:

```python
raise FunctionsHttpError(
    response.json().get("error")
    or f"An error occurred while requesting your edge function at {exc.request.url!r}.",
    status_code,
) from exc
```

A failing edge function does not always answer with a JSON object. A 502/504 from the gateway returns HTML, and a body can be a valid JSON array or string. So:

```
non-JSON body   -> json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
JSON list body  -> AttributeError: 'list' object has no attribute 'get'
```

The caller gets that raw exception instead of `FunctionsHttpError`, so `except FunctionsHttpError` around `invoke()` does not catch the failure, and the status code and body are lost.

There is a second effect worth calling out: the `or "An error occurred ..."` fallback was unreachable in exactly the situation it was written for. It could only be reached once `.json()` had already succeeded *and* returned a dict — i.e. never for the malformed bodies it was meant to cover.

The relay path had the identical call:

```python
raise FunctionsRelayError(response.json().get("error"))
```

## Fix

Read the body through a small `get_error_message` helper in `utils.py` that returns `None` when the body is not JSON or not an object, so the existing fallback message does its job. Applied to both sites.

## Tests

Two cases per flavour (async + sync): a non-JSON error body and a JSON body that is not an object. Both assert `FunctionsHttpError`. Reverting only the client call sites makes all four fail with `JSONDecodeError` / `AttributeError`.

Full functions suite: 69 passed, 1 skipped. `_sync` is generated, so the change was made in `_async` and regenerated with `make build-sync`.
