### PR TITLE
fix(storage): use exc.response.text instead of resp.text in error handler

### DIFF
--- a/src/storage/src/storage3/_async/file_api.py
+++ b/src/storage/src/storage3/_async/file_api.py
@@ -84,7 +84,7 @@ class AsyncBucketActionsMixin:
                     resp["message"], resp["error"], resp["statusCode"]
                 ) from exc
             except KeyError as err:
-                message = f"Unable to parse error message: {resp.text}"
+                message = f"Unable to parse error message: {exc.response.text}"
                 raise StorageApiError(message, "InternalError", 400) from err
 
         # close the resource before returning the response
@@ -620,3 +620,4 @@ class AsyncBucketProxy(AsyncBucketActionsMixin):
     _base_url: URL
     _headers: Headers
     _client: AsyncClient = field(repr=False)
+

--- a/src/storage/src/storage3/_sync/file_api.py
+++ b/src/storage/src/storage3/_sync/file_api.py
@@ -84,7 +84,7 @@ class SyncBucketActionsMixin:
                     resp["message"], resp["error"], resp["statusCode"]
                 ) from exc
             except KeyError as err:
-                message = f"Unable to parse error message: {resp.text}"
+                message = f"Unable to parse error message: {exc.response.text}"
                 raise StorageApiError(message, "InternalError", 400) from err
 
         # close the resource before returning the response
@@ -618,3 +618,4 @@ class SyncBucketProxy(SyncBucketActionsMixin):
     _base_url: URL
     _headers: Headers
     _client: Client = field(repr=False)
+


### PR DESCRIPTION
Fixes AttributeError in storage error handler: use exc.response.text instead of resp.text. Fixes #1563.