### PR TITLE
fix(auth): raise AuthInvalidJwtError when get_claims JWT has no exp

### DIFF
--- a/src/auth/src/supabase_auth/_async/gotrue_client.py
+++ b/src/auth/src/supabase_auth/_async/gotrue_client.py
@@ -1272,7 +1272,7 @@ class AsyncGoTrueClient(AsyncGoTrueBaseAPI):
             decoded_jwt["raw"]["payload"],
         )
 
-        validate_exp(payload["exp"])
+        validate_exp(payload.get("exp"))
 
         # if symmetric algorithm, fallback to get_user
         if "kid" not in header or header["alg"] == "HS256":

--- a/src/auth/src/supabase_auth/_sync/gotrue_client.py
+++ b/src/auth/src/supabase_auth/_sync/gotrue_client.py
@@ -1262,7 +1262,7 @@ class SyncGoTrueClient(SyncGoTrueBaseAPI):
             decoded_jwt["raw"]["payload"],
         )
 
-        validate_exp(payload["exp"])
+        validate_exp(payload.get("exp"))
 
         # if symmetric algorithm, fallback to get_user
         if "kid" not in header or header["alg"] == "HS256":

--- a/src/auth/src/supabase_auth/helpers.py
+++ b/src/auth/src/supabase_auth/helpers.py
@@ -283,7 +283,7 @@ def is_http_url(url: str) -> bool:
     return urlparse(url).scheme in {"https", "http"}
 
 
-def validate_exp(exp: int) -> None:
+def validate_exp(exp: Optional[int]) -> None:
     if not exp:
         raise AuthInvalidJwtError("JWT has no expiration time")
 

--- a/src/auth/tests/_async/test_gotrue.py
+++ b/src/auth/tests/_async/test_gotrue.py
@@ -16,6 +16,7 @@ from .clients import (
     auth_client,
     auth_client_with_asymmetric_session,
     auth_client_with_session,
+    mock_access_token,
     mock_user_credentials,
 )
 
@@ -23,6 +24,13 @@ from .clients import (
 async def test_get_claims_returns_none_when_session_is_none() -> None:
     claims = await auth_client().get_claims()
     assert claims is None
+
+
+async def test_get_claims_raises_when_exp_claim_is_missing() -> None:
+    # `mock_access_token()` carries no `exp` claim, so `validate_exp` must
+    # reject it with AuthInvalidJwtError instead of leaking a KeyError.
+    with pytest.raises(AuthInvalidJwtError, match="JWT has no expiration time"):
+        await auth_client().get_claims(mock_access_token())
 
 
 async def test_get_claims_calls_get_user_if_symmetric_jwt(mocker) -> None:

--- a/src/auth/tests/_sync/test_gotrue.py
+++ b/src/auth/tests/_sync/test_gotrue.py
@@ -16,6 +16,7 @@ from .clients import (
     auth_client,
     auth_client_with_asymmetric_session,
     auth_client_with_session,
+    mock_access_token,
     mock_user_credentials,
 )
 
@@ -23,6 +24,13 @@ from .clients import (
 def test_get_claims_returns_none_when_session_is_none() -> None:
     claims = auth_client().get_claims()
     assert claims is None
+
+
+def test_get_claims_raises_when_exp_claim_is_missing() -> None:
+    # `mock_access_token()` carries no `exp` claim, so `validate_exp` must
+    # reject it with AuthInvalidJwtError instead of leaking a KeyError.
+    with pytest.raises(AuthInvalidJwtError, match="JWT has no expiration time"):
+        auth_client().get_claims(mock_access_token())
 
 
 def test_get_claims_calls_get_user_if_symmetric_jwt(mocker) -> None:


### PR DESCRIPTION
Fixes SDK-1680

## What changed

`get_claims` read `payload["exp"]` directly. `JWTPayload` is `total=False`, so a JWT without an `exp` claim leaked a bare `KeyError` instead of the `AuthInvalidJwtError("JWT has no expiration time")` that `validate_exp` (`helpers.py:286`) exists to raise.

- `payload["exp"]` → `payload.get("exp")` in `_async` and generated `_sync` `gotrue_client.py`.
- `validate_exp` signature widened to `Optional[int]` so mypy accepts the missing claim. The function already handled a falsy `exp`.
- Regression test `test_get_claims_raises_when_exp_claim_is_missing` in `_async`/`_sync` `test_gotrue.py`. It fails with `KeyError: 'exp'` before the fix.

## Verification

`make auth.tests` against local infra: **164 passed**. mypy clean, ruff clean.