### PR TITLE
Allow single response builder after insert select

### DIFF
--- a/src/postgrest/src/postgrest/_async/request_builder.py
+++ b/src/postgrest/src/postgrest/_async/request_builder.py
@@ -71,6 +71,19 @@ class AsyncQueryRequestBuilder:
             self.request.headers["Prefer"] = "return=representation"
         return self
 
+    def single(self) -> AsyncSingleRequestBuilder:
+        """Specify that the query will only return a single row in response.
+
+        .. caution::
+            The API will raise an error if the query returned more than one row.
+        """
+        self.request.headers["Accept"] = "application/vnd.pgrst.object+json"
+        return AsyncSingleRequestBuilder(self.request)
+
+    def maybe_single(self) -> AsyncMaybeSingleRequestBuilder:
+        """Retrieves at most one row from the result. Result must be at most one row (e.g. using `eq` on a UNIQUE column), otherwise this will result in an error."""
+        return AsyncMaybeSingleRequestBuilder(self.request)
+
     def retry(self, enabled: bool) -> Self:
         self.request.retry_enabled = enabled
         return self
@@ -208,19 +221,6 @@ class AsyncSelectRequestBuilder(
     def __init__(self, request: ReqConfig) -> None:
         BaseSelectRequestBuilder.__init__(self, request)
         AsyncQueryRequestBuilder.__init__(self, request)
-
-    def single(self) -> AsyncSingleRequestBuilder:
-        """Specify that the query will only return a single row in response.
-
-        .. caution::
-            The API will raise an error if the query returned more than one row.
-        """
-        self.request.headers["Accept"] = "application/vnd.pgrst.object+json"
-        return AsyncSingleRequestBuilder(self.request)
-
-    def maybe_single(self) -> AsyncMaybeSingleRequestBuilder:
-        """Retrieves at most one row from the result. Result must be at most one row (e.g. using `eq` on a UNIQUE column), otherwise this will result in an error."""
-        return AsyncMaybeSingleRequestBuilder(self.request)
 
     def text_search(
         self, column: str, query: str, options: dict[str, Any] = {}

--- a/src/postgrest/src/postgrest/_sync/request_builder.py
+++ b/src/postgrest/src/postgrest/_sync/request_builder.py
@@ -71,6 +71,19 @@ class SyncQueryRequestBuilder:
             self.request.headers["Prefer"] = "return=representation"
         return self
 
+    def single(self) -> SyncSingleRequestBuilder:
+        """Specify that the query will only return a single row in response.
+
+        .. caution::
+            The API will raise an error if the query returned more than one row.
+        """
+        self.request.headers["Accept"] = "application/vnd.pgrst.object+json"
+        return SyncSingleRequestBuilder(self.request)
+
+    def maybe_single(self) -> SyncMaybeSingleRequestBuilder:
+        """Retrieves at most one row from the result. Result must be at most one row (e.g. using `eq` on a UNIQUE column), otherwise this will result in an error."""
+        return SyncMaybeSingleRequestBuilder(self.request)
+
     def retry(self, enabled: bool) -> Self:
         self.request.retry_enabled = enabled
         return self
@@ -208,19 +221,6 @@ class SyncSelectRequestBuilder(
     def __init__(self, request: ReqConfig) -> None:
         BaseSelectRequestBuilder.__init__(self, request)
         SyncQueryRequestBuilder.__init__(self, request)
-
-    def single(self) -> SyncSingleRequestBuilder:
-        """Specify that the query will only return a single row in response.
-
-        .. caution::
-            The API will raise an error if the query returned more than one row.
-        """
-        self.request.headers["Accept"] = "application/vnd.pgrst.object+json"
-        return SyncSingleRequestBuilder(self.request)
-
-    def maybe_single(self) -> SyncMaybeSingleRequestBuilder:
-        """Retrieves at most one row from the result. Result must be at most one row (e.g. using `eq` on a UNIQUE column), otherwise this will result in an error."""
-        return SyncMaybeSingleRequestBuilder(self.request)
 
     def text_search(
         self, column: str, query: str, options: dict[str, Any] = {}

--- a/src/postgrest/tests/_async/test_request_builder.py
+++ b/src/postgrest/tests/_async/test_request_builder.py
@@ -4,7 +4,11 @@ import pytest
 from httpx import AsyncClient, Headers, QueryParams, Request, Response
 from yarl import URL
 
-from postgrest import AsyncRequestBuilder, AsyncSingleRequestBuilder
+from postgrest import (
+    AsyncMaybeSingleRequestBuilder,
+    AsyncRequestBuilder,
+    AsyncSingleRequestBuilder,
+)
 from postgrest._async.request_builder import RequestConfig
 from postgrest.base_request_builder import APIResponse, SingleAPIResponse
 from postgrest.types import JSON, CountMethod, ReturnMethod
@@ -139,6 +143,19 @@ class TestInsert:
         assert builder.request.headers.get_list("prefer", True) == [
             "return=representation",
         ]
+
+    def test_insert_with_select_single(self, request_builder: AsyncRequestBuilder):
+        builder = request_builder.insert({"key1": "val1"}).select("id").single()
+
+        assert builder.request.params["select"] == "id"
+        assert builder.request.headers["Accept"] == "application/vnd.pgrst.object+json"
+        assert isinstance(builder, AsyncSingleRequestBuilder)
+
+    def test_insert_with_select_maybe_single(self, request_builder: AsyncRequestBuilder):
+        builder = request_builder.insert({"key1": "val1"}).select("id").maybe_single()
+
+        assert builder.request.params["select"] == "id"
+        assert isinstance(builder, AsyncMaybeSingleRequestBuilder)
 
     def test_bulk_upsert_with_default(self, request_builder: AsyncRequestBuilder):
         builder = request_builder.upsert(

--- a/src/postgrest/tests/_sync/test_request_builder.py
+++ b/src/postgrest/tests/_sync/test_request_builder.py
@@ -4,7 +4,11 @@ import pytest
 from httpx import Client, Headers, QueryParams, Request, Response
 from yarl import URL
 
-from postgrest import SyncRequestBuilder, SyncSingleRequestBuilder
+from postgrest import (
+    SyncMaybeSingleRequestBuilder,
+    SyncRequestBuilder,
+    SyncSingleRequestBuilder,
+)
 from postgrest._async.request_builder import RequestConfig
 from postgrest.base_request_builder import APIResponse, SingleAPIResponse
 from postgrest.types import JSON, CountMethod, ReturnMethod
@@ -139,6 +143,19 @@ class TestInsert:
         assert builder.request.headers.get_list("prefer", True) == [
             "return=representation",
         ]
+
+    def test_insert_with_select_single(self, request_builder: SyncRequestBuilder):
+        builder = request_builder.insert({"key1": "val1"}).select("id").single()
+
+        assert builder.request.params["select"] == "id"
+        assert builder.request.headers["Accept"] == "application/vnd.pgrst.object+json"
+        assert isinstance(builder, SyncSingleRequestBuilder)
+
+    def test_insert_with_select_maybe_single(self, request_builder: SyncRequestBuilder):
+        builder = request_builder.insert({"key1": "val1"}).select("id").maybe_single()
+
+        assert builder.request.params["select"] == "id"
+        assert isinstance(builder, SyncMaybeSingleRequestBuilder)
 
     def test_bulk_upsert_with_default(self, request_builder: SyncRequestBuilder):
         builder = request_builder.upsert(


### PR DESCRIPTION
## What kind of change does this PR introduce?

  Feature / API parity improvement.

  ## What is the current behavior?

  The Python client supports selecting rows after insert, but chaining `.single()` or `.maybe_single()` after `.insert(...).select(...)` does not work.

  Closes #1553.

  ## What is the new behavior?

  Mutation query builders now support `.single()` and `.maybe_single()`, so these work:

  `client.table("table").insert({"name": "test"}).select("id").single()`

  `client.table("table").insert({"name": "test"}).select("id").maybe_single()`

  ## Testing

  - Added sync request builder tests
  - Added async request builder tests
  - Ran focused postgrest request builder tests: 90 passed

