### PR TITLE
ci: bump the supabase/sdk validate workflow pin to v1.1.1

### DIFF
--- a/.github/workflows/validate-capabilities.yml
+++ b/.github/workflows/validate-capabilities.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   validate:
-    uses: supabase/sdk/.github/workflows/validate-sdk-compliance-python.yml@93b52588ffda761e61b22cebfc3e5e29aa3cb3f4 # v1.0.0
+    uses: supabase/sdk/.github/workflows/validate-sdk-compliance-python.yml@63c1ac1d44959bfd02e4fc70a09df287db4a425a # v1.1.1
     with:
       griffe-packages: >-
         supabase supabase_auth postgrest storage3 realtime supabase_functions


### PR DESCRIPTION
## What

Bumps the `supabase/sdk` pin in `.github/workflows/validate-capabilities.yml` from v1.0.0 (`93b52588`) to v1.1.1 (`63c1ac1d`).

## Why

This is a consistency bump, not a fix for this repo. v1.1.1 of supabase/sdk contains one workflow change, supabase/sdk#87, which stops the compliance sync from reading the capability spec at a frozen 2026-07-20 commit. This repo does not call the sync workflow, only the validate one, so the change is behaviorally a no-op here. The point is to keep every SDK repo pinned to the same sdk release, so the next bump is a single known version step rather than a per-repo archaeology exercise.

For context, the frozen spec is what produced the invalid feature IDs corrected in #1578. Since this repo has no sync workflow, those IDs must have arrived another way, so the underlying source here is worth a look separately. If a sync workflow is added later, it will pick up the fix automatically at this pin.

## Notes

`.github/` diff between v1.0.0 and v1.1.1 is limited to `sync-sdk-compliance.yml`, so `validate-sdk-compliance-python.yml` is unchanged at both pins.