### PR TITLE
fix(storage3): parse the real API error wire format

### DIFF
--- a/src/storage/src/storage3/exceptions.py
+++ b/src/storage/src/storage3/exceptions.py
@@ -14,11 +14,17 @@ class VectorBucketException(StorageException):
         self.msg = msg
 
 
-class VectorBucketErrorMessage(BaseModel):
+class StorageApiErrorMessage(BaseModel):
+    """Wire format of a storage API error body."""
+
     statusCode: str | int
     error: str
     message: str
     code: str | None = None
+
+
+# Kept as an alias: the vector endpoints return the same error body.
+VectorBucketErrorMessage = StorageApiErrorMessage
 
 
 @dataclass
@@ -34,15 +40,24 @@ class StorageApiError(StorageException):
         return f"StorageApiError(message='{self.message}', code={self.code}, status='{self.status}')"
 
 
-StorageApiErrorParser = TypeAdapter(StorageApiError)
+StorageApiErrorParser = TypeAdapter(StorageApiErrorMessage)
 
 
 def parse_api_error(response: Response) -> StorageApiError:
     try:
-        return StorageApiErrorParser.validate_json(response.content)
+        parsed = StorageApiErrorParser.validate_json(response.content)
     except ValidationError:
-        message = f"Unable to parse error message: {response.content.decode('utf-8')}"
-        return StorageApiError(message=message, code="InternalError", status=400)
+        body = response.content.decode("utf-8", errors="replace")
+        return StorageApiError(
+            message=f"Unable to parse error message: {body}",
+            code="InternalError",
+            status=response.status,
+        )
+    return StorageApiError(
+        message=parsed.message,
+        code=parsed.code or parsed.error,
+        status=parsed.statusCode,
+    )
 
 
 Inner = TypeVar("Inner")

--- a/src/storage/tests/_async/test_client.py
+++ b/src/storage/tests/_async/test_client.py
@@ -571,8 +571,13 @@ async def test_client_info_with_error(
         storage_file_client_public.executor.session, "send", new_callable=AsyncMock
     ) as mock_request:
         mock_request.return_value = mock_error_response
-        with pytest.raises(StorageApiError):
+        with pytest.raises(StorageApiError) as exc_info:
             await storage_file_client_public.info(file.bucket_path)
+
+    err = exc_info.value
+    assert err.message == "File not found"
+    assert err.code == "Custom error message"
+    assert err.status == 404
 
 
 async def test_client_exists(

--- a/src/storage/tests/_sync/test_client.py
+++ b/src/storage/tests/_sync/test_client.py
@@ -566,8 +566,13 @@ def test_client_info_with_error(
     ) as mock_request:
         mock_request.return_value = mock_error_response
 
-        with pytest.raises(StorageApiError):
+        with pytest.raises(StorageApiError) as exc_info:
             storage_file_client_public.info(file.bucket_path)
+
+    err = exc_info.value
+    assert err.message == "File not found"
+    assert err.code == "Custom error message"
+    assert err.status == 404
 
 
 def test_client_exists(

--- a/src/storage/tests/test_exceptions.py
+++ b/src/storage/tests/test_exceptions.py
@@ -1,0 +1,64 @@
+import pytest
+from supabase_utils.http.headers import Headers
+from supabase_utils.http.request import Request, Response
+from yarl import URL
+
+from storage3.exceptions import StorageApiError, parse_api_error
+
+
+def _response(content: bytes, status: int = 502) -> Response:
+    return Response(
+        headers=Headers.empty(),
+        content=content,
+        status=status,
+        request=Request(
+            url=URL("https://example.com"),
+            method="GET",
+            headers=Headers.empty(),
+            content=None,
+            delay=None,
+        ),
+    )
+
+
+def test_parse_api_error_reads_wire_format() -> None:
+    """The API sends statusCode/error/message, not status/code/message."""
+    err = parse_api_error(
+        _response(
+            b'{"statusCode":"404","error":"not_found","message":"Object not found"}',
+            status=400,
+        )
+    )
+    assert err.message == "Object not found"
+    assert err.code == "not_found"
+    assert err.status == "404"
+
+
+def test_parse_api_error_prefers_explicit_code() -> None:
+    err = parse_api_error(
+        _response(
+            b'{"statusCode":413,"error":"Payload too large","message":"nope","code":"PayloadTooLarge"}'
+        )
+    )
+    assert err.code == "PayloadTooLarge"
+    assert err.status == 413
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        b'{"code":"PayloadTooLarge"}',
+        b"<html>502 Bad Gateway</html>",
+        b"[]",
+        b"null",
+        b'"Service Unavailable"',
+        b"",
+        b"\xff\xfe not utf-8",
+    ],
+)
+def test_parse_api_error_falls_back_with_real_status(body: bytes) -> None:
+    """Unparsable bodies must not crash, and must keep the response status."""
+    err = parse_api_error(_response(body, status=502))
+    assert isinstance(err, StorageApiError)
+    assert err.code == "InternalError"
+    assert err.status == 502


### PR DESCRIPTION
Follow-up to #1577. Neither fix from that PR is needed on `v3` — pydantic's `ValidationError` already covers every malformed body shape, and `exists()` already branches on status rather than on an exception type. But verifying that surfaced a separate bug in the same code.

### The bug

`parse_api_error` validated the response body against `StorageApiError` itself, whose fields are `message` / `code` / `status`. The API sends `statusCode` / `error` / `message`. No aliases are configured, so validation always failed and **every** API error fell into the fallback:

| body | before | after |
|---|---|---|
| `{"statusCode":"404","error":"not_found","message":"Object not found"}` | `code='InternalError' status=400` | `code='not_found' status='404'` |
| `<html>502 Bad Gateway</html>` | `code='InternalError' status=400` | `code='InternalError' status=502` |

A 404 was indistinguishable from a 500, and the real message was buried in `Unable to parse error message: {raw json}`. This affects all 9 `parse_api_error` call sites across `file_api.py` and `vectors.py`.

Two things suggest an oversight rather than a deliberate shape change:

- `VectorBucketErrorMessage` sat in the same file describing the correct wire shape, imported nowhere.
- The two existing error tests only assert `pytest.raises(StorageApiError)`, never `.code` or `.status` — so the suite could not see it. Their mock body is already in the correct wire format.

### Changes

- Parse into `StorageApiErrorMessage` (the renamed, previously-dead model), then build `StorageApiError` from it. `VectorBucketErrorMessage` is kept as an alias — the vector endpoints return the same body.
- Fallback reports `response.status` instead of a hardcoded `400`.
- Fallback decodes with `errors="replace"`, so a non-utf-8 body cannot raise from the error path itself.
- New `tests/test_exceptions.py`: 9 unit tests, no infra needed. All 9 fail on the current `v3` code and pass with this change.
- Tightened the two existing `test_client_info_with_error` tests to assert `.message`, `.code` and `.status`.

### Verification

`ruff check`, `ruff format` and `mypy` clean; the 9 new unit tests pass. Docker is not available in my environment, so the integration suite was not run locally — CI covers it.