### PR TITLE
fix(storage): preserve malformed error response body

### DIFF
--- a/src/storage/src/storage3/_async/file_api.py
+++ b/src/storage/src/storage3/_async/file_api.py
@@ -84,7 +84,7 @@ class AsyncBucketActionsMixin:
                     resp["message"], resp["error"], resp["statusCode"]
                 ) from exc
             except KeyError as err:
-                message = f"Unable to parse error message: {resp.text}"
+                message = f"Unable to parse error message: {exc.response.text}"
                 raise StorageApiError(message, "InternalError", 400) from err
 
         # close the resource before returning the response

--- a/src/storage/src/storage3/_sync/file_api.py
+++ b/src/storage/src/storage3/_sync/file_api.py
@@ -84,7 +84,7 @@ class SyncBucketActionsMixin:
                     resp["message"], resp["error"], resp["statusCode"]
                 ) from exc
             except KeyError as err:
-                message = f"Unable to parse error message: {resp.text}"
+                message = f"Unable to parse error message: {exc.response.text}"
                 raise StorageApiError(message, "InternalError", 400) from err
 
         # close the resource before returning the response

--- a/src/storage/tests/_async/test_client.py
+++ b/src/storage/tests/_async/test_client.py
@@ -8,10 +8,11 @@ from uuid import uuid4
 
 import pytest
 from httpx import AsyncClient as HttpxClient
-from httpx import HTTPStatusError, Response
+from httpx import Headers, HTTPStatusError, Response
 from storage3 import AsyncStorageClient
 from storage3.exceptions import StorageApiError
 from storage3.utils import StorageException
+from yarl import URL
 
 from .. import AsyncBucketProxy
 from ..utils import AsyncFinalizerFactory
@@ -597,6 +598,33 @@ async def test_client_info_with_error(
             match="{'statusCode': 404, 'error': Custom error message, 'message': File not found}",
         ):
             await storage_file_client_public.info(file.bucket_path)
+
+
+async def test_client_request_with_malformed_error_response() -> None:
+    """Ensure malformed storage error bodies retain the raw response text."""
+    error_response = Mock(spec=Response)
+    error_response.json.return_value = {"code": "TooLarge"}
+    error_response.text = '{"code":"TooLarge"}'
+
+    response = Mock(spec=Response)
+    response.raise_for_status.side_effect = HTTPStatusError(
+        "HTTP Error", request=Mock(), response=error_response
+    )
+
+    bucket = AsyncBucketProxy(
+        "bucket", URL("https://example.com/storage/v1/"), Headers(), Mock()
+    )
+    with patch.object(bucket._client, "request", new_callable=AsyncMock) as request:
+        request.return_value = response
+
+        with pytest.raises(StorageApiError) as exc_info:
+            await bucket._request("GET", ["object", "bucket", "file"])
+
+    assert exc_info.value.message == (
+        'Unable to parse error message: {"code":"TooLarge"}'
+    )
+    assert exc_info.value.code == "InternalError"
+    assert exc_info.value.status == 400
 
 
 async def test_client_exists(

--- a/src/storage/tests/_sync/test_client.py
+++ b/src/storage/tests/_sync/test_client.py
@@ -8,10 +8,11 @@ from uuid import uuid4
 
 import pytest
 from httpx import Client as HttpxClient
-from httpx import HTTPStatusError, Response
+from httpx import Headers, HTTPStatusError, Response
 from storage3 import SyncStorageClient
 from storage3.exceptions import StorageApiError
 from storage3.utils import StorageException
+from yarl import URL
 
 from .. import SyncBucketProxy
 from ..utils import SyncFinalizerFactory
@@ -595,6 +596,33 @@ def test_client_info_with_error(
             match="{'statusCode': 404, 'error': Custom error message, 'message': File not found}",
         ):
             storage_file_client_public.info(file.bucket_path)
+
+
+def test_client_request_with_malformed_error_response() -> None:
+    """Ensure malformed storage error bodies retain the raw response text."""
+    error_response = Mock(spec=Response)
+    error_response.json.return_value = {"code": "TooLarge"}
+    error_response.text = '{"code":"TooLarge"}'
+
+    response = Mock(spec=Response)
+    response.raise_for_status.side_effect = HTTPStatusError(
+        "HTTP Error", request=Mock(), response=error_response
+    )
+
+    bucket = SyncBucketProxy(
+        "bucket", URL("https://example.com/storage/v1/"), Headers(), Mock()
+    )
+    with patch.object(bucket._client, "request", new_callable=Mock) as request:
+        request.return_value = response
+
+        with pytest.raises(StorageApiError) as exc_info:
+            bucket._request("GET", ["object", "bucket", "file"])
+
+    assert exc_info.value.message == (
+        'Unable to parse error message: {"code":"TooLarge"}'
+    )
+    assert exc_info.value.code == "InternalError"
+    assert exc_info.value.status == 400
 
 
 def test_client_exists(


### PR DESCRIPTION
## Summary

- Preserve the raw Storage API response body when its JSON omits required error fields.
- Add synchronous and asynchronous regression coverage.

## Problem / root cause

When a non-2xx Storage response lacked `message`, `error`, or `statusCode`, the fallback attempted to read `.text` from the parsed JSON dictionary. That raised `AttributeError` and hid the server response.

## Solution

Read the raw body from `exc.response.text` in both request implementations and assert the resulting `StorageApiError` preserves it.

## Testing performed

- Added sync and async mocked regression tests for `{"code":"TooLarge"}`.
- Verified the exact original request handlers raise `AttributeError` and the patched handlers raise `StorageApiError` with the raw body, fallback code, and status.
- `python3 -m py_compile` and `git diff --check` passed.
- Repository-native `pytest`, `ruff`, and `mypy` could not run locally because this environment lacks `uv`/test dependencies and cannot reach PyPI.

Closes #1563.