### PR TITLE
fix(postgrest): serialize filter values in eq()

### DIFF
--- a/src/postgrest/src/postgrest/base_request_builder.py
+++ b/src/postgrest/src/postgrest/base_request_builder.py
@@ -110,6 +110,21 @@ def _unique_columns(json: List[Dict[str, JSON]]):
     return columns
 
 
+def _serialize_filter_value(value: Any) -> str:
+    """Serialize a filter value into the wire format PostgREST expects.
+
+    ``None`` maps to ``null``, booleans to ``true``/``false``, and dicts/lists
+    to compact JSON, instead of the plain ``str()`` result (e.g. ``"None"``).
+    """
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, separators=(",", ":"))
+    return str(value)
+
+
 def _cleaned_columns(columns: Tuple[str, ...]) -> str:
     quoted = False
     cleaned = []
@@ -310,7 +325,7 @@ class BaseFilterRequestBuilder(Generic[C]):
             column: The name of the column to apply a filter on
             value: The value to filter by
         """
-        return self.filter(column, Filters.EQ, value)
+        return self.filter(column, Filters.EQ, _serialize_filter_value(value))
 
     def neq(self: Self, column: str, value: Any) -> Self:
         """A 'not equal to' filter

--- a/src/postgrest/tests/_async/test_filter_request_builder.py
+++ b/src/postgrest/tests/_async/test_filter_request_builder.py
@@ -72,6 +72,24 @@ def test_equals(filter_request_builder):
     assert str(builder.request.params) == "x=eq.a"
 
 
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (None, "eq.null"),
+        (True, "eq.true"),
+        (False, "eq.false"),
+        ({"key": "value"}, 'eq.{"key":"value"}'),
+        (["a", "b"], 'eq.["a","b"]'),
+        ("a", "eq.a"),
+        (42, "eq.42"),
+    ],
+)
+def test_eq_serializes_values(filter_request_builder, value, expected):
+    builder = filter_request_builder.eq("x", value)
+
+    assert builder.request.params["x"] == expected
+
+
 def test_not_equal(filter_request_builder):
     builder = filter_request_builder.neq("x", "a")
 

--- a/src/postgrest/tests/_sync/test_filter_request_builder.py
+++ b/src/postgrest/tests/_sync/test_filter_request_builder.py
@@ -72,6 +72,24 @@ def test_equals(filter_request_builder):
     assert str(builder.request.params) == "x=eq.a"
 
 
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (None, "eq.null"),
+        (True, "eq.true"),
+        (False, "eq.false"),
+        ({"key": "value"}, 'eq.{"key":"value"}'),
+        (["a", "b"], 'eq.["a","b"]'),
+        ("a", "eq.a"),
+        (42, "eq.42"),
+    ],
+)
+def test_eq_serializes_values(filter_request_builder, value, expected):
+    builder = filter_request_builder.eq("x", value)
+
+    assert builder.request.params["x"] == expected
+
+
 def test_not_equal(filter_request_builder):
     builder = filter_request_builder.neq("x", "a")
 


### PR DESCRIPTION
 ## What                                                                                                               
  Fixes #1583 — `.eq()` stringified filter values directly, so `None` produced `eq.None` (invalid SQL) and dict/list    
  values (for JSON columns) were serialized as Python reprs.                                                            
                                                                                                                        
  ## How                                                                                                                
  Added `_serialize_filter_value()` in `base_request_builder.py` and used it in `.eq()`:                                
  - `None` → `null`                                                                                                     
  - `bool` → `true` / `false`                                                                                           
  - `dict` / `list` → compact JSON (`{"key":"value"}`)                                                                  
  - everything else → unchanged `str()`                                                                                 
                                                                                                                        
  ## Tests                                                                                                              
  Added parametrized `test_eq_serializes_values` in both `tests/_async` and `tests/_sync` (7 cases: None, True, False,  
  dict, list, str, int).                                                                                                
                                                                                                                        
  Verified: reverting only the source change fails 5/7 cases. All 192 unit tests pass; `ruff check` and `ruff format`   
  clean. 