### PR TITLE
ci: bump supabase/sdk reusable workflows to capability-matrix-v1.6.0

### DIFF
--- a/.github/workflows/validate-capabilities.yml
+++ b/.github/workflows/validate-capabilities.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   validate:
-    uses: supabase/sdk/.github/workflows/validate-sdk-compliance-python.yml@4d74492587bde35691e8a85470c0a7ebd7badb3e # v1.3.0
+    uses: supabase/sdk/.github/workflows/validate-sdk-compliance-python.yml@7ea18703f9148439941454238f2ee03012bae24b # v1.4.0
     with:
       griffe-packages: >-
         supabase supabase_auth postgrest storage3 realtime supabase_functions

--- a/.github/workflows/validate-capabilities.yml
+++ b/.github/workflows/validate-capabilities.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   validate:
-    uses: supabase/sdk/.github/workflows/validate-sdk-compliance-python.yml@7ea18703f9148439941454238f2ee03012bae24b # v1.4.0
+    uses: supabase/sdk/.github/workflows/validate-sdk-compliance-python.yml@75cf587c486f80c2d2afe57ec909ee2520c098b9 # v1.5.0
     with:
       griffe-packages: >-
         supabase supabase_auth postgrest storage3 realtime supabase_functions

--- a/.github/workflows/validate-capabilities.yml
+++ b/.github/workflows/validate-capabilities.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   validate:
-    uses: supabase/sdk/.github/workflows/validate-sdk-compliance-python.yml@75cf587c486f80c2d2afe57ec909ee2520c098b9 # v1.5.0
+    uses: supabase/sdk/.github/workflows/validate-sdk-compliance-python.yml@a494be6719174adbca0313de1ee187407e2dca95 # capability-matrix-v1.6.0
     with:
       griffe-packages: >-
         supabase supabase_auth postgrest storage3 realtime supabase_functions


### PR DESCRIPTION
Bumps the supabase/sdk reusable workflow pin to the `capability-matrix-v1.6.0` tag (commit a494be6719174adbca0313de1ee187407e2dca95).

supabase/sdk stopped cutting root `vX.Y.Z` release tags (supabase/sdk#112); the compliance workflows and their tooling are now versioned through `capability-matrix-vX.Y.Z` tags instead. This is the one-time repin onto the new tag family; Dependabot follows the `capability-matrix-v*` prefix from here on.