### PR TITLE
fix(auth): stop putting the raw JWT in UserDoesntExist

### DIFF
--- a/src/auth/src/supabase_auth/_async/gotrue_client.py
+++ b/src/auth/src/supabase_auth/_async/gotrue_client.py
@@ -750,7 +750,7 @@ class AsyncGoTrueClient(AsyncGoTrueBaseAPI):
         else:
             user_response = await self.get_user(access_token)
             if user_response is None:
-                raise UserDoesntExist(access_token)
+                raise UserDoesntExist()
             session = Session(
                 access_token=access_token,
                 refresh_token=refresh_token,
@@ -1025,7 +1025,7 @@ class AsyncGoTrueClient(AsyncGoTrueBaseAPI):
         expires_at = time_now + int(expires_in)
         user = await self.get_user(access_token)
         if user is None:
-            raise UserDoesntExist(access_token)
+            raise UserDoesntExist()
         session = Session(
             provider_token=provider_token,
             provider_refresh_token=provider_refresh_token,

--- a/src/auth/src/supabase_auth/_sync/gotrue_client.py
+++ b/src/auth/src/supabase_auth/_sync/gotrue_client.py
@@ -746,7 +746,7 @@ class SyncGoTrueClient(SyncGoTrueBaseAPI):
         else:
             user_response = self.get_user(access_token)
             if user_response is None:
-                raise UserDoesntExist(access_token)
+                raise UserDoesntExist()
             session = Session(
                 access_token=access_token,
                 refresh_token=refresh_token,
@@ -1019,7 +1019,7 @@ class SyncGoTrueClient(SyncGoTrueBaseAPI):
         expires_at = time_now + int(expires_in)
         user = self.get_user(access_token)
         if user is None:
-            raise UserDoesntExist(access_token)
+            raise UserDoesntExist()
         session = Session(
             provider_token=provider_token,
             provider_refresh_token=provider_refresh_token,

--- a/src/auth/src/supabase_auth/errors.py
+++ b/src/auth/src/supabase_auth/errors.py
@@ -90,11 +90,6 @@ ErrorCode = Literal[
 ]
 
 
-class UserDoesntExist(Exception):
-    def __init__(self, access_token: str) -> None:
-        self.access_token = access_token
-
-
 class AuthError(Exception):
     def __init__(self, message: str, code: ErrorCode | None) -> None:
         Exception.__init__(self, message)
@@ -148,6 +143,17 @@ class CustomAuthError(AuthError):
             "status": self.status,
             "code": self.code,
         }
+
+
+class UserDoesntExist(CustomAuthError):
+    def __init__(self) -> None:
+        CustomAuthError.__init__(
+            self,
+            "User does not exist for the provided access token",
+            "UserDoesntExist",
+            404,
+            "user_not_found",
+        )
 
 
 class AuthSessionMissingError(CustomAuthError):

--- a/src/auth/tests/test_errors.py
+++ b/src/auth/tests/test_errors.py
@@ -1,0 +1,9 @@
+from supabase_auth.errors import AuthError, UserDoesntExist
+
+
+def test_user_doesnt_exist_never_carries_the_token() -> None:
+    error = UserDoesntExist()
+    assert isinstance(error, AuthError)
+    assert str(error) == "User does not exist for the provided access token"
+    assert error.args == ("User does not exist for the provided access token",)
+    assert not hasattr(error, "access_token")


### PR DESCRIPTION
Closes [SDK-1678](https://linear.app/supabase/issue/SDK-1678/auth-userdoesntexist-puts-the-raw-jwt-in-the-exception-message).

## The problem

`UserDoesntExist` stored the access token and never called `Exception.__init__` with a message:

```python
class UserDoesntExist(Exception):
    def __init__(self, access_token: str) -> None:
        self.access_token = access_token
```

`BaseException.__new__` still sets `args = (access_token,)`. So `str(e)` and every traceback line printed the raw user JWT. It reached application logs, error trackers, and any traceback shown to an end user.

It is raised from `set_session` and `_get_session_from_url`, in both the async and sync clients.

Second problem: the class derived from `Exception`, not `AuthError`. So `except AuthError` did not catch it, unlike every other auth error in the module.

## The change

- `UserDoesntExist` now takes no arguments and passes a fixed, non-secret message to `super().__init__`.
- It derives from `CustomAuthError` (status 404, code `user_not_found`), so it joins the documented hierarchy.
- Both call sites updated, in `_async` and the generated `_sync` twin.
- New test in `src/auth/tests/test_errors.py` fails if the token comes back through `args`, `str()`, or an attribute. It needs no docker infra.

## Breaking change

`UserDoesntExist()` takes no arguments, and the `.access_token` attribute is gone. Nothing in this repo read that attribute. Callers who construct the error or read the token must update.

## Note for the reviewer

I did not run `make build-sync` in the commit. The local black/ruff reflows about ten unrelated blocks in the generated `_sync` files, which would bury the real change. I applied the same two-line edit to `_sync/gotrue_client.py` by hand instead. The formatting drift is worth a separate fix.

## Checks

- `pytest src/auth/tests/test_errors.py` passes.
- `mypy` clean on the changed files.
- `ruff check` and `ruff format --check` clean on the changed files.