### PR TITLE
fix(postgrest): handle empty HEAD error responses

### DIFF
--- a/src/postgrest/src/postgrest/_async/request_builder.py
+++ b/src/postgrest/src/postgrest/_async/request_builder.py
@@ -91,6 +91,8 @@ class AsyncQueryRequestBuilder:
         try:
             if r.is_success:
                 return APIResponse.from_http_request_response(r)
+            elif not r.content:
+                raise APIError(generate_default_error_message(r))
             else:
                 json_obj = model_validate_json(APIErrorFromJSON, r.content)
                 raise APIError(dict(json_obj))

--- a/src/postgrest/src/postgrest/_sync/request_builder.py
+++ b/src/postgrest/src/postgrest/_sync/request_builder.py
@@ -91,6 +91,8 @@ class SyncQueryRequestBuilder:
         try:
             if r.is_success:
                 return APIResponse.from_http_request_response(r)
+            elif not r.content:
+                raise APIError(generate_default_error_message(r))
             else:
                 json_obj = model_validate_json(APIErrorFromJSON, r.content)
                 raise APIError(dict(json_obj))

--- a/src/postgrest/tests/_async/test_filter_request_builder_integration.py
+++ b/src/postgrest/tests/_async/test_filter_request_builder_integration.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 
 from postgrest import CountMethod
@@ -639,6 +641,22 @@ async def test_rpc_head_count():
 
     assert res.count == 2
     assert res.data == []
+
+async def test_head_query_error():
+    with patch(
+        "postgrest._async.request_builder.model_validate_json"
+    ) as mock_validate:
+        with pytest.raises(APIError) as exc_info:
+            await (
+                rest_client()
+                .from_("countries")
+                .select("*", count=CountMethod.exact, head=True)
+                .eq("ref.othercol", 123)
+                .execute()
+            )
+
+    mock_validate.assert_not_called()
+    assert exc_info.value.code == 400
 
 
 async def test_order():


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

A HEAD request that returns an HTTP error with an empty response body causes the client to attempt JSON parsing of the empty body, resulting in a Pydantic `ValidationError` instead of the expected `APIError`.

## What is the new behavior?

Empty error response bodies are handled before JSON parsing, and the existing default `APIError` is raised with the HTTP status code.

A regression test verifies that `model_validate_json` is not called for an empty HEAD error response.

## Additional context

This addresses supabase/supabase#1584.

Tests:
- Async integration tests: 53 passed
- Sync integration tests: 52 passed