### PR TITLE
fix(postgrest): retry transient failures for HEAD requests

### DIFF
--- a/src/postgrest/src/postgrest/base_request_builder.py
+++ b/src/postgrest/src/postgrest/base_request_builder.py
@@ -99,7 +99,7 @@ class RequestConfig(Generic[C]):
     def should_retry(self, response: RequestResponse, attempt_count: int) -> bool:
         if not self.retry_enabled or attempt_count >= MAX_RETRIES:
             return False
-        if not (self.http_method == "GET" or self.http_method == "HTTP"):
+        if not (self.http_method == "GET" or self.http_method == "HEAD"):
             return False
         return response.status_code == 503 or response.status_code == 520
 

--- a/src/postgrest/tests/_async/test_request_builder.py
+++ b/src/postgrest/tests/_async/test_request_builder.py
@@ -20,6 +20,15 @@ def test_constructor(request_builder):
     assert str(request_builder.path) == "/example_table"
 
 
+@pytest.mark.parametrize("head", [False, True])
+def test_select_request_retries_transient_response(
+    request_builder: AsyncRequestBuilder, head: bool
+):
+    request = request_builder.select(head=head).request
+
+    assert request.should_retry(Response(503), attempt_count=0)
+
+
 class TestSelect:
     def test_select(self, request_builder: AsyncRequestBuilder):
         builder = request_builder.select("col1", "col2")

--- a/src/postgrest/tests/_sync/test_request_builder.py
+++ b/src/postgrest/tests/_sync/test_request_builder.py
@@ -20,6 +20,15 @@ def test_constructor(request_builder):
     assert str(request_builder.path) == "/example_table"
 
 
+@pytest.mark.parametrize("head", [False, True])
+def test_select_request_retries_transient_response(
+    request_builder: SyncRequestBuilder, head: bool
+):
+    request = request_builder.select(head=head).request
+
+    assert request.should_retry(Response(503), attempt_count=0)
+
+
 class TestSelect:
     def test_select(self, request_builder: SyncRequestBuilder):
         builder = request_builder.select("col1", "col2")


### PR DESCRIPTION
## Summary

- correct the retry method guard so HEAD requests are treated as safe/idempotent alongside GET
- cover both sync and async `select(..., head=True)` request builders

## Why

The retry helper documents GET and HEAD support, but the guard checked for the impossible method string `HTTP`. As a result, transient 503 and 520 responses to HEAD count requests failed immediately.

Closes #1609.

## Testing

- `uv run --package postgrest pytest src/postgrest/tests/_async/test_request_builder.py src/postgrest/tests/_sync/test_request_builder.py -q` (90 passed)
- `uv run --package postgrest ruff check src/postgrest/src/postgrest/base_request_builder.py src/postgrest/tests/_async/test_request_builder.py src/postgrest/tests/_sync/test_request_builder.py`
- `uv run --package postgrest ruff format --check src/postgrest/src/postgrest/base_request_builder.py src/postgrest/tests/_async/test_request_builder.py src/postgrest/tests/_sync/test_request_builder.py`
- `git diff --check`
