### PR TITLE
fix(storage): close the upload handle we opened, and only that one

### DIFF
--- a/src/storage/src/storage3/_async/file_api.py
+++ b/src/storage/src/storage3/_async/file_api.py
@@ -89,10 +89,6 @@ class AsyncBucketActionsMixin:
                     message, "InternalError", exc.response.status_code
                 ) from err
 
-        # close the resource before returning the response
-        if files and "file" in files and isinstance(files["file"][1], BufferedReader):
-            files["file"][1].close()
-
         return response
 
     async def create_signed_upload_url(
@@ -185,25 +181,27 @@ class AsyncBucketActionsMixin:
             or isinstance(file, bytes)
             or isinstance(file, FileIO)
         ):
-            # bytes or byte-stream-like object received
+            # bytes or byte-stream-like object received -- the caller owns it
+            opened = None
             _file = {"file": (filename, file, content_type)}
         else:
-            # str or pathlib.path received
-            _file = {
-                "file": (
-                    filename,
-                    open(file, "rb"),
-                    content_type,
-                )
-            }
-        response = await self._request(
-            "PUT",
-            final_url,
-            files=_file,
-            headers=headers,
-            data=_data,
-            query_params=query_params,
-        )
+            # str or pathlib.path received -- we own the handle, so we close it
+            opened = open(file, "rb")
+            _file = {"file": (filename, opened, content_type)}
+
+        try:
+            response = await self._request(
+                "PUT",
+                final_url,
+                files=_file,
+                headers=headers,
+                data=_data,
+                query_params=query_params,
+            )
+        finally:
+            if opened is not None:
+                opened.close()
+
         data: UploadData = response.json()
 
         return UploadResponse(path=path, Key=data["Key"])
@@ -562,21 +560,25 @@ class AsyncBucketActionsMixin:
             or isinstance(file, bytes)
             or isinstance(file, FileIO)
         ):
-            # bytes or byte-stream-like object received
+            # bytes or byte-stream-like object received -- the caller owns it
+            opened = None
             files = {"file": (filename, file, content_type)}
         else:
-            # str or pathlib.path received
-            files = {
-                "file": (
-                    filename,
-                    open(file, "rb"),
-                    content_type,
-                )
-            }
+            # str or pathlib.path received -- we own the handle, so we close it
+            opened = open(file, "rb")
+            files = {"file": (filename, opened, content_type)}
 
-        response = await self._request(
-            method, ["object", self.id, *path], files=files, headers=headers, data=_data
-        )
+        try:
+            response = await self._request(
+                method,
+                ["object", self.id, *path],
+                files=files,
+                headers=headers,
+                data=_data,
+            )
+        finally:
+            if opened is not None:
+                opened.close()
 
         data: UploadData = response.json()
 

--- a/src/storage/src/storage3/_sync/file_api.py
+++ b/src/storage/src/storage3/_sync/file_api.py
@@ -89,10 +89,6 @@ class SyncBucketActionsMixin:
                     message, "InternalError", exc.response.status_code
                 ) from err
 
-        # close the resource before returning the response
-        if files and "file" in files and isinstance(files["file"][1], BufferedReader):
-            files["file"][1].close()
-
         return response
 
     def create_signed_upload_url(
@@ -185,25 +181,27 @@ class SyncBucketActionsMixin:
             or isinstance(file, bytes)
             or isinstance(file, FileIO)
         ):
-            # bytes or byte-stream-like object received
+            # bytes or byte-stream-like object received -- the caller owns it
+            opened = None
             _file = {"file": (filename, file, content_type)}
         else:
-            # str or pathlib.path received
-            _file = {
-                "file": (
-                    filename,
-                    open(file, "rb"),
-                    content_type,
-                )
-            }
-        response = self._request(
-            "PUT",
-            final_url,
-            files=_file,
-            headers=headers,
-            data=_data,
-            query_params=query_params,
-        )
+            # str or pathlib.path received -- we own the handle, so we close it
+            opened = open(file, "rb")
+            _file = {"file": (filename, opened, content_type)}
+
+        try:
+            response = self._request(
+                "PUT",
+                final_url,
+                files=_file,
+                headers=headers,
+                data=_data,
+                query_params=query_params,
+            )
+        finally:
+            if opened is not None:
+                opened.close()
+
         data: UploadData = response.json()
 
         return UploadResponse(path=path, Key=data["Key"])
@@ -560,21 +558,25 @@ class SyncBucketActionsMixin:
             or isinstance(file, bytes)
             or isinstance(file, FileIO)
         ):
-            # bytes or byte-stream-like object received
+            # bytes or byte-stream-like object received -- the caller owns it
+            opened = None
             files = {"file": (filename, file, content_type)}
         else:
-            # str or pathlib.path received
-            files = {
-                "file": (
-                    filename,
-                    open(file, "rb"),
-                    content_type,
-                )
-            }
+            # str or pathlib.path received -- we own the handle, so we close it
+            opened = open(file, "rb")
+            files = {"file": (filename, opened, content_type)}
 
-        response = self._request(
-            method, ["object", self.id, *path], files=files, headers=headers, data=_data
-        )
+        try:
+            response = self._request(
+                method,
+                ["object", self.id, *path],
+                files=files,
+                headers=headers,
+                data=_data,
+            )
+        finally:
+            if opened is not None:
+                opened.close()
 
         data: UploadData = response.json()
 

--- a/src/storage/tests/_async/test_file_api.py
+++ b/src/storage/tests/_async/test_file_api.py
@@ -1,0 +1,95 @@
+from pathlib import Path
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+from httpx import Headers, HTTPStatusError, Request, Response
+from storage3.exceptions import StorageApiError
+from yarl import URL
+
+from .. import AsyncBucketProxy
+
+
+def _error_response() -> Mock:
+    response = Mock(spec=Response)
+    response.status_code = 409
+    response.json.return_value = {
+        "message": "The resource already exists",
+        "error": "Duplicate",
+        "statusCode": 409,
+    }
+    response.raise_for_status = Mock(
+        side_effect=HTTPStatusError(
+            "Conflict", request=Mock(spec=Request), response=response
+        )
+    )
+    return response
+
+
+def _success_response() -> Mock:
+    response = Mock(spec=Response)
+    response.status_code = 200
+    response.json.return_value = {"Key": "bucket/upload.txt"}
+    response.raise_for_status = Mock()
+    return response
+
+
+def _proxy(response: Mock, captured: dict) -> AsyncBucketProxy:
+    """A proxy whose transport records the `files` mapping storage3 built for the request."""
+
+    async def request(*args: Any, **kwargs: Any) -> Mock:
+        captured["files"] = kwargs["files"]
+        return response
+
+    client = Mock(headers=Headers())
+    client.request = request
+    return AsyncBucketProxy("bucket", URL("http://example.com"), Headers(), client)
+
+
+@pytest.fixture
+def source(tmp_path: Path) -> str:
+    path = tmp_path / "upload.txt"
+    path.write_bytes(b"payload")
+    return str(path)
+
+
+async def test_upload_closes_file_handle_on_error(source: str) -> None:
+    """A handle storage3 opened itself must be closed when the upload fails."""
+    captured: dict = {}
+
+    with pytest.raises(StorageApiError):
+        await _proxy(_error_response(), captured).upload("upload.txt", source)
+
+    assert captured["files"]["file"][1].closed
+
+
+async def test_upload_closes_file_handle_on_success(source: str) -> None:
+    """Regression: the success path must keep closing the handle it opened."""
+    captured: dict = {}
+
+    await _proxy(_success_response(), captured).upload("upload.txt", source)
+
+    assert captured["files"]["file"][1].closed
+
+
+async def test_update_closes_file_handle_on_error(source: str) -> None:
+    """update() shares _upload_or_update, so it leaks the same way."""
+    captured: dict = {}
+
+    with pytest.raises(StorageApiError):
+        await _proxy(_error_response(), captured).update("upload.txt", source)
+
+    assert captured["files"]["file"][1].closed
+
+
+async def test_caller_supplied_handle_is_left_open(source: str) -> None:
+    """storage3 must not close a stream the caller owns, on either path."""
+    captured: dict = {}
+
+    with open(source, "rb") as handle:
+        with pytest.raises(StorageApiError):
+            await _proxy(_error_response(), captured).upload("upload.txt", handle)
+        assert not handle.closed
+
+        await _proxy(_success_response(), captured).upload("upload.txt", handle)
+        assert not handle.closed

--- a/src/storage/tests/_sync/test_file_api.py
+++ b/src/storage/tests/_sync/test_file_api.py
@@ -1,0 +1,95 @@
+from pathlib import Path
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+from httpx import Headers, HTTPStatusError, Request, Response
+from storage3.exceptions import StorageApiError
+from yarl import URL
+
+from .. import SyncBucketProxy
+
+
+def _error_response() -> Mock:
+    response = Mock(spec=Response)
+    response.status_code = 409
+    response.json.return_value = {
+        "message": "The resource already exists",
+        "error": "Duplicate",
+        "statusCode": 409,
+    }
+    response.raise_for_status = Mock(
+        side_effect=HTTPStatusError(
+            "Conflict", request=Mock(spec=Request), response=response
+        )
+    )
+    return response
+
+
+def _success_response() -> Mock:
+    response = Mock(spec=Response)
+    response.status_code = 200
+    response.json.return_value = {"Key": "bucket/upload.txt"}
+    response.raise_for_status = Mock()
+    return response
+
+
+def _proxy(response: Mock, captured: dict) -> SyncBucketProxy:
+    """A proxy whose transport records the `files` mapping storage3 built for the request."""
+
+    def request(*args: Any, **kwargs: Any) -> Mock:
+        captured["files"] = kwargs["files"]
+        return response
+
+    client = Mock(headers=Headers())
+    client.request = request
+    return SyncBucketProxy("bucket", URL("http://example.com"), Headers(), client)
+
+
+@pytest.fixture
+def source(tmp_path: Path) -> str:
+    path = tmp_path / "upload.txt"
+    path.write_bytes(b"payload")
+    return str(path)
+
+
+def test_upload_closes_file_handle_on_error(source: str) -> None:
+    """A handle storage3 opened itself must be closed when the upload fails."""
+    captured: dict = {}
+
+    with pytest.raises(StorageApiError):
+        _proxy(_error_response(), captured).upload("upload.txt", source)
+
+    assert captured["files"]["file"][1].closed
+
+
+def test_upload_closes_file_handle_on_success(source: str) -> None:
+    """Regression: the success path must keep closing the handle it opened."""
+    captured: dict = {}
+
+    _proxy(_success_response(), captured).upload("upload.txt", source)
+
+    assert captured["files"]["file"][1].closed
+
+
+def test_update_closes_file_handle_on_error(source: str) -> None:
+    """update() shares _upload_or_update, so it leaks the same way."""
+    captured: dict = {}
+
+    with pytest.raises(StorageApiError):
+        _proxy(_error_response(), captured).update("upload.txt", source)
+
+    assert captured["files"]["file"][1].closed
+
+
+def test_caller_supplied_handle_is_left_open(source: str) -> None:
+    """storage3 must not close a stream the caller owns, on either path."""
+    captured: dict = {}
+
+    with open(source, "rb") as handle:
+        with pytest.raises(StorageApiError):
+            _proxy(_error_response(), captured).upload("upload.txt", handle)
+        assert not handle.closed
+
+        _proxy(_success_response(), captured).upload("upload.txt", handle)
+        assert not handle.closed


### PR DESCRIPTION
Supersedes #1586 and the closed #1575.

## The leak

`_request` closed the uploaded file handle *after* the `except HTTPStatusError` block, so the close only ran on success. Any non-2xx raised `StorageApiError` straight past it and the handle stayed open. The handle only ever existed inside the local `files` mapping, so the caller had no way to close it either — Python reports it as `ResourceWarning: unclosed file`. Both `upload()` / `update()` (via `_upload_or_update`) and `upload_to_signed_url()` are affected.

Credit for the diagnosis goes to @tushardev-365 in #1575, including the fd-count reproduction and the note that a retained traceback keeps the frame holding the reader alive.

## Why not just `try/finally` around `_request`

That is what both #1575 and #1586 did, and it does close the leak. But it leaves the close in a frame that cannot tell the two cases apart:

```python
if files and "file" in files and isinstance(files["file"][1], BufferedReader):
    files["file"][1].close()
```

`_request` sees only a `BufferedReader`. A handle storage3 opened from a path and a stream the caller passed in are both `BufferedReader`, so it closes both. On `main` that already bites callers who supply their own stream — it is closed under them on the success path. Wrapping `_request` in `try/finally` extends that to the error path too, which breaks retry-after-failure:

```python
with open("big.bin", "rb") as f:
    try:
        client.storage.from_("bucket").upload("big.bin", f)
    except StorageApiError:
        f.seek(0)   # ValueError: I/O operation on closed file
        client.storage.from_("bucket").upload("big.bin", f)
```

## This change

Move the close into the two functions that open the file — `_upload_or_update` and `upload_to_signed_url` — which know whether they own the handle:

```python
if isinstance(file, BufferedReader) or isinstance(file, bytes) or isinstance(file, FileIO):
    # bytes or byte-stream-like object received -- the caller owns it
    opened = None
    files = {"file": (filename, file, content_type)}
else:
    # str or pathlib.path received -- we own the handle, so we close it
    opened = open(file, "rb")
    files = {"file": (filename, opened, content_type)}

try:
    response = await self._request(...)
finally:
    if opened is not None:
        opened.close()
```

`_request` no longer touches the handle at all.

Result: a handle storage3 opened is closed on both paths; a caller-supplied stream is left alone on both paths.

## Tests

`tests/_async/test_file_api.py` and its generated `_sync` twin, 4 tests each:

- `test_upload_closes_file_handle_on_error`
- `test_upload_closes_file_handle_on_success` (regression)
- `test_update_closes_file_handle_on_error` — `update()` shares `_upload_or_update`
- `test_caller_supplied_handle_is_left_open` — asserts on both paths

They assert on the real handle's `.closed` (captured from the `files` mapping the client received) rather than patching `builtins.open` and asserting on a mock. That approach is from #1575.

Reverting only the source change turns 6 of the 8 red, including the caller-supplied guard on the success path, which fails on `main` today.

## Note for reviewers

`run-unasync.py` cannot regenerate the existing storage test files: it emits `from unittest.mock import SyncMock` (no such name) wherever a test uses `AsyncMock`, so `tests/_sync/test_bucket.py` and `tests/_sync/test_client.py` are hand-corrected and running the script today breaks them. The new test file avoids `AsyncMock` entirely, so its `_sync` copy is genuinely generated and round-trips. Worth a separate issue.

## Verification

- 74 storage unit tests pass
- `ruff check` and `ruff format --check` clean
- `mypy` shows only the pre-existing `pyiceberg` import-not-found errors in `analytics.py`, untouched here
