### PR TITLE
feat(postgrest): add client-level retry toggle (postgrest_client_retry)

### DIFF
--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -445,6 +445,7 @@ features:
 
   database.configuration.auto_retry:
     status: implemented
+    note: "Per request via .retry(); client-wide via the retry_enabled constructor option on AsyncPostgrestClient/SyncPostgrestClient, exposed as ClientOptions.postgrest_client_retry."
     symbols:
       - AsyncSelectRequestBuilder.retry
       - SyncSelectRequestBuilder.retry

--- a/src/postgrest/src/postgrest/_async/client.py
+++ b/src/postgrest/src/postgrest/_async/client.py
@@ -36,6 +36,7 @@ class AsyncPostgrestClient(BasePostgrestClient):
         verify: Optional[bool] = None,
         proxy: Optional[str] = None,
         http_client: Optional[AsyncClient] = None,
+        retry_enabled: bool = True,
     ) -> None:
         headers = {
             "X-Client-Info": (
@@ -93,6 +94,7 @@ class AsyncPostgrestClient(BasePostgrestClient):
             verify=self.verify,
             proxy=proxy,
         )
+        self.retry_enabled = retry_enabled
 
         self.session = http_client or AsyncClient(
             base_url=base_url,
@@ -113,6 +115,7 @@ class AsyncPostgrestClient(BasePostgrestClient):
             timeout=self.timeout,
             verify=self.verify,
             proxy=self.proxy,
+            retry_enabled=self.retry_enabled,
         )
 
     async def __aenter__(self) -> AsyncPostgrestClient:
@@ -134,7 +137,11 @@ class AsyncPostgrestClient(BasePostgrestClient):
             :class:`AsyncRequestBuilder`
         """
         return AsyncRequestBuilder(
-            self.session, self.base_url.joinpath(table), self.headers, self.basic_auth
+            self.session,
+            self.base_url.joinpath(table),
+            self.headers,
+            self.basic_auth,
+            retry_enabled=self.retry_enabled,
         )
 
     def table(self, table: str) -> AsyncRequestBuilder:
@@ -193,5 +200,6 @@ class AsyncPostgrestClient(BasePostgrestClient):
             http_params,
             self.basic_auth,
             json,
+            retry_enabled=self.retry_enabled,
         )
         return AsyncRPCFilterRequestBuilder(request)

--- a/src/postgrest/src/postgrest/_async/request_builder.py
+++ b/src/postgrest/src/postgrest/_async/request_builder.py
@@ -294,12 +294,18 @@ class AsyncSelectRequestBuilder(
 
 class AsyncRequestBuilder:  #
     def __init__(
-        self, session: AsyncClient, path: URL, headers: Headers, auth: BasicAuth | None
+        self,
+        session: AsyncClient,
+        path: URL,
+        headers: Headers,
+        auth: BasicAuth | None,
+        retry_enabled: bool = True,
     ) -> None:
         self.session = session
         self.path = path
         self.headers = headers
         self.auth = auth
+        self.retry_enabled = retry_enabled
 
     def select(
         self,
@@ -325,6 +331,7 @@ class AsyncRequestBuilder:  #
             http_method=method,
             headers=headers,
             json=json,
+            retry_enabled=self.retry_enabled,
         )
         return AsyncSelectRequestBuilder(request)
 
@@ -366,6 +373,7 @@ class AsyncRequestBuilder:  #
             http_method=method,
             headers=headers,
             json=json,
+            retry_enabled=self.retry_enabled,
         )
         return AsyncQueryRequestBuilder(request)
 
@@ -411,6 +419,7 @@ class AsyncRequestBuilder:  #
             http_method=method,
             headers=headers,
             json=json,
+            retry_enabled=self.retry_enabled,
         )
         return AsyncQueryRequestBuilder(request)
 
@@ -444,6 +453,7 @@ class AsyncRequestBuilder:  #
             http_method=method,
             headers=headers,
             json=json,
+            retry_enabled=self.retry_enabled,
         )
         return AsyncFilterRequestBuilder(request)
 
@@ -474,5 +484,6 @@ class AsyncRequestBuilder:  #
             http_method=method,
             headers=headers,
             json=json,
+            retry_enabled=self.retry_enabled,
         )
         return AsyncFilterRequestBuilder(request)

--- a/src/postgrest/src/postgrest/_sync/client.py
+++ b/src/postgrest/src/postgrest/_sync/client.py
@@ -36,6 +36,7 @@ class SyncPostgrestClient(BasePostgrestClient):
         verify: Optional[bool] = None,
         proxy: Optional[str] = None,
         http_client: Optional[Client] = None,
+        retry_enabled: bool = True,
     ) -> None:
         headers = {
             "X-Client-Info": (
@@ -93,6 +94,7 @@ class SyncPostgrestClient(BasePostgrestClient):
             verify=self.verify,
             proxy=proxy,
         )
+        self.retry_enabled = retry_enabled
 
         self.session = http_client or Client(
             base_url=base_url,
@@ -113,6 +115,7 @@ class SyncPostgrestClient(BasePostgrestClient):
             timeout=self.timeout,
             verify=self.verify,
             proxy=self.proxy,
+            retry_enabled=self.retry_enabled,
         )
 
     def __enter__(self) -> SyncPostgrestClient:
@@ -134,7 +137,11 @@ class SyncPostgrestClient(BasePostgrestClient):
             :class:`AsyncRequestBuilder`
         """
         return SyncRequestBuilder(
-            self.session, self.base_url.joinpath(table), self.headers, self.basic_auth
+            self.session,
+            self.base_url.joinpath(table),
+            self.headers,
+            self.basic_auth,
+            retry_enabled=self.retry_enabled,
         )
 
     def table(self, table: str) -> SyncRequestBuilder:
@@ -193,5 +200,6 @@ class SyncPostgrestClient(BasePostgrestClient):
             http_params,
             self.basic_auth,
             json,
+            retry_enabled=self.retry_enabled,
         )
         return SyncRPCFilterRequestBuilder(request)

--- a/src/postgrest/src/postgrest/_sync/request_builder.py
+++ b/src/postgrest/src/postgrest/_sync/request_builder.py
@@ -294,12 +294,18 @@ class SyncSelectRequestBuilder(
 
 class SyncRequestBuilder:  #
     def __init__(
-        self, session: Client, path: URL, headers: Headers, auth: BasicAuth | None
+        self,
+        session: Client,
+        path: URL,
+        headers: Headers,
+        auth: BasicAuth | None,
+        retry_enabled: bool = True,
     ) -> None:
         self.session = session
         self.path = path
         self.headers = headers
         self.auth = auth
+        self.retry_enabled = retry_enabled
 
     def select(
         self,
@@ -325,6 +331,7 @@ class SyncRequestBuilder:  #
             http_method=method,
             headers=headers,
             json=json,
+            retry_enabled=self.retry_enabled,
         )
         return SyncSelectRequestBuilder(request)
 
@@ -366,6 +373,7 @@ class SyncRequestBuilder:  #
             http_method=method,
             headers=headers,
             json=json,
+            retry_enabled=self.retry_enabled,
         )
         return SyncQueryRequestBuilder(request)
 
@@ -411,6 +419,7 @@ class SyncRequestBuilder:  #
             http_method=method,
             headers=headers,
             json=json,
+            retry_enabled=self.retry_enabled,
         )
         return SyncQueryRequestBuilder(request)
 
@@ -444,6 +453,7 @@ class SyncRequestBuilder:  #
             http_method=method,
             headers=headers,
             json=json,
+            retry_enabled=self.retry_enabled,
         )
         return SyncFilterRequestBuilder(request)
 
@@ -474,5 +484,6 @@ class SyncRequestBuilder:  #
             http_method=method,
             headers=headers,
             json=json,
+            retry_enabled=self.retry_enabled,
         )
         return SyncFilterRequestBuilder(request)

--- a/src/postgrest/tests/_async/test_client.py
+++ b/src/postgrest/tests/_async/test_client.py
@@ -1,5 +1,5 @@
 import re
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from httpx import (
@@ -14,6 +14,7 @@ from httpx import (
 )
 
 from postgrest import AsyncPostgrestClient
+from postgrest.base_request_builder import MAX_RETRIES
 from postgrest.exceptions import APIError
 
 
@@ -176,3 +177,81 @@ async def test_response_client_invalid_response_but_valid_json(
         assert isinstance(exc_response.get("message"), str)
         assert exc_response.get("message") == "JSON could not be generated"
         assert "code" in exc_response and int(exc_response["code"]) == 502
+
+
+class TestRetryEnabled:
+    def test_default_enabled(self, postgrest_client: AsyncPostgrestClient):
+        assert postgrest_client.retry_enabled is True
+        assert postgrest_client.from_("test").select("*").request.retry_enabled is True
+
+    async def test_client_level_disable_propagates(self):
+        async with AsyncPostgrestClient(
+            "https://example.com", retry_enabled=False
+        ) as client:
+            assert client.from_("test").select("*").request.retry_enabled is False
+            assert client.rpc("test_fn", {}).request.retry_enabled is False
+            assert client.schema("other").retry_enabled is False
+
+    async def test_request_level_override(self):
+        async with AsyncPostgrestClient(
+            "https://example.com", retry_enabled=False
+        ) as client:
+            builder = client.from_("test").select("*").retry(True)
+            assert builder.request.retry_enabled is True
+
+    async def test_client_level_disable_does_not_retry_on_503(self):
+        calls = 0
+
+        async def fake_send(request: Request, **kwargs):
+            nonlocal calls
+            calls += 1
+            return Response(503)
+
+        async with AsyncPostgrestClient(
+            "https://example.com", retry_enabled=False
+        ) as client:
+            with patch.object(client.session, "send", wraps=fake_send):
+                with pytest.raises(APIError):
+                    await client.from_("test").select("*").execute()
+
+        assert calls == 1
+
+    async def test_client_level_disable_request_override_retries(self):
+        calls = 0
+
+        async def fake_send(request: Request, **kwargs):
+            nonlocal calls
+            if calls > 0:
+                assert request.headers["X-Retry-Count"] == str(calls)
+            calls += 1
+            return Response(503)
+
+        async with AsyncPostgrestClient(
+            "https://example.com", retry_enabled=False
+        ) as client:
+            with (
+                patch.object(client.session, "send", wraps=fake_send),
+                patch("asyncio.sleep", new=AsyncMock()),
+            ):
+                with pytest.raises(APIError):
+                    await client.from_("test").select("*").retry(True).execute()
+
+        assert calls == 1 + MAX_RETRIES
+
+    async def test_default_retries_on_503(self):
+        calls = 0
+
+        async def fake_send(request: Request, **kwargs):
+            nonlocal calls
+            calls += 1
+            return Response(503)
+
+        async with AsyncPostgrestClient("https://example.com") as client:
+            with (
+                patch.object(client.session, "send", wraps=fake_send),
+                patch("asyncio.sleep", new=AsyncMock()),
+            ):
+                with pytest.raises(APIError):
+                    await client.from_("test").select("*").execute()
+
+        assert calls == 1 + MAX_RETRIES

--- a/src/postgrest/tests/_sync/test_client.py
+++ b/src/postgrest/tests/_sync/test_client.py
@@ -1,5 +1,5 @@
 import re
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 from httpx import (
@@ -14,6 +14,7 @@ from httpx import (
 )
 
 from postgrest import SyncPostgrestClient
+from postgrest.base_request_builder import MAX_RETRIES
 from postgrest.exceptions import APIError
 
 
@@ -174,3 +175,73 @@ def test_response_client_invalid_response_but_valid_json(
         assert isinstance(exc_response.get("message"), str)
         assert exc_response.get("message") == "JSON could not be generated"
         assert "code" in exc_response and int(exc_response["code"]) == 502
+
+
+class TestRetryEnabled:
+    def test_default_enabled(self, postgrest_client: SyncPostgrestClient):
+        assert postgrest_client.retry_enabled is True
+        assert postgrest_client.from_("test").select("*").request.retry_enabled is True
+
+    def test_client_level_disable_propagates(self):
+        with SyncPostgrestClient("https://example.com", retry_enabled=False) as client:
+            assert client.from_("test").select("*").request.retry_enabled is False
+            assert client.rpc("test_fn", {}).request.retry_enabled is False
+            assert client.schema("other").retry_enabled is False
+
+    def test_request_level_override(self):
+        with SyncPostgrestClient("https://example.com", retry_enabled=False) as client:
+            builder = client.from_("test").select("*").retry(True)
+            assert builder.request.retry_enabled is True
+
+    def test_client_level_disable_does_not_retry_on_503(self):
+        calls = 0
+
+        def fake_send(request: Request, **kwargs):
+            nonlocal calls
+            calls += 1
+            return Response(503)
+
+        with SyncPostgrestClient("https://example.com", retry_enabled=False) as client:
+            with patch.object(client.session, "send", wraps=fake_send):
+                with pytest.raises(APIError):
+                    client.from_("test").select("*").execute()
+
+        assert calls == 1
+
+    def test_client_level_disable_request_override_retries(self):
+        calls = 0
+
+        def fake_send(request: Request, **kwargs):
+            nonlocal calls
+            if calls > 0:
+                assert request.headers["X-Retry-Count"] == str(calls)
+            calls += 1
+            return Response(503)
+
+        with SyncPostgrestClient("https://example.com", retry_enabled=False) as client:
+            with (
+                patch.object(client.session, "send", wraps=fake_send),
+                patch("time.sleep", new=Mock()),
+            ):
+                with pytest.raises(APIError):
+                    client.from_("test").select("*").retry(True).execute()
+
+        assert calls == 1 + MAX_RETRIES
+
+    def test_default_retries_on_503(self):
+        calls = 0
+
+        def fake_send(request: Request, **kwargs):
+            nonlocal calls
+            calls += 1
+            return Response(503)
+
+        with SyncPostgrestClient("https://example.com") as client:
+            with (
+                patch.object(client.session, "send", wraps=fake_send),
+                patch("time.sleep", new=Mock()),
+            ):
+                with pytest.raises(APIError):
+                    client.from_("test").select("*").execute()
+
+        assert calls == 1 + MAX_RETRIES

--- a/src/supabase/src/supabase/_async/client.py
+++ b/src/supabase/src/supabase/_async/client.py
@@ -187,6 +187,7 @@ class AsyncClient:
                 headers=self.options.headers,
                 schema=self.options.schema,
                 timeout=self.options.postgrest_client_timeout,
+                retry_enabled=self.options.postgrest_client_retry,
                 http_client=self.options.httpx_client,
             )
 
@@ -300,12 +301,17 @@ class AsyncClient:
         verify: bool = True,
         proxy: Optional[str] = None,
         http_client: Union[AsyncHttpxClient, None] = None,
+        retry_enabled: bool = True,
     ) -> AsyncPostgrestClient:
         """Private helper for creating an instance of the Postgrest client."""
         if http_client is not None:
             # If an http client is provided, use it
             return AsyncPostgrestClient(
-                rest_url, headers=headers, schema=schema, http_client=http_client
+                rest_url,
+                headers=headers,
+                schema=schema,
+                http_client=http_client,
+                retry_enabled=retry_enabled,
             )
         return AsyncPostgrestClient(
             rest_url,
@@ -315,6 +321,7 @@ class AsyncClient:
             verify=verify,
             proxy=proxy,
             http_client=None,
+            retry_enabled=retry_enabled,
         )
 
     def _create_auth_header(self, token: str) -> str:

--- a/src/supabase/src/supabase/_sync/client.py
+++ b/src/supabase/src/supabase/_sync/client.py
@@ -186,6 +186,7 @@ class Client:
                 headers=self.options.headers,
                 schema=self.options.schema,
                 timeout=self.options.postgrest_client_timeout,
+                retry_enabled=self.options.postgrest_client_retry,
                 http_client=self.options.httpx_client,
             )
 
@@ -299,12 +300,17 @@ class Client:
         verify: bool = True,
         proxy: Optional[str] = None,
         http_client: Union[SyncHttpxClient, None] = None,
+        retry_enabled: bool = True,
     ) -> SyncPostgrestClient:
         """Private helper for creating an instance of the Postgrest client."""
         if http_client is not None:
             # If an http client is provided, use it
             return SyncPostgrestClient(
-                rest_url, headers=headers, schema=schema, http_client=http_client
+                rest_url,
+                headers=headers,
+                schema=schema,
+                http_client=http_client,
+                retry_enabled=retry_enabled,
             )
         return SyncPostgrestClient(
             rest_url,
@@ -314,6 +320,7 @@ class Client:
             verify=verify,
             proxy=proxy,
             http_client=None,
+            retry_enabled=retry_enabled,
         )
 
     def _create_auth_header(self, token: str) -> str:

--- a/src/supabase/src/supabase/lib/client_options.py
+++ b/src/supabase/src/supabase/lib/client_options.py
@@ -56,6 +56,9 @@ class ClientOptions:
     )
     """Timeout passed to the SyncPostgrestClient instance."""
 
+    postgrest_client_retry: bool = True
+    """Automatically retry transient PostgREST errors. Passed to the SyncPostgrestClient instance."""
+
     storage_client_timeout: int = DEFAULT_STORAGE_CLIENT_TIMEOUT
     """Timeout passed to the SyncStorageClient instance"""
 

--- a/src/supabase/tests/_async/test_client.py
+++ b/src/supabase/tests/_async/test_client.py
@@ -44,6 +44,19 @@ async def test_postgrest_client() -> None:
     assert client.postgrest.schema("new_schema")
 
 
+async def test_postgrest_client_retry_option() -> None:
+    url = os.environ["SUPABASE_TEST_URL"]
+    key = os.environ["SUPABASE_TEST_KEY"]
+
+    client = await create_async_client(url, key)
+    assert client.postgrest.retry_enabled is True
+
+    options = AsyncClientOptions(postgrest_client_retry=False)
+    client = await create_async_client(url, key, options)
+    assert client.postgrest.retry_enabled is False
+    assert client.table("sample").select("*").request.retry_enabled is False
+
+
 async def test_rpc_client() -> None:
     url = os.environ["SUPABASE_TEST_URL"]
     key = os.environ["SUPABASE_TEST_KEY"]

--- a/src/supabase/tests/_sync/test_client.py
+++ b/src/supabase/tests/_sync/test_client.py
@@ -44,6 +44,19 @@ def test_postgrest_client() -> None:
     assert client.postgrest.schema("new_schema")
 
 
+def test_postgrest_client_retry_option() -> None:
+    url = os.environ["SUPABASE_TEST_URL"]
+    key = os.environ["SUPABASE_TEST_KEY"]
+
+    client = create_client(url, key)
+    assert client.postgrest.retry_enabled is True
+
+    options = ClientOptions(postgrest_client_retry=False)
+    client = create_client(url, key, options)
+    assert client.postgrest.retry_enabled is False
+    assert client.table("sample").select("*").request.retry_enabled is False
+
+
 def test_rpc_client() -> None:
     url = os.environ["SUPABASE_TEST_URL"]
     key = os.environ["SUPABASE_TEST_KEY"]


### PR DESCRIPTION
Closes #1561.

Adds `postgrest_client_retry` (default `True`) to `ClientOptions`, mirroring `postgrest_client_timeout`, and forwards it to the PostgREST client as a new `retry_enabled` constructor option. The flag propagates through `schema()`, `from_()`/`table()` and `rpc()` into every request builder, so `postgrest_client_retry=False` disables the automatic retry of transient PostgREST errors for the whole client. The existing per-request `.retry()` override still takes precedence.

No behavior change by default. `_sync` mirrors `_async`. `sdk-compliance.yaml` gets a note on `database.configuration.auto_retry` for the client-wide option.

Review guide: the logic lives in four files (`postgrest/_async/client.py`, `postgrest/_async/request_builder.py`, `supabase/_async/client.py`, `supabase/lib/client_options.py`); the `_sync` files are line-for-line mirrors, and the rest of the diff is tests.

Tests (`TestRetryEnabled`, async and sync): the flag propagates through `from_`/`rpc`/`schema`; and, with `session.send` patched to always answer 503, a client created with `retry_enabled=False` sends exactly one request, a per-request `.retry(True)` on that client sends `1 + MAX_RETRIES`, and the default client also sends `1 + MAX_RETRIES`. `test_postgrest_client_retry_option` covers the `ClientOptions` path in supabase. Locally: postgrest 210 passed (integration excluded), supabase 32 passed, mypy clean for both packages, ruff clean.
