### PR TITLE
feat(functions): fix invoke option leakage, add method and bytes body support

### DIFF
--- a/src/functions/src/supabase_functions/_async/functions_client.py
+++ b/src/functions/src/supabase_functions/_async/functions_client.py
@@ -6,7 +6,7 @@ from warnings import warn
 from httpx import AsyncClient, HTTPError, QueryParams, Response
 from yarl import URL
 
-from ..errors import FunctionsHttpError, FunctionsRelayError, error_message_from
+from ..errors import FunctionsHttpError, FunctionsRelayError, _error_message_from
 from ..utils import (
     FunctionRegion,
     is_http_url,
@@ -104,7 +104,7 @@ class AsyncFunctionsClient:
                 status_code = response.status_code
 
             raise FunctionsHttpError(
-                error_message_from(response)
+                _error_message_from(response)
                 or f"An error occurred while requesting your edge function at {exc.request.url!r}.",
                 status_code,
             ) from exc
@@ -175,7 +175,7 @@ class AsyncFunctionsClient:
 
         if is_relay_error and is_relay_error == "true":
             raise FunctionsRelayError(
-                error_message_from(response)
+                _error_message_from(response)
                 or "An error occurred while relaying your edge function request."
             )
 

--- a/src/functions/src/supabase_functions/_async/functions_client.py
+++ b/src/functions/src/supabase_functions/_async/functions_client.py
@@ -6,13 +6,15 @@ from warnings import warn
 from httpx import AsyncClient, HTTPError, QueryParams, Response
 from yarl import URL
 
-from ..errors import FunctionsHttpError, FunctionsRelayError
+from ..errors import FunctionsHttpError, FunctionsRelayError, error_message_from
 from ..utils import (
     FunctionRegion,
     is_http_url,
     is_valid_str_arg,
 )
 from ..version import __version__
+
+HTTPMethod = Literal["GET", "OPTIONS", "HEAD", "POST", "PUT", "PATCH", "DELETE"]
 
 
 class AsyncFunctionsClient:
@@ -77,20 +79,19 @@ class AsyncFunctionsClient:
 
     async def _request(
         self,
-        method: Literal["GET", "OPTIONS", "HEAD", "POST", "PUT", "PATCH", "DELETE"],
+        method: HTTPMethod,
         path: list[str],
         headers: Optional[Dict[str, str]] = None,
-        json: Optional[Dict[Any, Any]] = None,
+        json: Optional[Union[Dict[Any, Any], str, bytes]] = None,
         params: Optional[QueryParams] = None,
     ) -> Response:
         url = self.url.joinpath(*path)
-        headers = headers or dict()
-        headers.update(self.headers)
+        headers = {**self.headers, **(headers or {})}
         response = (
             await self._client.request(
-                method, str(url), data=json, headers=headers, params=params
+                method, str(url), content=json, headers=headers, params=params
             )
-            if isinstance(json, str)
+            if isinstance(json, (str, bytes))
             else await self._client.request(
                 method, str(url), json=json, headers=headers, params=params
             )
@@ -103,7 +104,7 @@ class AsyncFunctionsClient:
                 status_code = response.status_code
 
             raise FunctionsHttpError(
-                response.json().get("error")
+                error_message_from(response)
                 or f"An error occurred while requesting your edge function at {exc.request.url!r}.",
                 status_code,
             ) from exc
@@ -132,17 +133,20 @@ class AsyncFunctionsClient:
         invoke_options : object with the following properties
             `headers`: object representing the headers to send with the request
             `body`: the body of the request
+            `method`: the HTTP method to invoke the function with. The default is `POST`
             `responseType`: how the response should be parsed. The default is `json`
         """
         if not is_valid_str_arg(function_name):
             raise ValueError("function_name must a valid string value.")
-        headers = self.headers
+        headers: Dict[str, str] = {}
         params = QueryParams()
         body = None
+        method: HTTPMethod = "POST"
         response_type = "text/plain"
 
         if invoke_options is not None:
             headers.update(invoke_options.get("headers", {}))
+            method = invoke_options.get("method", "POST")
             response_type = invoke_options.get("responseType", "text/plain")
 
             region = invoke_options.get("region")
@@ -161,14 +165,19 @@ class AsyncFunctionsClient:
                 headers["Content-Type"] = "text/plain"
             elif isinstance(body, dict):
                 headers["Content-Type"] = "application/json"
+            elif isinstance(body, bytes):
+                headers["Content-Type"] = "application/octet-stream"
 
         response = await self._request(
-            "POST", [function_name], headers=headers, json=body, params=params
+            method, [function_name], headers=headers, json=body, params=params
         )
         is_relay_error = response.headers.get("x-relay-header")
 
         if is_relay_error and is_relay_error == "true":
-            raise FunctionsRelayError(response.json().get("error"))
+            raise FunctionsRelayError(
+                error_message_from(response)
+                or "An error occurred while relaying your edge function request."
+            )
 
         if response_type == "json":
             data = response.json()

--- a/src/functions/src/supabase_functions/_sync/functions_client.py
+++ b/src/functions/src/supabase_functions/_sync/functions_client.py
@@ -6,7 +6,7 @@ from warnings import warn
 from httpx import Client, HTTPError, QueryParams, Response
 from yarl import URL
 
-from ..errors import FunctionsHttpError, FunctionsRelayError, error_message_from
+from ..errors import FunctionsHttpError, FunctionsRelayError, _error_message_from
 from ..utils import (
     FunctionRegion,
     is_http_url,
@@ -104,7 +104,7 @@ class SyncFunctionsClient:
                 status_code = response.status_code
 
             raise FunctionsHttpError(
-                error_message_from(response)
+                _error_message_from(response)
                 or f"An error occurred while requesting your edge function at {exc.request.url!r}.",
                 status_code,
             ) from exc
@@ -175,7 +175,7 @@ class SyncFunctionsClient:
 
         if is_relay_error and is_relay_error == "true":
             raise FunctionsRelayError(
-                error_message_from(response)
+                _error_message_from(response)
                 or "An error occurred while relaying your edge function request."
             )
 

--- a/src/functions/src/supabase_functions/_sync/functions_client.py
+++ b/src/functions/src/supabase_functions/_sync/functions_client.py
@@ -6,13 +6,15 @@ from warnings import warn
 from httpx import Client, HTTPError, QueryParams, Response
 from yarl import URL
 
-from ..errors import FunctionsHttpError, FunctionsRelayError
+from ..errors import FunctionsHttpError, FunctionsRelayError, error_message_from
 from ..utils import (
     FunctionRegion,
     is_http_url,
     is_valid_str_arg,
 )
 from ..version import __version__
+
+HTTPMethod = Literal["GET", "OPTIONS", "HEAD", "POST", "PUT", "PATCH", "DELETE"]
 
 
 class SyncFunctionsClient:
@@ -77,20 +79,19 @@ class SyncFunctionsClient:
 
     def _request(
         self,
-        method: Literal["GET", "OPTIONS", "HEAD", "POST", "PUT", "PATCH", "DELETE"],
+        method: HTTPMethod,
         path: list[str],
         headers: Optional[Dict[str, str]] = None,
-        json: Optional[Dict[Any, Any]] = None,
+        json: Optional[Union[Dict[Any, Any], str, bytes]] = None,
         params: Optional[QueryParams] = None,
     ) -> Response:
         url = self.url.joinpath(*path)
-        headers = headers or dict()
-        headers.update(self.headers)
+        headers = {**self.headers, **(headers or {})}
         response = (
             self._client.request(
-                method, str(url), data=json, headers=headers, params=params
+                method, str(url), content=json, headers=headers, params=params
             )
-            if isinstance(json, str)
+            if isinstance(json, (str, bytes))
             else self._client.request(
                 method, str(url), json=json, headers=headers, params=params
             )
@@ -103,7 +104,7 @@ class SyncFunctionsClient:
                 status_code = response.status_code
 
             raise FunctionsHttpError(
-                response.json().get("error")
+                error_message_from(response)
                 or f"An error occurred while requesting your edge function at {exc.request.url!r}.",
                 status_code,
             ) from exc
@@ -132,17 +133,20 @@ class SyncFunctionsClient:
         invoke_options : object with the following properties
             `headers`: object representing the headers to send with the request
             `body`: the body of the request
+            `method`: the HTTP method to invoke the function with. The default is `POST`
             `responseType`: how the response should be parsed. The default is `json`
         """
         if not is_valid_str_arg(function_name):
             raise ValueError("function_name must a valid string value.")
-        headers = self.headers
+        headers: Dict[str, str] = {}
         params = QueryParams()
         body = None
+        method: HTTPMethod = "POST"
         response_type = "text/plain"
 
         if invoke_options is not None:
             headers.update(invoke_options.get("headers", {}))
+            method = invoke_options.get("method", "POST")
             response_type = invoke_options.get("responseType", "text/plain")
 
             region = invoke_options.get("region")
@@ -161,14 +165,19 @@ class SyncFunctionsClient:
                 headers["Content-Type"] = "text/plain"
             elif isinstance(body, dict):
                 headers["Content-Type"] = "application/json"
+            elif isinstance(body, bytes):
+                headers["Content-Type"] = "application/octet-stream"
 
         response = self._request(
-            "POST", [function_name], headers=headers, json=body, params=params
+            method, [function_name], headers=headers, json=body, params=params
         )
         is_relay_error = response.headers.get("x-relay-header")
 
         if is_relay_error and is_relay_error == "true":
-            raise FunctionsRelayError(response.json().get("error"))
+            raise FunctionsRelayError(
+                error_message_from(response)
+                or "An error occurred while relaying your edge function request."
+            )
 
         if response_type == "json":
             data = response.json()

--- a/src/functions/src/supabase_functions/errors.py
+++ b/src/functions/src/supabase_functions/errors.py
@@ -47,7 +47,7 @@ class FunctionsRelayError(FunctionsError):
         )
 
 
-def error_message_from(response: Response) -> str | None:
+def _error_message_from(response: Response) -> str | None:
     """Best-effort extraction of an error message from an edge function response.
 
     An edge function may reply with a plain-text or empty body, so a failed JSON

--- a/src/functions/src/supabase_functions/errors.py
+++ b/src/functions/src/supabase_functions/errors.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from typing import TypedDict
+from typing import TYPE_CHECKING, TypedDict
+
+if TYPE_CHECKING:
+    from httpx import Response
 
 
 class FunctionsApiErrorDict(TypedDict):
@@ -42,3 +45,18 @@ class FunctionsRelayError(FunctionsError):
             "FunctionsRelayError",
             400 if code is None else code,
         )
+
+
+def error_message_from(response: Response) -> str | None:
+    """Best-effort extraction of an error message from an edge function response.
+
+    An edge function may reply with a plain-text or empty body, so a failed JSON
+    decode must not mask the underlying HTTP error.
+    """
+    try:
+        body = response.json()
+    except ValueError:
+        return response.text or None
+    if isinstance(body, dict):
+        return body.get("error")
+    return response.text or None

--- a/src/functions/tests/_async/test_function_client.py
+++ b/src/functions/tests/_async/test_function_client.py
@@ -3,7 +3,7 @@ from typing import Dict
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
-from httpx import AsyncClient, HTTPError, Response, Timeout
+from httpx import AsyncClient, HTTPError, Request, Response, Timeout
 
 # Import the class to test
 from supabase_functions import AsyncFunctionsClient
@@ -229,3 +229,185 @@ async def test_init_with_httpx_client() -> None:
 
     # Verify the client is properly configured with our custom client
     assert client._client is custom_client
+
+
+async def test_invoke_does_not_leak_per_call_headers(
+    client: AsyncFunctionsClient,
+) -> None:
+    mock_response = Mock(spec=Response)
+    mock_response.json.return_value = {"message": "success"}
+    mock_response.raise_for_status = Mock()
+    mock_response.headers = {}
+
+    with patch.object(
+        client._client, "request", new_callable=AsyncMock
+    ) as mock_request:
+        mock_request.return_value = mock_response
+
+        await client.invoke(
+            "test-function",
+            {
+                "headers": {"x-one-off": "yes"},
+                "region": FunctionRegion("us-east-1"),
+                "body": {"key": "value"},
+            },
+        )
+        await client.invoke("test-function")
+
+        first, second = mock_request.call_args_list
+        assert first.kwargs["headers"]["x-one-off"] == "yes"
+        assert "x-one-off" not in second.kwargs["headers"]
+        assert "x-region" not in second.kwargs["headers"]
+        assert "Content-Type" not in second.kwargs["headers"]
+        assert "x-one-off" not in client.headers
+
+
+async def test_invoke_per_call_headers_override_client_headers(
+    client: AsyncFunctionsClient,
+) -> None:
+    mock_response = Mock(spec=Response)
+    mock_response.json.return_value = {"message": "success"}
+    mock_response.raise_for_status = Mock()
+    mock_response.headers = {}
+
+    with patch.object(
+        client._client, "request", new_callable=AsyncMock
+    ) as mock_request:
+        mock_request.return_value = mock_response
+
+        await client.invoke(
+            "test-function", {"headers": {"Authorization": "Bearer override"}}
+        )
+
+        _, kwargs = mock_request.call_args
+        assert kwargs["headers"]["Authorization"] == "Bearer override"
+        assert client.headers["Authorization"] == "Bearer valid.jwt.token"
+
+
+@pytest.mark.parametrize("method", ["GET", "PUT", "PATCH", "DELETE"])
+async def test_invoke_with_method(client: AsyncFunctionsClient, method: str) -> None:
+    mock_response = Mock(spec=Response)
+    mock_response.json.return_value = {"message": "success"}
+    mock_response.raise_for_status = Mock()
+    mock_response.headers = {}
+
+    with patch.object(
+        client._client, "request", new_callable=AsyncMock
+    ) as mock_request:
+        mock_request.return_value = mock_response
+
+        await client.invoke("test-function", {"method": method})
+
+        args, _ = mock_request.call_args
+        assert args[0] == method
+
+
+async def test_invoke_defaults_to_post(client: AsyncFunctionsClient) -> None:
+    mock_response = Mock(spec=Response)
+    mock_response.json.return_value = {"message": "success"}
+    mock_response.raise_for_status = Mock()
+    mock_response.headers = {}
+
+    with patch.object(
+        client._client, "request", new_callable=AsyncMock
+    ) as mock_request:
+        mock_request.return_value = mock_response
+
+        await client.invoke("test-function")
+
+        args, _ = mock_request.call_args
+        assert args[0] == "POST"
+
+
+async def test_invoke_with_bytes_body(client: AsyncFunctionsClient) -> None:
+    mock_response = Mock(spec=Response)
+    mock_response.json.return_value = {"message": "success"}
+    mock_response.raise_for_status = Mock()
+    mock_response.headers = {}
+
+    with patch.object(
+        client._client, "request", new_callable=AsyncMock
+    ) as mock_request:
+        mock_request.return_value = mock_response
+
+        await client.invoke("test-function", {"body": b"\x00binary"})
+
+        _, kwargs = mock_request.call_args
+        assert kwargs["headers"]["Content-Type"] == "application/octet-stream"
+        assert kwargs["content"] == b"\x00binary"
+
+
+async def test_invoke_string_body_sent_as_content(
+    client: AsyncFunctionsClient,
+) -> None:
+    mock_response = Mock(spec=Response)
+    mock_response.json.return_value = {"message": "success"}
+    mock_response.raise_for_status = Mock()
+    mock_response.headers = {}
+
+    with patch.object(
+        client._client, "request", new_callable=AsyncMock
+    ) as mock_request:
+        mock_request.return_value = mock_response
+
+        await client.invoke("test-function", {"body": "string data"})
+
+        _, kwargs = mock_request.call_args
+        assert kwargs["content"] == "string data"
+
+
+async def test_invoke_http_error_with_non_json_body(
+    client: AsyncFunctionsClient,
+) -> None:
+    mock_response = Mock(spec=Response)
+    mock_response.json.side_effect = ValueError("not json")
+    mock_response.text = "boom"
+    mock_response.raise_for_status.side_effect = HTTPError("HTTP Error")
+    mock_response.headers = {}
+
+    with patch.object(
+        client._client, "request", new_callable=AsyncMock
+    ) as mock_request:
+        mock_request.return_value = mock_response
+
+        with pytest.raises(FunctionsHttpError, match="boom"):
+            await client.invoke("test-function")
+
+
+async def test_invoke_http_error_with_empty_body(client: AsyncFunctionsClient) -> None:
+    error = HTTPError("HTTP Error")
+    error.request = Request("POST", "https://example.com/test-function")
+
+    mock_response = Mock(spec=Response)
+    mock_response.json.side_effect = ValueError("not json")
+    mock_response.text = ""
+    mock_response.raise_for_status.side_effect = error
+    mock_response.headers = {}
+
+    with patch.object(
+        client._client, "request", new_callable=AsyncMock
+    ) as mock_request:
+        mock_request.return_value = mock_response
+
+        with pytest.raises(
+            FunctionsHttpError, match="An error occurred while requesting"
+        ):
+            await client.invoke("test-function")
+
+
+async def test_invoke_relay_error_with_non_json_body(
+    client: AsyncFunctionsClient,
+) -> None:
+    mock_response = Mock(spec=Response)
+    mock_response.json.side_effect = ValueError("not json")
+    mock_response.text = "relay exploded"
+    mock_response.raise_for_status = Mock()
+    mock_response.headers = {"x-relay-header": "true"}
+
+    with patch.object(
+        client._client, "request", new_callable=AsyncMock
+    ) as mock_request:
+        mock_request.return_value = mock_response
+
+        with pytest.raises(FunctionsRelayError, match="relay exploded"):
+            await client.invoke("test-function")

--- a/src/functions/tests/_sync/test_function_client.py
+++ b/src/functions/tests/_sync/test_function_client.py
@@ -3,7 +3,7 @@ from typing import Dict
 from unittest.mock import Mock, patch
 
 import pytest
-from httpx import Client, HTTPError, Response, Timeout
+from httpx import Client, HTTPError, Request, Response, Timeout
 
 # Import the class to test
 from supabase_functions import SyncFunctionsClient
@@ -213,3 +213,167 @@ def test_init_with_httpx_client() -> None:
 
     # Verify the client is properly configured with our custom client
     assert client._client is custom_client
+
+
+def test_invoke_does_not_leak_per_call_headers(
+    client: SyncFunctionsClient,
+) -> None:
+    mock_response = Mock(spec=Response)
+    mock_response.json.return_value = {"message": "success"}
+    mock_response.raise_for_status = Mock()
+    mock_response.headers = {}
+
+    with patch.object(client._client, "request", new_callable=Mock) as mock_request:
+        mock_request.return_value = mock_response
+
+        client.invoke(
+            "test-function",
+            {
+                "headers": {"x-one-off": "yes"},
+                "region": FunctionRegion("us-east-1"),
+                "body": {"key": "value"},
+            },
+        )
+        client.invoke("test-function")
+
+        first, second = mock_request.call_args_list
+        assert first.kwargs["headers"]["x-one-off"] == "yes"
+        assert "x-one-off" not in second.kwargs["headers"]
+        assert "x-region" not in second.kwargs["headers"]
+        assert "Content-Type" not in second.kwargs["headers"]
+        assert "x-one-off" not in client.headers
+
+
+def test_invoke_per_call_headers_override_client_headers(
+    client: SyncFunctionsClient,
+) -> None:
+    mock_response = Mock(spec=Response)
+    mock_response.json.return_value = {"message": "success"}
+    mock_response.raise_for_status = Mock()
+    mock_response.headers = {}
+
+    with patch.object(client._client, "request", new_callable=Mock) as mock_request:
+        mock_request.return_value = mock_response
+
+        client.invoke(
+            "test-function", {"headers": {"Authorization": "Bearer override"}}
+        )
+
+        _, kwargs = mock_request.call_args
+        assert kwargs["headers"]["Authorization"] == "Bearer override"
+        assert client.headers["Authorization"] == "Bearer valid.jwt.token"
+
+
+@pytest.mark.parametrize("method", ["GET", "PUT", "PATCH", "DELETE"])
+def test_invoke_with_method(client: SyncFunctionsClient, method: str) -> None:
+    mock_response = Mock(spec=Response)
+    mock_response.json.return_value = {"message": "success"}
+    mock_response.raise_for_status = Mock()
+    mock_response.headers = {}
+
+    with patch.object(client._client, "request", new_callable=Mock) as mock_request:
+        mock_request.return_value = mock_response
+
+        client.invoke("test-function", {"method": method})
+
+        args, _ = mock_request.call_args
+        assert args[0] == method
+
+
+def test_invoke_defaults_to_post(client: SyncFunctionsClient) -> None:
+    mock_response = Mock(spec=Response)
+    mock_response.json.return_value = {"message": "success"}
+    mock_response.raise_for_status = Mock()
+    mock_response.headers = {}
+
+    with patch.object(client._client, "request", new_callable=Mock) as mock_request:
+        mock_request.return_value = mock_response
+
+        client.invoke("test-function")
+
+        args, _ = mock_request.call_args
+        assert args[0] == "POST"
+
+
+def test_invoke_with_bytes_body(client: SyncFunctionsClient) -> None:
+    mock_response = Mock(spec=Response)
+    mock_response.json.return_value = {"message": "success"}
+    mock_response.raise_for_status = Mock()
+    mock_response.headers = {}
+
+    with patch.object(client._client, "request", new_callable=Mock) as mock_request:
+        mock_request.return_value = mock_response
+
+        client.invoke("test-function", {"body": b"\x00binary"})
+
+        _, kwargs = mock_request.call_args
+        assert kwargs["headers"]["Content-Type"] == "application/octet-stream"
+        assert kwargs["content"] == b"\x00binary"
+
+
+def test_invoke_string_body_sent_as_content(
+    client: SyncFunctionsClient,
+) -> None:
+    mock_response = Mock(spec=Response)
+    mock_response.json.return_value = {"message": "success"}
+    mock_response.raise_for_status = Mock()
+    mock_response.headers = {}
+
+    with patch.object(client._client, "request", new_callable=Mock) as mock_request:
+        mock_request.return_value = mock_response
+
+        client.invoke("test-function", {"body": "string data"})
+
+        _, kwargs = mock_request.call_args
+        assert kwargs["content"] == "string data"
+
+
+def test_invoke_http_error_with_non_json_body(
+    client: SyncFunctionsClient,
+) -> None:
+    mock_response = Mock(spec=Response)
+    mock_response.json.side_effect = ValueError("not json")
+    mock_response.text = "boom"
+    mock_response.raise_for_status.side_effect = HTTPError("HTTP Error")
+    mock_response.headers = {}
+
+    with patch.object(client._client, "request", new_callable=Mock) as mock_request:
+        mock_request.return_value = mock_response
+
+        with pytest.raises(FunctionsHttpError, match="boom"):
+            client.invoke("test-function")
+
+
+def test_invoke_http_error_with_empty_body(client: SyncFunctionsClient) -> None:
+    error = HTTPError("HTTP Error")
+    error.request = Request("POST", "https://example.com/test-function")
+
+    mock_response = Mock(spec=Response)
+    mock_response.json.side_effect = ValueError("not json")
+    mock_response.text = ""
+    mock_response.raise_for_status.side_effect = error
+    mock_response.headers = {}
+
+    with patch.object(client._client, "request", new_callable=Mock) as mock_request:
+        mock_request.return_value = mock_response
+
+        with pytest.raises(
+            FunctionsHttpError, match="An error occurred while requesting"
+        ):
+            client.invoke("test-function")
+
+
+def test_invoke_relay_error_with_non_json_body(
+    client: SyncFunctionsClient,
+) -> None:
+    mock_response = Mock(spec=Response)
+    mock_response.json.side_effect = ValueError("not json")
+    mock_response.text = "relay exploded"
+    mock_response.raise_for_status = Mock()
+    mock_response.headers = {"x-relay-header": "true"}
+
+    with patch.object(client._client, "request", new_callable=Mock) as mock_request:
+        mock_request.return_value = mock_response
+
+        with pytest.raises(FunctionsRelayError, match="relay exploded"):
+            client.invoke("test-function")

--- a/src/functions/tests/test_errors.py
+++ b/src/functions/tests/test_errors.py
@@ -1,11 +1,13 @@
-from typing import Type
+from typing import Optional, Type
 
 import pytest
+from httpx import Response
 from supabase_functions.errors import (
     FunctionsApiErrorDict,
     FunctionsError,
     FunctionsHttpError,
     FunctionsRelayError,
+    error_message_from,
 )
 
 
@@ -105,3 +107,17 @@ def test_error_message_types() -> None:
         error = FunctionsError(message, "test", 500)
         assert error.message == message
         assert error.to_dict()["message"] == message
+
+
+@pytest.mark.parametrize(
+    "response,expected",
+    [
+        (Response(500, json={"error": "boom"}), "boom"),
+        (Response(500, json={"detail": "boom"}), None),
+        (Response(500, json=["boom"]), '["boom"]'),
+        (Response(500, text="plain boom"), "plain boom"),
+        (Response(500), None),
+    ],
+)
+def test_error_message_from(response: Response, expected: Optional[str]) -> None:
+    assert error_message_from(response) == expected

--- a/src/functions/tests/test_errors.py
+++ b/src/functions/tests/test_errors.py
@@ -7,7 +7,7 @@ from supabase_functions.errors import (
     FunctionsError,
     FunctionsHttpError,
     FunctionsRelayError,
-    error_message_from,
+    _error_message_from,
 )
 
 
@@ -120,4 +120,4 @@ def test_error_message_types() -> None:
     ],
 )
 def test_error_message_from(response: Response, expected: Optional[str]) -> None:
-    assert error_message_from(response) == expected
+    assert _error_message_from(response) == expected


### PR DESCRIPTION
## What

Four fixes to `supabase_functions`, backported from the `v3` branch where they were incidental to the sync/async refactor. All are backward compatible — no existing call site changes behaviour except the bug fix below.

**1. Per-call `invoke` options leaked onto the client (bug).**
`invoke` did `headers = self.headers`, which aliases rather than copies. The subsequent `headers.update(invoke_options["headers"])`, `headers["x-region"]`, and `headers["Content-Type"]` writes all landed on the client's default headers. Every later `invoke()` on the same client carried the previous call's headers, region, and content type.

`_request` now builds the merged dict itself — client defaults first, per-call headers second — so per-call values still take precedence and neither dict is mutated.

**2. Non-JSON error bodies raised the wrong exception.**
Both the HTTP error and relay error paths called `response.json().get("error")`. An edge function returning a plain-text or empty body made that raise `JSONDecodeError`, masking the actual HTTP failure. New `error_message_from` helper in `errors.py` falls back to the response text.

**3. `invoke` accepts a `method`.** Previously hard-coded to POST. `invoke_options["method"]` now works, defaulting to `"POST"`, matching supabase-js's `FunctionInvokeOptions`.

**4. `invoke` accepts a `bytes` body**, sent as `application/octet-stream`. String and bytes bodies now go through httpx's `content=` rather than the deprecated `data=`.

## Why

Found while auditing `v3` for changes that could land on `main` without breaking the public API. `v3` is overwhelmingly a structural refactor (drop `unasync`, unify sync/async through a generator-based `HttpIO`), but these four carried real user-facing value and are independent of that refactor.

Item 1 is the one worth reviewing closely — it silently corrupts a long-lived client, and the corruption grows with each call.

## Test plan

`_sync` is generated, so all source edits are in `_async/functions_client.py` and regenerated via `make -C src/functions build-sync`.

New tests in `tests/_async/test_function_client.py` (mirrored into `_sync`):
- per-call headers, region, and content type do not persist to the next `invoke()`, nor to `client.headers`
- per-call headers override client defaults for the same key
- `method` is honoured for GET/PUT/PATCH/DELETE, and defaults to POST
- bytes body sets `application/octet-stream` and is passed as `content=`
- string body is passed as `content=`
- HTTP error with a non-JSON body surfaces the response text; with an empty body, the generic fallback message
- relay error with a non-JSON body surfaces the response text

New parametrised test in `tests/test_errors.py` covers `error_message_from` across dict-with-error, dict-without-error, non-dict JSON, plain text, and empty body.

Edge cases considered: empty body, non-dict JSON payload, header key collisions between client and per-call, repeated invokes on one client, and `HTTPError` without an attached request.

```
94 passed, 1 skipped
mypy: Success: no issues found in 16 source files
ruff check + format: clean
coverage: supabase_functions 98% (the 2 misses are pre-existing)
```

## Risk

Low. The one behavioural change users could depend on is the header leak itself — code that set a header via `invoke_options` once and relied on it sticking for later calls will now need to pass it to the client constructor or `set_auth`. That reliance was on a bug, and the leak also carried `x-region` and `Content-Type` across calls, which is far more likely to have caused problems than solved them.

## Notes for reviewers

- `make -C src/functions build-sync` uses GNU `sed -i` syntax and fails on macOS (BSD sed). I applied the three post-unasync substitutions manually to get an identical result. Worth fixing separately.
- Not included from `v3`, all breaking: the auth type renames, the postgrest builder rewrite, the storage `StorageApiError` dataclass rewrite, the realtime callback → async-iterator rewrite, and dropping Python 3.9.
- Separately: `base_request_builder.py:102` checks `http_method == "HTTP"` where the docstring says HEAD, so HEAD requests never retry. Present on both `main` and `v3`; out of scope here.
