### PR TITLE
fix(postgrest): retry HEAD requests on 503/520

### DIFF
--- a/src/postgrest/src/postgrest/base_request_builder.py
+++ b/src/postgrest/src/postgrest/base_request_builder.py
@@ -99,7 +99,7 @@ class RequestConfig(Generic[C]):
     def should_retry(self, response: RequestResponse, attempt_count: int) -> bool:
         if not self.retry_enabled or attempt_count >= MAX_RETRIES:
             return False
-        if not (self.http_method == "GET" or self.http_method == "HTTP"):
+        if not (self.http_method == "GET" or self.http_method == "HEAD"):
             return False
         return response.status_code == 503 or response.status_code == 520
 


### PR DESCRIPTION
Issue: HEAD requests from select(head=True) never retried transient 503/520 responses. should_retry checked for GET or HTTP, and HTTP is not a method the builders produce.

Fix: check for GET or HEAD instead. HEAD is idempotent, matching the documented behavior in send_with_retry (GET or HEAD, status 503 or 520).

Verified: HEAD 503/520 retry, GET unchanged, POST/PUT/PATCH/DELETE still excluded, non-transient statuses excluded, retry limits and retry_enabled=False respected.

Fixes #1609