### PR TITLE
test(postgrest)- Cover HEAD count with embedded filters

### DIFF
--- a/src/postgrest/tests/_async/test_request_builder.py
+++ b/src/postgrest/tests/_async/test_request_builder.py
@@ -45,6 +45,20 @@ class TestSelect:
         assert builder.request.http_method == "HEAD"
         assert builder.request.json is None
 
+    def test_select_with_head_and_embedded_filter(
+        self, request_builder: AsyncRequestBuilder
+    ):
+        builder = (
+            request_builder
+            .select("*, ref!inner(*)", count=CountMethod.exact, head=True)
+            .eq("ref.foo", 123)
+        )
+
+        assert builder.request.params["select"] == "*,ref!inner(*)"
+        assert builder.request.params["ref.foo"] == "eq.123"
+        assert builder.request.headers["prefer"] == "count=exact"
+        assert builder.request.http_method == "HEAD"
+
     def test_select_as_csv(self, request_builder: AsyncRequestBuilder):
         builder = request_builder.select("*").csv()
 

--- a/src/postgrest/tests/_sync/test_request_builder.py
+++ b/src/postgrest/tests/_sync/test_request_builder.py
@@ -45,6 +45,20 @@ class TestSelect:
         assert builder.request.http_method == "HEAD"
         assert builder.request.json is None
 
+    def test_select_with_head_and_embedded_filter(
+        self, request_builder: SyncRequestBuilder
+    ):
+        builder = (
+            request_builder
+            .select("*, ref!inner(*)", count=CountMethod.exact, head=True)
+            .eq("ref.foo", 123)
+        )
+
+        assert builder.request.params["select"] == "*,ref!inner(*)"
+        assert builder.request.params["ref.foo"] == "eq.123"
+        assert builder.request.headers["prefer"] == "count=exact"
+        assert builder.request.http_method == "HEAD"
+
     def test_select_as_csv(self, request_builder: SyncRequestBuilder):
         builder = request_builder.select("*").csv()
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix regression test for PostgREST HEAD requests with embedded-resource filters.


## What is the current behavior?
Queries using `head=True`, an exact count, and an embedded-resource filter can fail when the `select` parameter is missing:

```text
'ref' is not an embedded resource in this request
```

Please link any relevant issues here.
#1585 

## What is the new behavior?
- Add sync and async regression tests confirming that HEAD requests retain:
- The embedded-resource select expression
- The embedded-resource filter
- The count=exact preference
- The HEAD HTTP method

## Additional context
The current implementation already preserves the select parameter for HEAD requests. This PR adds regression coverage to prevent that behavior from breaking in the future.
