### PR TITLE
fix(ci): unbreak storage tests (service_role for bucket empty) and stop fail-fast cancelling sibling jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
   test:
     name: py${{ matrix.python-version }} | ${{ matrix.package }} @ ${{ matrix.os }}
     strategy:
+      # Don't let one broken package cancel the other packages' jobs.
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]

--- a/src/storage/tests/tests.env
+++ b/src/storage/tests/tests.env
@@ -1,2 +1,3 @@
-SUPABASE_TEST_KEY="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0"
+# service_role key: storage-api >= v1.70.0 restricts POST /bucket/:id/empty to service_role.
+SUPABASE_TEST_KEY="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU"
 SUPABASE_TEST_URL="http://localhost:55321/storage/v1/"


### PR DESCRIPTION
## Problem

The `storage` CI jobs have failed on `main` since 2026-08-28. Every test in `src/storage/tests/_async/test_client.py` and `_sync/test_client.py` reported `ERROR at teardown of <test_name>`:

```
storage3.exceptions.StorageApiError:
  {'statusCode': 403, 'error': Unauthorized, 'message': Access denied: Invalid role}
  for POST http://localhost:55321/storage/v1/bucket/<id>/empty
```

The tests themselves passed. Only the `bucket` fixture teardown failed.

## Root cause

Not a regression in this repo — nothing changed here. CI installs the **latest** Supabase CLI, which bumped the storage image:

| run | storage-api |
| --- | --- |
| [32135651973](https://github.com/supabase/supabase-py/actions/runs/32135651973) — green, 2026-08-18 | `v1.69.11` |
| [33181358879](https://github.com/supabase/supabase-py/actions/runs/33181358879) — broken, 2026-08-28 | `v1.70.3` |

In storage-api v1.70.0, `POST /bucket/:id/empty` moved out of the normal auth group into a `service_role`-only group ([`src/http/routes/bucket/index.ts`](https://github.com/supabase/storage/blob/v1.70.3/src/http/routes/bucket/index.ts)):

```diff
-    fastify.register(emptyBucket)
+  fastify.register(async function serviceRoleOnly(fastify) {
+    registerJwtAuth(fastify, { enforceJwtRoles: [dbServiceRole] })
+    fastify.register(db)
+    fastify.register(storage)
+
+    fastify.register(emptyBucket)
+  })
```

`enforceJwtRole` returns `403 Access denied: Invalid role` for any other role. `src/storage/tests/tests.env` held an **anon** JWT, so `empty_bucket()` in the teardown of the `bucket` fixture failed.

## Changes

1. **`src/storage/tests/tests.env`** — anon JWT → the demo `service_role` JWT. Same local dev signing secret (`super-secret-jwt-token-with-at-least-32-characters-long`); I verified the signature rather than pasting a key from memory. Added a one-line comment recording why the role matters, so the next person doesn't downgrade it.
2. **`.github/workflows/ci.yml`** — `fail-fast: false` on the package matrix. One failing storage job was cancelling every sibling job, so the `realtime` jobs had not run their tests since 2026-08-18. Two weeks of no realtime coverage, hidden behind a red storage job.

## Verification

Reproduced locally by swapping the storage container to `v1.70.3` (the CLI available locally, 2.115.0, still ships v1.69.11):

| storage-api | anon key | service_role key |
| --- | --- | --- |
| `v1.70.3` | 25 passed, **25 errors** | **97 passed** |
| `v1.69.11` | (was green) | **97 passed** |

The fix works on the new image and stays green on the old one, so a CLI rollback won't re-break it.

## Note for reviewers

The realtime jobs in the failing runs were `cancelled`, not `failed` — their `Run Tests` step never executed ([job 98883067468](https://github.com/supabase/supabase-py/actions/runs/33181358879/job/98883067468) reports `conclusion: cancelled`). `make realtime.tests` passes locally (26 passed), so no realtime regression appears to be hiding behind the cancellations. With `fail-fast: false` in place, CI will confirm that independently from now on.