### PR TITLE
fix(postgrest): escape array-literal elements in cs/cd/contains/contained_by/overlaps

### DIFF
--- a/src/postgrest/src/postgrest/base_request_builder.py
+++ b/src/postgrest/src/postgrest/base_request_builder.py
@@ -40,7 +40,7 @@ except ImportError:
 
 from .base_client import BasePostgrestClient
 from .types import JSON, CountMethod, Filters, JSONAdapter, RequestMethod, ReturnMethod
-from .utils import sanitize_param
+from .utils import sanitize_array_param, sanitize_param
 
 
 class QueryArgs(NamedTuple):
@@ -455,12 +455,10 @@ class BaseFilterRequestBuilder(Generic[C]):
         return self.filter(column, Filters.IN, f"({values})")
 
     def cs(self: Self, column: str, values: Iterable[Any]) -> Self:
-        values = ",".join(str(v) for v in values)
-        return self.filter(column, Filters.CS, f"{{{values}}}")
+        return self.filter(column, Filters.CS, sanitize_array_param(values))
 
     def cd(self: Self, column: str, values: Iterable[Any]) -> Self:
-        values = ",".join(str(v) for v in values)
-        return self.filter(column, Filters.CD, f"{{{values}}}")
+        return self.filter(column, Filters.CD, sanitize_array_param(values))
 
     def contains(
         self: Self, column: str, value: Union[Iterable[Any], str, Dict[Any, Any]]
@@ -471,8 +469,7 @@ class BaseFilterRequestBuilder(Generic[C]):
             return self.filter(column, Filters.CS, value)
         if not isinstance(value, dict) and isinstance(value, Iterable):
             # Expected to be some type of iterable
-            stringified_values = ",".join(str(v) for v in value)
-            return self.filter(column, Filters.CS, f"{{{stringified_values}}}")
+            return self.filter(column, Filters.CS, sanitize_array_param(value))
 
         return self.filter(column, Filters.CS, json.dumps(value))
 
@@ -483,8 +480,7 @@ class BaseFilterRequestBuilder(Generic[C]):
             # range
             return self.filter(column, Filters.CD, value)
         if not isinstance(value, dict) and isinstance(value, Iterable):
-            stringified_values = ",".join(str(v) for v in value)
-            return self.filter(column, Filters.CD, f"{{{stringified_values}}}")
+            return self.filter(column, Filters.CD, sanitize_array_param(value))
         return self.filter(column, Filters.CD, json.dumps(value))
 
     def ov(self: Self, column: str, value: Iterable[Any]) -> Self:
@@ -494,8 +490,7 @@ class BaseFilterRequestBuilder(Generic[C]):
             return self.filter(column, Filters.OV, value)
         if not isinstance(value, dict) and isinstance(value, Iterable):
             # Expected to be some type of iterable
-            stringified_values = ",".join(str(v) for v in value)
-            return self.filter(column, Filters.OV, f"{{{stringified_values}}}")
+            return self.filter(column, Filters.OV, sanitize_array_param(value))
         return self.filter(column, Filters.OV, json.dumps(value))
 
     def sl(self: Self, column: str, range: Tuple[int, int]) -> Self:

--- a/src/postgrest/src/postgrest/utils.py
+++ b/src/postgrest/src/postgrest/utils.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Type, TypeVar, cast, get_origin
+from typing import Any, Iterable, Type, TypeVar, cast, get_origin
 from urllib.parse import urlparse
 
 from deprecation import deprecated
@@ -35,6 +35,35 @@ def sanitize_param(param: Any) -> str:
     if any(char in param_str for char in reserved_chars):
         return f'"{param_str}"'
     return param_str
+
+
+def sanitize_array_element(element: Any) -> str:
+    """Quote a single value for use inside a PostgreSQL array literal ``{...}``.
+
+    PostgreSQL quotes an array element when it is empty, matches ``NULL``
+    case-insensitively, or contains a brace, the comma delimiter, a double
+    quote, a backslash, or whitespace; embedded double quotes and backslashes
+    are backslash-escaped. Without this, a value such as ``"a,b"`` is emitted
+    bare and parsed by PostgREST as two separate elements.
+    """
+    element_str = str(element)
+    needs_quoting = (
+        element_str == ""
+        or element_str.lower() == "null"
+        or any(char in element_str for char in '{},"\\')
+        or any(char.isspace() for char in element_str)
+    )
+    if not needs_quoting:
+        return element_str
+    escaped = element_str.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def sanitize_array_param(values: Iterable[Any]) -> str:
+    """Render an iterable as a PostgreSQL array literal ``{elem,elem,...}``,
+    quoting each element as needed so values containing the comma delimiter (or
+    other special characters) survive as single elements."""
+    return f"{{{','.join(sanitize_array_element(value) for value in values)}}}"
 
 
 def sanitize_pattern_param(pattern: str) -> str:

--- a/src/postgrest/tests/_async/test_filter_request_builder.py
+++ b/src/postgrest/tests/_async/test_filter_request_builder.py
@@ -155,10 +155,48 @@ def test_contains_in_list(filter_request_builder):
 
 
 def test_contained_by_mixed_items(filter_request_builder):
+    # The second element is the literal string '["b", "c"]'. It contains the
+    # array delimiter, so it has to be quoted (with its inner quotes escaped);
+    # emitting it bare as {a,["b", "c"]} produced a corrupted literal that
+    # PostgREST would have split into several elements.
     builder = filter_request_builder.contained_by("x", ["a", '["b", "c"]'])
 
-    # {a,["b",+"c"]}
-    assert str(builder.request.params) == "x=cd.%7Ba%2C%5B%22b%22%2C+%22c%22%5D%7D"
+    assert builder.request.params["x"] == 'cd.{a,"[\\"b\\", \\"c\\"]"}'
+
+
+def test_contains_quotes_element_containing_the_delimiter(filter_request_builder):
+    # A value containing the comma delimiter must be quoted, otherwise
+    # PostgREST reads {a,b,c} as three elements rather than the two passed.
+    builder = filter_request_builder.contains("x", ["a,b", "c"])
+
+    assert builder.request.params["x"] == 'cs.{"a,b",c}'
+
+
+def test_cs_quotes_element_containing_the_delimiter(filter_request_builder):
+    builder = filter_request_builder.cs("x", ["a,b"])
+
+    assert builder.request.params["x"] == 'cs.{"a,b"}'
+
+
+def test_cd_quotes_element_containing_the_delimiter(filter_request_builder):
+    builder = filter_request_builder.cd("x", ["a,b"])
+
+    assert builder.request.params["x"] == 'cd.{"a,b"}'
+
+
+def test_overlaps_quotes_element_containing_the_delimiter(filter_request_builder):
+    builder = filter_request_builder.overlaps("x", ["a,b"])
+
+    assert builder.request.params["x"] == 'ov.{"a,b"}'
+
+
+def test_contains_quotes_braces_quotes_whitespace_empty_and_null(filter_request_builder):
+    # Braces, embedded double quotes, whitespace, the empty string and the word
+    # NULL all force quoting; embedded quotes are backslash-escaped so each
+    # element round-trips as a single value.
+    builder = filter_request_builder.contains("x", ["a}b", 'x"y', "a b", "", "NULL"])
+
+    assert builder.request.params["x"] == 'cs.{"a}b","x\\"y","a b","","NULL"}'
 
 
 def test_range_greater_than(filter_request_builder):

--- a/src/postgrest/tests/_sync/test_filter_request_builder.py
+++ b/src/postgrest/tests/_sync/test_filter_request_builder.py
@@ -155,10 +155,48 @@ def test_contains_in_list(filter_request_builder):
 
 
 def test_contained_by_mixed_items(filter_request_builder):
+    # The second element is the literal string '["b", "c"]'. It contains the
+    # array delimiter, so it has to be quoted (with its inner quotes escaped);
+    # emitting it bare as {a,["b", "c"]} produced a corrupted literal that
+    # PostgREST would have split into several elements.
     builder = filter_request_builder.contained_by("x", ["a", '["b", "c"]'])
 
-    # {a,["b",+"c"]}
-    assert str(builder.request.params) == "x=cd.%7Ba%2C%5B%22b%22%2C+%22c%22%5D%7D"
+    assert builder.request.params["x"] == 'cd.{a,"[\\"b\\", \\"c\\"]"}'
+
+
+def test_contains_quotes_element_containing_the_delimiter(filter_request_builder):
+    # A value containing the comma delimiter must be quoted, otherwise
+    # PostgREST reads {a,b,c} as three elements rather than the two passed.
+    builder = filter_request_builder.contains("x", ["a,b", "c"])
+
+    assert builder.request.params["x"] == 'cs.{"a,b",c}'
+
+
+def test_cs_quotes_element_containing_the_delimiter(filter_request_builder):
+    builder = filter_request_builder.cs("x", ["a,b"])
+
+    assert builder.request.params["x"] == 'cs.{"a,b"}'
+
+
+def test_cd_quotes_element_containing_the_delimiter(filter_request_builder):
+    builder = filter_request_builder.cd("x", ["a,b"])
+
+    assert builder.request.params["x"] == 'cd.{"a,b"}'
+
+
+def test_overlaps_quotes_element_containing_the_delimiter(filter_request_builder):
+    builder = filter_request_builder.overlaps("x", ["a,b"])
+
+    assert builder.request.params["x"] == 'ov.{"a,b"}'
+
+
+def test_contains_quotes_braces_quotes_whitespace_empty_and_null(filter_request_builder):
+    # Braces, embedded double quotes, whitespace, the empty string and the word
+    # NULL all force quoting; embedded quotes are backslash-escaped so each
+    # element round-trips as a single value.
+    builder = filter_request_builder.contains("x", ["a}b", 'x"y', "a b", "", "NULL"])
+
+    assert builder.request.params["x"] == 'cs.{"a}b","x\\"y","a b","","NULL"}'
 
 
 def test_range_greater_than(filter_request_builder):


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

Fixes #1592.

## What is the current behavior?

`cs`, `cd`, `contains`, `contained_by`, and `overlaps` build their PostgreSQL array literal `{...}` from the raw `str()` of each element with no escaping. Any element containing the comma delimiter (or a brace, double quote, backslash, whitespace, or the word `NULL`, or an empty string) is emitted bare and mis-parsed by PostgREST. The comma case is the clearest:

```python
client.from_("things").select("*").contains("tags", ["a,b", "c"])
# sends: tags=cs.{a,b,c}   ->  PostgREST reads THREE elements, not the two passed
```

`in_()` already quotes correctly via `sanitize_param`; the `{...}` operators did not. The suite even encoded the corruption: `test_contained_by_mixed_items` asserted `{a,["b", "c"]}`, itself a malformed literal whose inner comma splits the second element.

## What is the new behavior?

Added `sanitize_array_element` / `sanitize_array_param` in `utils.py` that quote each element following PostgreSQL array-literal rules (quote when empty, `NULL`, or containing a brace / comma / double quote / backslash / whitespace; backslash-escape embedded quotes and backslashes), and routed the five array operators through it.

```python
contains("tags", ["a,b", "c"])   ->   tags=cs.{"a,b",c}   # two elements, as passed
```

Simple values are unchanged (`["a", "b"]` -> `{a,b}`, `[1, 2, 3]` -> `{1,2,3}`; plain-string and dict/JSON inputs untouched), so this is backward-compatible for the common case. `test_contained_by_mixed_items` is updated to the corrected literal, with a comment noting the old output was corrupted.

## Additional context

- Tests added for the comma, brace, embedded-quote, whitespace, empty and `NULL` cases across `cs`/`cd`/`contains`/`contained_by`/`overlaps`, in both the `_async` source and the generated `_sync` mirror. Full postgrest unit suite, `ruff`, and `mypy` pass locally.
- Scope is intentionally limited to the `{...}` array operators. `in_()` uses a different (parenthesized) syntax and its own quoting, left untouched.
