### PR TITLE
fix: correct invalid feature IDs in sdk-compliance.yaml

### DIFF
--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -53,7 +53,7 @@ features:
     symbols:
       - AsyncGoTrueClient.resend
       - SyncGoTrueClient.resend
-  auth.sign_in.reset_password:
+  auth.sign_in.send_password_reset_email:
     status: implemented
     symbols:
       - AsyncGoTrueClient.reset_password_for_email
@@ -532,7 +532,7 @@ features:
     symbols:
       - AsyncRealtimeChannel.unsubscribe
       - SyncRealtimeChannel.unsubscribe
-  realtime.channel.send:
+  realtime.channel.broadcast:
     status: implemented
     symbols:
       - AsyncRealtimeChannel.send_broadcast
@@ -649,6 +649,8 @@ features:
     symbols:
       - AsyncBucketActionsMixin.list
       - SyncBucketActionsMixin.list
+      - AsyncBucketActionsMixin.list_v2
+      - SyncBucketActionsMixin.list_v2
   storage.file_buckets.move:
     status: implemented
     symbols:
@@ -704,11 +706,6 @@ features:
     symbols:
       - AsyncBucketActionsMixin.info
       - SyncBucketActionsMixin.info
-  storage.file_buckets.list_files_paginated:
-    status: implemented
-    symbols:
-      - AsyncBucketActionsMixin.list_v2
-      - SyncBucketActionsMixin.list_v2
   storage.file_buckets.download_with_transform:
     status: implemented
     note: "Pass a transform key in the url_options argument of create_signed_url(); the transform dict is forwarded in the signed URL request."
@@ -845,16 +842,107 @@ features:
       - AsyncStorageAnalyticsClient.delete
       - SyncStorageAnalyticsClient.delete
 
-  storage.analytics.iceberg_namespace:
+  storage.analytics.access_catalog:
     status: implemented
-    note: "catalog() returns a pyiceberg RestCatalog giving full Iceberg REST catalog access including namespace management."
+    note: "catalog() returns a pyiceberg RestCatalog scoped to the analytics bucket's REST Catalog."
     symbols:
       - AsyncStorageAnalyticsClient.catalog
       - SyncStorageAnalyticsClient.catalog
 
-  storage.analytics.iceberg_table:
+  storage.analytics.create_namespace:
     status: implemented
-    note: "catalog() returns a pyiceberg RestCatalog giving full Iceberg REST catalog access including table management."
+    note: "Via the standard pyiceberg RestCatalog returned by catalog()."
+    symbols:
+      - AsyncStorageAnalyticsClient.catalog
+      - SyncStorageAnalyticsClient.catalog
+
+  storage.analytics.list_namespaces:
+    status: implemented
+    note: "Via the standard pyiceberg RestCatalog returned by catalog()."
+    symbols:
+      - AsyncStorageAnalyticsClient.catalog
+      - SyncStorageAnalyticsClient.catalog
+
+  storage.analytics.delete_namespace:
+    status: implemented
+    note: "Via the standard pyiceberg RestCatalog returned by catalog()."
+    symbols:
+      - AsyncStorageAnalyticsClient.catalog
+      - SyncStorageAnalyticsClient.catalog
+
+  storage.analytics.load_namespace_metadata:
+    status: implemented
+    note: "Via the standard pyiceberg RestCatalog returned by catalog()."
+    symbols:
+      - AsyncStorageAnalyticsClient.catalog
+      - SyncStorageAnalyticsClient.catalog
+
+  storage.analytics.namespace_exists:
+    status: implemented
+    note: "Via the standard pyiceberg RestCatalog returned by catalog()."
+    symbols:
+      - AsyncStorageAnalyticsClient.catalog
+      - SyncStorageAnalyticsClient.catalog
+
+  storage.analytics.update_namespace_properties:
+    status: implemented
+    note: "Via the standard pyiceberg RestCatalog returned by catalog()."
+    symbols:
+      - AsyncStorageAnalyticsClient.catalog
+      - SyncStorageAnalyticsClient.catalog
+
+  storage.analytics.create_table:
+    status: implemented
+    note: "Via the standard pyiceberg RestCatalog returned by catalog()."
+    symbols:
+      - AsyncStorageAnalyticsClient.catalog
+      - SyncStorageAnalyticsClient.catalog
+
+  storage.analytics.list_tables:
+    status: implemented
+    note: "Via the standard pyiceberg RestCatalog returned by catalog()."
+    symbols:
+      - AsyncStorageAnalyticsClient.catalog
+      - SyncStorageAnalyticsClient.catalog
+
+  storage.analytics.load_table:
+    status: implemented
+    note: "Via the standard pyiceberg RestCatalog returned by catalog()."
+    symbols:
+      - AsyncStorageAnalyticsClient.catalog
+      - SyncStorageAnalyticsClient.catalog
+
+  storage.analytics.update_table:
+    status: implemented
+    note: "Via the standard pyiceberg RestCatalog returned by catalog()."
+    symbols:
+      - AsyncStorageAnalyticsClient.catalog
+      - SyncStorageAnalyticsClient.catalog
+
+  storage.analytics.rename_table:
+    status: implemented
+    note: "Via the standard pyiceberg RestCatalog returned by catalog()."
+    symbols:
+      - AsyncStorageAnalyticsClient.catalog
+      - SyncStorageAnalyticsClient.catalog
+
+  storage.analytics.delete_table:
+    status: implemented
+    note: "Via the standard pyiceberg RestCatalog returned by catalog()."
+    symbols:
+      - AsyncStorageAnalyticsClient.catalog
+      - SyncStorageAnalyticsClient.catalog
+
+  storage.analytics.register_table:
+    status: implemented
+    note: "Via the standard pyiceberg RestCatalog returned by catalog()."
+    symbols:
+      - AsyncStorageAnalyticsClient.catalog
+      - SyncStorageAnalyticsClient.catalog
+
+  storage.analytics.table_exists:
+    status: implemented
+    note: "Via the standard pyiceberg RestCatalog returned by catalog()."
     symbols:
       - AsyncStorageAnalyticsClient.catalog
       - SyncStorageAnalyticsClient.catalog


### PR DESCRIPTION
## Summary

The capability matrix site (https://supabase.github.io/sdk/) shows Python parity as **0%**. The daily `deploy-pages.yml` run in [supabase/sdk](https://github.com/supabase/sdk) logs:

```
python (supabase/supabase-py): unknown feature id "auth.sign_in.reset_password"
python (supabase/supabase-py): unknown feature id "realtime.channel.send"
python (supabase/supabase-py): unknown feature id "storage.file_buckets.list_files_paginated"
python (supabase/supabase-py): unknown feature id "storage.analytics.iceberg_namespace"
python (supabase/supabase-py): unknown feature id "storage.analytics.iceberg_table"
python: skipping supabase/supabase-py due to 5 error(s)
```

The aggregator rejects the whole `sdk-compliance.yaml` when any feature ID isn't in the canonical registry, so Python compliance is entirely skipped instead of scored.

- `auth.sign_in.reset_password` → renamed to `auth.sign_in.send_password_reset_email` (the registered ID for this feature)
- `realtime.channel.send` → renamed to `realtime.channel.broadcast` (matches the `send_broadcast` symbols)
- `storage.file_buckets.list_files_paginated` → merged into the existing `storage.file_buckets.list_files` entry (its `list_v2` symbols added there; the registry has one ID covering both paginated and non-paginated listing)
- `storage.analytics.iceberg_namespace` / `storage.analytics.iceberg_table` → these two custom IDs don't exist in the registry. Expanded into the 15 granular `storage.analytics.*` namespace/table/catalog IDs, all backed by `catalog()`, which (per `src/storage/src/storage3/_async/analytics.py`) returns a genuine `pyiceberg.catalog.rest.RestCatalog` implementing the full namespace/table lifecycle — this mirrors how `supabase-js` already declares the same feature set.

Validated locally against `supabase/sdk`'s own validator (`npm run validate-compliance`): the file now passes with 0 errors.

## Test plan
- [x] `npm run validate-compliance -- sdk-compliance.yaml` passes in supabase/sdk
- [ ] CI's `SDK Compliance — Python (reusable)` check passes on this PR